### PR TITLE
feat: fetch mkdocs-base.yaml in installMkdocs for INHERIT support

### DIFF
--- a/.devcontainer/util/functions.sh
+++ b/.devcontainer/util/functions.sh
@@ -1005,13 +1005,21 @@ undeployOperatorViaHelm(){
 
 
 installMkdocs(){
-  
+
   installRunme
   printInfo "Installing MKdocs"
   pip install --break-system-packages -r docs/requirements/requirements-mkdocs.txt
+  fetchMkdocsBase
   exposeMkdocs
 }
 
+fetchMkdocsBase(){
+  # If mkdocs.yaml uses INHERIT and mkdocs-base.yaml is missing, fetch it from the framework
+  if grep -q '^INHERIT:' "${REPO_PATH}/mkdocs.yaml" 2>/dev/null && [ ! -f "${REPO_PATH}/mkdocs-base.yaml" ]; then
+    printInfo "Fetching mkdocs-base.yaml from framework v${FRAMEWORK_VERSION}..."
+    curl -fsSL "https://raw.githubusercontent.com/dynatrace-wwse/codespaces-framework/${FRAMEWORK_VERSION}/mkdocs-base.yaml" -o "${REPO_PATH}/mkdocs-base.yaml"
+  fi
+}
 
 exposeMkdocs(){
   printInfo "Exposing Mkdocs in your dev.container in port 8000 & running in the background, type 'jobs' to show the process."


### PR DESCRIPTION
## Summary
- Adds `fetchMkdocsBase()` function that detects `INHERIT:` in `mkdocs.yaml` and fetches `mkdocs-base.yaml` from the framework tag if missing
- Called automatically during `installMkdocs` so `mkdocs serve` works locally in enablement repos that use the INHERIT pattern
- No-op for repos that don't use INHERIT (backward compatible)

## Test plan
- [x] Run `installMkdocs` in an enablement repo using INHERIT — verify `mkdocs-base.yaml` is fetched and `mkdocs serve` starts
- [x] Run `installMkdocs` in a repo without INHERIT — verify no fetch attempt
- [x] Verify `exposeMkdocs` still works standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)