### PR TITLE
feat: k3d as default engine, Kind reserved for CNFS, Orbital detection

### DIFF
--- a/.devcontainer/test/integration.sh
+++ b/.devcontainer/test/integration.sh
@@ -18,6 +18,7 @@ assertRunningPod dynatrace activegate
 assertRunningPod todoapp todoapp
 
 # Test app is reachable via nginx ingress + magic DNS (sslip.io)
+# Works for both k3d (default) and Kind clusters
 assertRunningApp todoapp
 
 

--- a/.devcontainer/test/integration_engines.sh
+++ b/.devcontainer/test/integration_engines.sh
@@ -13,8 +13,11 @@
 source .devcontainer/util/source_framework.sh
 
 # Wipe any pre-existing clusters so port bindings don't conflict between engines.
+# Note: k3d cluster list -o name still emits a header; use JSON output instead.
 printInfo "Pre-test cleanup: removing any existing clusters..."
-k3d cluster list -o name 2>/dev/null | xargs -r -I{} k3d cluster delete {} 2>/dev/null || true
+k3d cluster list -o json 2>/dev/null \
+  | python3 -c "import sys,json; [print(c['name']) for c in json.load(sys.stdin)]" 2>/dev/null \
+  | xargs -r k3d cluster delete 2>/dev/null || true
 kind get clusters 2>/dev/null | xargs -r -I{} kind delete cluster --name {} 2>/dev/null || true
 
 # Kind test only makes sense on AMD64 — kind node images are amd64-only;

--- a/.devcontainer/test/integration_engines.sh
+++ b/.devcontainer/test/integration_engines.sh
@@ -12,13 +12,19 @@
 # Run: bash .devcontainer/test/integration_engines.sh
 source .devcontainer/util/source_framework.sh
 
-# --- Kind ---
-printInfoSection "Engine test 1/2: Kind"
-export CLUSTER_ENGINE=kind
-startKindCluster
-deployTodoApp
-assertRunningApp todoapp
-deleteKindCluster
+# Kind test only makes sense on AMD64 — kind node images are amd64-only;
+# CNFS (the primary Kind use-case) requires AMD64 Codespaces / Orbital.
+if [[ "$ARCH" != "x86_64" ]]; then
+  printWarn "Skipping Kind engine test — not running on AMD64 (arch: $ARCH)"
+else
+  # --- Kind ---
+  printInfoSection "Engine test 1/2: Kind"
+  export CLUSTER_ENGINE=kind
+  startKindCluster
+  deployTodoApp
+  assertRunningApp todoapp
+  deleteKindCluster
+fi
 
 # --- K3d ---
 printInfoSection "Engine test 2/2: K3d"

--- a/.devcontainer/test/integration_engines.sh
+++ b/.devcontainer/test/integration_engines.sh
@@ -12,6 +12,11 @@
 # Run: bash .devcontainer/test/integration_engines.sh
 source .devcontainer/util/source_framework.sh
 
+# Wipe any pre-existing clusters so port bindings don't conflict between engines.
+printInfo "Pre-test cleanup: removing any existing clusters..."
+k3d cluster list -o name 2>/dev/null | xargs -r -I{} k3d cluster delete {} 2>/dev/null || true
+kind get clusters 2>/dev/null | xargs -r -I{} kind delete cluster --name {} 2>/dev/null || true
+
 # Kind test only makes sense on AMD64 — kind node images are amd64-only;
 # CNFS (the primary Kind use-case) requires AMD64 Codespaces / Orbital.
 if [[ "$ARCH" != "x86_64" ]]; then

--- a/.devcontainer/test/integration_engines.sh
+++ b/.devcontainer/test/integration_engines.sh
@@ -20,10 +20,17 @@ k3d cluster list -o json 2>/dev/null \
   | xargs -r k3d cluster delete 2>/dev/null || true
 kind get clusters 2>/dev/null | xargs -r -I{} kind delete cluster --name {} 2>/dev/null || true
 
-# Kind test only makes sense on AMD64 — kind node images are amd64-only;
-# CNFS (the primary Kind use-case) requires AMD64 Codespaces / Orbital.
+# Kind test: AMD64 + not Orbital.
+# On Orbital (Sysbox), Kind node pods get stuck in ContainerCreating — the
+# container nesting depth (Sysbox→DinD→dt-enablement→kind-node→pod) exceeds
+# what Sysbox's userspace kernel can virtualise. k3d works because it uses
+# k3s (single binary, no inner containerd) — one fewer nesting level.
+# Kind is only valid in real VM environments (GitHub Codespaces, local).
+_run_env=$(detectRunEnvironment)
 if [[ "$ARCH" != "x86_64" ]]; then
-  printWarn "Skipping Kind engine test — not running on AMD64 (arch: $ARCH)"
+  printWarn "Skipping Kind engine test — not AMD64 (arch: $ARCH)"
+elif [[ "$_run_env" == "orbital" ]]; then
+  printWarn "Skipping Kind engine test — running on Orbital/Sysbox (pods would stuck ContainerCreating)"
 else
   # --- Kind ---
   printInfoSection "Engine test 1/2: Kind"

--- a/.devcontainer/test/integration_k3d_apps.sh
+++ b/.devcontainer/test/integration_k3d_apps.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# K3d multi-app integration test — AMD64 only.
+#
+# Validates that each app deploys successfully on k3d and is reachable
+# through the nginx ingress. Runs sequentially — each app is deployed into
+# a fresh k3d cluster, verified, then torn down.
+#
+# Skip list: apps that only support amd64 already guard themselves, but
+# we also skip here because this test file is exclusively for AMD64 CI.
+#
+# Run: bash .devcontainer/test/integration_k3d_apps.sh
+source .devcontainer/util/source_framework.sh
+
+if [[ "$ARCH" != "x86_64" ]]; then
+  printWarn "Skipping k3d apps integration test — AMD64 only (arch: $ARCH)"
+  exit 0
+fi
+
+PASSED=0
+FAILED=0
+
+run_app_test() {
+  local app_name="$1"
+  local deploy_fn="$2"
+  local assert_name="${3:-$app_name}"
+
+  printInfoSection "Testing app: $app_name"
+  export CLUSTER_ENGINE=k3d
+  startK3dCluster
+
+  if "$deploy_fn" 2>&1; then
+    if assertRunningApp "$assert_name" 2>&1; then
+      printInfo "✅ $app_name — deployed and reachable"
+      PASSED=$((PASSED + 1))
+    else
+      printError "❌ $app_name — deployed but NOT reachable via ingress"
+      FAILED=$((FAILED + 1))
+    fi
+  else
+    printError "❌ $app_name — deployment FAILED"
+    FAILED=$((FAILED + 1))
+  fi
+
+  deleteK3dCluster
+}
+
+# ---------------------------------------------------------------------------
+# 1. Todo App — lightweight test app, always available
+# ---------------------------------------------------------------------------
+run_app_test "todoapp" deployTodoApp "todoapp"
+
+# ---------------------------------------------------------------------------
+# 2. Astroshop (AMD64 only — guarded inside deployAstroshop)
+# ---------------------------------------------------------------------------
+run_app_test "astroshop" deployAstroshop "astroshop"
+
+# ---------------------------------------------------------------------------
+# 3. Astronomy Shop (OTel demo — used by k8s-otel labs)
+# ---------------------------------------------------------------------------
+run_app_test "astronomy-shop" deployAstronomyShopOpenTelemetry "astronomy-shop"
+
+# ---------------------------------------------------------------------------
+# 4. AI Travel Advisor (gen-ai lab)
+# ---------------------------------------------------------------------------
+run_app_test "aitraveladvisor" deployAITravelAdvisorApp "aitraveladvisor"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printInfoSection "K3d apps integration test — results"
+printInfo "Passed: $PASSED"
+if [[ "$FAILED" -gt 0 ]]; then
+  printError "Failed: $FAILED"
+  exit 1
+else
+  printInfo "✅ All $PASSED app(s) passed on k3d"
+fi

--- a/.devcontainer/test/integration_k3d_apps.sh
+++ b/.devcontainer/test/integration_k3d_apps.sh
@@ -61,9 +61,15 @@ if run_app_test "astroshop" deployAstroshop "astroshop"; then PASSED=$((PASSED +
 if run_app_test "otel-demo" deployOpentelemetryDemo "otel-demo"; then PASSED=$((PASSED + 1)); else FAILED=$((FAILED + 1)); fi
 
 # ---------------------------------------------------------------------------
-# 4. AI Travel Advisor (gen-ai lab)
+# 4. AI Travel Advisor (gen-ai lab) — requires DT_LLM_TOKEN; skip if absent
 # ---------------------------------------------------------------------------
-if run_app_test "aitraveladvisor" deployAITravelAdvisorApp "aitraveladvisor"; then PASSED=$((PASSED + 1)); else FAILED=$((FAILED + 1)); fi
+if [[ -z "$DT_LLM_TOKEN" ]]; then
+  printWarn "Skipping aitraveladvisor — DT_LLM_TOKEN not set"
+elif run_app_test "aitraveladvisor" deployAITravelAdvisorApp "aitraveladvisor"; then
+  PASSED=$((PASSED + 1))
+else
+  FAILED=$((FAILED + 1))
+fi
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/.devcontainer/test/integration_k3d_apps.sh
+++ b/.devcontainer/test/integration_k3d_apps.sh
@@ -55,9 +55,9 @@ run_app_test "todoapp" deployTodoApp "todoapp"
 run_app_test "astroshop" deployAstroshop "astroshop"
 
 # ---------------------------------------------------------------------------
-# 3. Astronomy Shop (OTel demo — used by k8s-otel labs)
+# 3. OpenTelemetry Demo (OTel demo — used by k8s-otel labs)
 # ---------------------------------------------------------------------------
-run_app_test "astronomy-shop" deployAstronomyShopOpenTelemetry "astronomy-shop"
+run_app_test "otel-demo" deployOpentelemetryDemo "otel-demo"
 
 # ---------------------------------------------------------------------------
 # 4. AI Travel Advisor (gen-ai lab)

--- a/.devcontainer/test/integration_k3d_apps.sh
+++ b/.devcontainer/test/integration_k3d_apps.sh
@@ -23,6 +23,7 @@ run_app_test() {
   local app_name="$1"
   local deploy_fn="$2"
   local assert_name="${3:-$app_name}"
+  local result=0
 
   printInfoSection "Testing app: $app_name"
   export CLUSTER_ENGINE=k3d
@@ -31,38 +32,38 @@ run_app_test() {
   if "$deploy_fn" 2>&1; then
     if assertRunningApp "$assert_name" 2>&1; then
       printInfo "✅ $app_name — deployed and reachable"
-      PASSED=$((PASSED + 1))
     else
       printError "❌ $app_name — deployed but NOT reachable via ingress"
-      FAILED=$((FAILED + 1))
+      result=1
     fi
   else
     printError "❌ $app_name — deployment FAILED"
-    FAILED=$((FAILED + 1))
+    result=1
   fi
 
   deleteK3dCluster
+  return $result
 }
 
 # ---------------------------------------------------------------------------
 # 1. Todo App — lightweight test app, always available
 # ---------------------------------------------------------------------------
-run_app_test "todoapp" deployTodoApp "todoapp"
+if run_app_test "todoapp" deployTodoApp "todoapp"; then PASSED=$((PASSED + 1)); else FAILED=$((FAILED + 1)); fi
 
 # ---------------------------------------------------------------------------
 # 2. Astroshop (AMD64 only — guarded inside deployAstroshop)
 # ---------------------------------------------------------------------------
-run_app_test "astroshop" deployAstroshop "astroshop"
+if run_app_test "astroshop" deployAstroshop "astroshop"; then PASSED=$((PASSED + 1)); else FAILED=$((FAILED + 1)); fi
 
 # ---------------------------------------------------------------------------
 # 3. OpenTelemetry Demo (OTel demo — used by k8s-otel labs)
 # ---------------------------------------------------------------------------
-run_app_test "otel-demo" deployOpentelemetryDemo "otel-demo"
+if run_app_test "otel-demo" deployOpentelemetryDemo "otel-demo"; then PASSED=$((PASSED + 1)); else FAILED=$((FAILED + 1)); fi
 
 # ---------------------------------------------------------------------------
 # 4. AI Travel Advisor (gen-ai lab)
 # ---------------------------------------------------------------------------
-run_app_test "aitraveladvisor" deployAITravelAdvisorApp "aitraveladvisor"
+if run_app_test "aitraveladvisor" deployAITravelAdvisorApp "aitraveladvisor"; then PASSED=$((PASSED + 1)); else FAILED=$((FAILED + 1)); fi
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/.devcontainer/test/unit/test_cluster_engine.bats
+++ b/.devcontainer/test/unit/test_cluster_engine.bats
@@ -1,0 +1,219 @@
+#!/usr/bin/env bats
+# Tests for cluster engine routing and run environment detection.
+# Covers: detectRunEnvironment, startCluster/stopCluster/deleteCluster dispatch,
+#         deployCloudNative Kind guard, deployCloudNative Orbital warn.
+
+setup() {
+  export TEST_DIR="$(mktemp -d)"
+  export HOME="$TEST_DIR/home"
+  mkdir -p "$HOME"
+
+  export FAKE_REPO="$TEST_DIR/workspaces/test-enablement"
+  mkdir -p "$FAKE_REPO/.devcontainer/util"
+  mkdir -p "$FAKE_REPO/.devcontainer/test"
+  mkdir -p "$FAKE_REPO/.devcontainer/yaml/gen"
+  mkdir -p "$FAKE_REPO/.vscode"
+
+  export REPO_PATH="$FAKE_REPO"
+  export RepositoryName="test-enablement"
+  export ENV_FILE="$FAKE_REPO/.devcontainer/.env"
+  export APP_REGISTRY="$TEST_DIR/app-registry"
+  export FRAMEWORK_CACHE=""
+  export ARCH="x86_64"
+
+  cat > "$FAKE_REPO/.devcontainer/util/variables.sh" <<'VARSEOF'
+LOGNAME="test"
+GREEN=""
+BLUE=""
+CYAN=""
+YELLOW=""
+ORANGE=""
+RED=""
+LILA=""
+NORMAL=""
+RESET=""
+thickline=""
+halfline=""
+thinline=""
+ENV_FILE="$REPO_PATH/.devcontainer/.env"
+export ENV_FILE
+export USE_LEGACY_PORTS="false"
+export MAGIC_DOMAIN="sslip.io"
+VARSEOF
+
+  echo '# stub' > "$FAKE_REPO/.devcontainer/test/test_functions.sh"
+  echo '# stub' > "$FAKE_REPO/.devcontainer/util/my_functions.sh"
+  cp "$BATS_TEST_DIRNAME/../../util/functions.sh" \
+     "$FAKE_REPO/.devcontainer/util/functions.sh"
+
+  kubectl() { return 0; }
+  export -f kubectl
+  helm() { return 0; }
+  export -f helm
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+source_functions() {
+  cd "$FAKE_REPO"
+  source ".devcontainer/util/functions.sh"
+}
+
+# ============================================================
+# detectRunEnvironment
+# ============================================================
+
+@test "detectRunEnvironment: returns orbital when ORBITAL_ENVIRONMENT=true" {
+  source_functions
+  unset CODESPACE_NAME K3D_CLUSTER_NAME
+  export ORBITAL_ENVIRONMENT=true
+  run detectRunEnvironment
+  [ "$status" -eq 0 ]
+  [ "$output" = "orbital" ]
+}
+
+@test "detectRunEnvironment: returns orbital when K3D_CLUSTER_NAME=master-*" {
+  source_functions
+  unset CODESPACE_NAME ORBITAL_ENVIRONMENT
+  export K3D_CLUSTER_NAME="master-test"
+  run detectRunEnvironment
+  [ "$status" -eq 0 ]
+  [ "$output" = "orbital" ]
+}
+
+@test "detectRunEnvironment: returns codespaces when CODESPACE_NAME set" {
+  source_functions
+  unset ORBITAL_ENVIRONMENT K3D_CLUSTER_NAME
+  export CODESPACE_NAME="my-codespace-123"
+  run detectRunEnvironment
+  [ "$status" -eq 0 ]
+  [ "$output" = "codespaces" ]
+}
+
+@test "detectRunEnvironment: returns local as fallback" {
+  source_functions
+  unset ORBITAL_ENVIRONMENT K3D_CLUSTER_NAME CODESPACE_NAME
+  run detectRunEnvironment
+  [ "$status" -eq 0 ]
+  [ "$output" = "local" ]
+}
+
+@test "detectRunEnvironment: ORBITAL_ENVIRONMENT takes priority over CODESPACE_NAME" {
+  source_functions
+  export ORBITAL_ENVIRONMENT=true
+  export CODESPACE_NAME="my-codespace-123"
+  run detectRunEnvironment
+  [ "$status" -eq 0 ]
+  [ "$output" = "orbital" ]
+}
+
+@test "detectRunEnvironment: K3D_CLUSTER_NAME without master- prefix is not orbital" {
+  source_functions
+  unset ORBITAL_ENVIRONMENT CODESPACE_NAME
+  export K3D_CLUSTER_NAME="k3s-default"
+  run detectRunEnvironment
+  [ "$status" -eq 0 ]
+  [ "$output" = "local" ]
+}
+
+# ============================================================
+# startCluster / stopCluster / deleteCluster engine routing
+# ============================================================
+
+@test "startCluster routes to startK3dCluster when CLUSTER_ENGINE=k3d" {
+  source_functions
+  export CLUSTER_ENGINE=k3d
+  startK3dCluster() { echo "called=k3d"; }
+  export -f startK3dCluster
+  result=$(startCluster)
+  [[ "$result" == *"called=k3d"* ]]
+}
+
+@test "startCluster routes to startKindCluster when CLUSTER_ENGINE=kind" {
+  source_functions
+  export CLUSTER_ENGINE=kind
+  startKindCluster() { echo "called=kind"; }
+  export -f startKindCluster
+  result=$(startCluster)
+  [[ "$result" == *"called=kind"* ]]
+}
+
+@test "stopCluster routes to stopK3dCluster when CLUSTER_ENGINE=k3d" {
+  source_functions
+  export CLUSTER_ENGINE=k3d
+  stopK3dCluster() { echo "stopped=k3d"; }
+  export -f stopK3dCluster
+  result=$(stopCluster)
+  [[ "$result" == *"stopped=k3d"* ]]
+}
+
+@test "stopCluster routes to stopKindCluster when CLUSTER_ENGINE=kind" {
+  source_functions
+  export CLUSTER_ENGINE=kind
+  stopKindCluster() { echo "stopped=kind"; }
+  export -f stopKindCluster
+  result=$(stopCluster)
+  [[ "$result" == *"stopped=kind"* ]]
+}
+
+@test "deleteCluster routes to deleteK3dCluster when CLUSTER_ENGINE=k3d" {
+  source_functions
+  export CLUSTER_ENGINE=k3d
+  deleteK3dCluster() { echo "deleted=k3d"; }
+  export -f deleteK3dCluster
+  result=$(deleteCluster)
+  [[ "$result" == *"deleted=k3d"* ]]
+}
+
+@test "deleteCluster routes to deleteKindCluster when CLUSTER_ENGINE=kind" {
+  source_functions
+  export CLUSTER_ENGINE=kind
+  deleteKindCluster() { echo "deleted=kind"; }
+  export -f deleteKindCluster
+  result=$(deleteCluster)
+  [[ "$result" == *"deleted=kind"* ]]
+}
+
+# ============================================================
+# deployCloudNative — k3d guard warning
+# ============================================================
+
+@test "deployCloudNative warns when CLUSTER_ENGINE=k3d (default)" {
+  source_functions
+  unset CLUSTER_ENGINE
+  warned=0
+  printWarn() { warned=1; }
+  export -f printWarn
+  deployDynatrace() { :; }
+  export -f deployDynatrace
+  deployCloudNative
+  [ "$warned" -eq 1 ]
+}
+
+@test "deployCloudNative does NOT warn when CLUSTER_ENGINE=kind (non-Orbital)" {
+  source_functions
+  export CLUSTER_ENGINE=kind
+  unset ORBITAL_ENVIRONMENT CODESPACE_NAME K3D_CLUSTER_NAME
+  warned=0
+  printWarn() { warned=1; }
+  export -f printWarn
+  deployDynatrace() { :; }
+  export -f deployDynatrace
+  deployCloudNative
+  [ "$warned" -eq 0 ]
+}
+
+@test "deployCloudNative warns on Orbital even when CLUSTER_ENGINE=kind" {
+  source_functions
+  export CLUSTER_ENGINE=kind
+  export ORBITAL_ENVIRONMENT=true
+  warned=0
+  printWarn() { warned=1; }
+  export -f printWarn
+  deployDynatrace() { :; }
+  export -f deployDynatrace
+  deployCloudNative
+  [ "$warned" -eq 1 ]
+}

--- a/.devcontainer/test/unit/test_dynakube.bats
+++ b/.devcontainer/test/unit/test_dynakube.bats
@@ -302,7 +302,9 @@ EOF
 @test "deployCloudNative calls deployDynatrace with cloudnative" {
   source_functions
 
-  # Mock deployDynatrace to capture the mode
+  # Suppress warning banners (printWarn → stdout) so we can match MODE= cleanly
+  printWarn() { :; }
+  export -f printWarn
   deployDynatrace() { echo "MODE=$1"; }
   export -f deployDynatrace
 

--- a/.devcontainer/test/unit/test_source_framework.bats
+++ b/.devcontainer/test/unit/test_source_framework.bats
@@ -194,7 +194,7 @@ create_partial_cache() {
 # ============================================================
 # Test: FRAMEWORK_VERSION defaults to 1.2.0 when not set
 # ============================================================
-@test "FRAMEWORK_VERSION defaults to 1.3.0 when unset" {
+@test "FRAMEWORK_VERSION defaults to 1.3.2 when unset" {
   unset FRAMEWORK_VERSION
 
   cd "$FAKE_REPO"
@@ -205,7 +205,7 @@ create_partial_cache() {
   '
 
   # It will fail (no matching tag for remote clone) but should set the variable
-  [[ "$output" == *"VER=1.3.0"* ]]
+  [[ "$output" == *"VER=1.3.2"* ]]
 }
 
 # ============================================================

--- a/.devcontainer/util/functions.sh
+++ b/.devcontainer/util/functions.sh
@@ -660,12 +660,15 @@ stopKindCluster(){
 
 startKindCluster(){
   export CLUSTER_ENGINE=kind
-  # On Orbital (Sysbox), Kind runs but OneAgent DaemonSet will fail — warn early
+  # On Orbital (Sysbox), Kind pods get stuck ContainerCreating — too many
+  # nesting levels (Sysbox→DinD→dt-enablement→kind-node→pod containers).
+  # Use k3d (startK3dCluster) on Orbital instead.
   if [[ "$(detectRunEnvironment)" == "orbital" ]]; then
     printWarn "═══════════════════════════════════════════════════════════════════════════════"
-    printWarn " Running Kind on Orbital (Sysbox): cluster will start, but OneAgent DaemonSet"
-    printWarn " will CrashLoopBackOff — Sysbox restricts host-level syscalls required by"
-    printWarn " the OneAgent host module. Application monitoring (CSI injection) still works."
+    printWarn " Kind on Orbital (Sysbox): pod containers will be stuck ContainerCreating."
+    printWarn " Sysbox cannot virtualise the 4-level container nesting Kind requires."
+    printWarn " Use startK3dCluster instead — k3d works on Orbital (3 levels only)."
+    printWarn " Kind is only supported in real VM environments (Codespaces, local)."
     printWarn "═══════════════════════════════════════════════════════════════════════════════"
   fi
   printInfoSection "Starting Kubernetes Cluster (kind-control-plane)"

--- a/.devcontainer/util/functions.sh
+++ b/.devcontainer/util/functions.sh
@@ -69,6 +69,21 @@ printError() {
   echo -e "${GREEN}[$LOGNAME| ${RED}ERROR${GREEN} |$(timestamp) ${LILA}| ${RESET}$1${LILA}  |"
 }
 
+detectRunEnvironment(){
+  # Returns "orbital", "codespaces", or "local" based on available signals.
+  # orbital:   ORBITAL_ENVIRONMENT=true is set by the Orbital worker manager
+  #            or K3D_CLUSTER_NAME starts with "master-" (worker port-override pattern)
+  # codespaces: CODESPACE_NAME is set by GitHub Codespaces
+  # local:     fallback
+  if [[ "${ORBITAL_ENVIRONMENT:-}" == "true" ]] || [[ "${K3D_CLUSTER_NAME:-}" == master-* ]]; then
+    echo "orbital"
+  elif [[ -n "${CODESPACE_NAME:-}" ]]; then
+    echo "codespaces"
+  else
+    echo "local"
+  fi
+}
+
 postCodespaceTracker(){
 
   printInfo "Sending bizevent for $RepositoryName with $ERROR_COUNT issues built in $DURATION seconds"
@@ -81,6 +96,8 @@ postCodespaceTracker(){
 
   # Unique app ID for RUM monitoring: dynatrace-wwse-{repo-name}
   local app_id="dynatrace-wwse-${RepositoryName}"
+  local run_env
+  run_env=$(detectRunEnvironment)
 
   curl -s -X POST "$ENDPOINT_CODESPACES_TRACKER" \
   -H "Content-Type: application/json" \
@@ -95,6 +112,7 @@ postCodespaceTracker(){
   \"codespace.arch\": \"$ARCH\",
   \"codespace.name\": \"$CODESPACE_NAME\",
   \"codespace.app_id\": \"$app_id\",
+  \"run.environment\": \"$run_env\",
   \"environment\": \"$DT_ENVIRONMENT\",
   \"tenant\": \"$DT_TENANT\",
   \"framework.version\": \"$FRAMEWORK_VERSION\"
@@ -642,6 +660,14 @@ stopKindCluster(){
 
 startKindCluster(){
   export CLUSTER_ENGINE=kind
+  # On Orbital (Sysbox), Kind runs but OneAgent DaemonSet will fail — warn early
+  if [[ "$(detectRunEnvironment)" == "orbital" ]]; then
+    printWarn "═══════════════════════════════════════════════════════════════════════════════"
+    printWarn " Running Kind on Orbital (Sysbox): cluster will start, but OneAgent DaemonSet"
+    printWarn " will CrashLoopBackOff — Sysbox restricts host-level syscalls required by"
+    printWarn " the OneAgent host module. Application monitoring (CSI injection) still works."
+    printWarn "═══════════════════════════════════════════════════════════════════════════════"
+  fi
   printInfoSection "Starting Kubernetes Cluster (kind-control-plane)"
   KIND_STATUS=$(docker inspect -f '{{.State.Status}}' $KINDIMAGE 2>/dev/null)
   if [ "$KIND_STATUS" = "exited" ] || [ "$KIND_STATUS" = "dead" ]; then
@@ -1213,6 +1239,14 @@ deployCloudNative() {
     printWarn ""
     printWarn " Or use application-only mode (no CrashLoopBackOff, full app observability):"
     printWarn "   deployApplicationMonitoring"
+    printWarn "═══════════════════════════════════════════════════════════════════════════════"
+  elif [[ "$(detectRunEnvironment)" == "orbital" ]]; then
+    # Kind on Orbital: cluster runs inside Sysbox but OneAgent host module will fail
+    printWarn "═══════════════════════════════════════════════════════════════════════════════"
+    printWarn " CloudNativeFullStack on Orbital (Sysbox + Kind): OneAgent DaemonSet will"
+    printWarn " CrashLoopBackOff. Sysbox restricts host-level syscalls needed by OneAgent's"
+    printWarn " host monitoring module. Code-injection (CSI driver) still works."
+    printWarn " This environment is flagged as 'orbital' in the tracker payload."
     printWarn "═══════════════════════════════════════════════════════════════════════════════"
   fi
   deployDynatrace cloudnative "$@"

--- a/.devcontainer/util/functions.sh
+++ b/.devcontainer/util/functions.sh
@@ -2547,28 +2547,28 @@ registerOpentelemetryDemoIngress() {
         pathType: ImplementationSpecific
         backend:
           service:
-            name: opentelemetry-demo-otelcol
+            name: otel-collector
             port:
               number: 4318
       - path: /v1/metrics
         pathType: ImplementationSpecific
         backend:
           service:
-            name: opentelemetry-demo-otelcol
+            name: otel-collector
             port:
               number: 4318
       - path: /v1/logs
         pathType: ImplementationSpecific
         backend:
           service:
-            name: opentelemetry-demo-otelcol
+            name: otel-collector
             port:
               number: 4318
       - path: /
         pathType: Prefix
         backend:
           service:
-            name: opentelemetry-demo-frontendproxy
+            name: frontend-proxy
             port:
               number: 8080'
 
@@ -2601,12 +2601,12 @@ OTELINGRESSEOF
   local cs_port=""
   if [[ "$CODESPACES" == true ]]; then
     cs_port=$(getNextCodespacesPort)
-    kubectl port-forward -n "$namespace" "svc/opentelemetry-demo-frontendproxy" "${cs_port}:8080" &>/dev/null &
+    kubectl port-forward -n "$namespace" "svc/frontend-proxy" "${cs_port}:8080" &>/dev/null &
   fi
   mkdir -p "$(dirname "$APP_REGISTRY")"
   grep -v "^otel-demo|" "$APP_REGISTRY" > "${APP_REGISTRY}.tmp" 2>/dev/null || true
   mv "${APP_REGISTRY}.tmp" "$APP_REGISTRY" 2>/dev/null || true
-  echo "otel-demo|${namespace}|opentelemetry-demo-frontendproxy|8080|${ingress_host}|${cs_port}" >> "$APP_REGISTRY"
+  echo "otel-demo|${namespace}|frontend-proxy|8080|${ingress_host}|${cs_port}" >> "$APP_REGISTRY"
 
   local app_url
   app_url=$(getAppURL "otel-demo" "$cs_port")

--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -13,7 +13,7 @@
 #                    Local to the container → fast access, lost on container rebuild
 
 # Framework version pin — sync push-update updates this line
-FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.3.0}"
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.3.2}"
 
 REPO_PATH="$(pwd)"
 RepositoryName="$(basename "$REPO_PATH")"

--- a/.devcontainer/yaml/kind/kind-cluster.yml
+++ b/.devcontainer/yaml/kind/kind-cluster.yml
@@ -22,7 +22,7 @@ networking:
   apiServerPort: 6443
 nodes:
 - role: control-plane
-  image: kindest/node:v1.30.0
+  image: kindest/node:v1.32.11@sha256:5fc52d52a7b9574015299724bd68f183702956aa4a2116ae75a63cb574b35af8
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -2984,7 +2984,7 @@ async def api_arena_session_exec(job_id: str, body: ArenaExecRequest):
 # ── Framework test suites ─────────────────────────────────────────────────────
 
 FRAMEWORK_SUITES = [
-    {"id": "bats",      "name": "Unit Tests (bats)",         "description": "Shell unit tests — static, no cluster needed", "arch": "arm64", "needs_creds": False, "test_script": None},
+    {"id": "bats",      "name": "Unit Tests (bats)",         "description": "Shell unit tests — static, no cluster needed", "arch": "arm64", "needs_creds": False, "test_script": "cd .devcontainer && bats test/unit/"},
     {"id": "engines",   "name": "Engine Tests",              "description": "k3d + Kind (AMD64; Kind skipped on Orbital)",   "arch": "amd64", "needs_creds": False, "test_script": "bash .devcontainer/test/integration_engines.sh"},
     {"id": "k3d-apps",  "name": "K3d App Exposure",          "description": "All demo apps deployed + exposed via ingress",  "arch": "amd64", "needs_creds": False, "test_script": "bash .devcontainer/test/integration_k3d_apps.sh"},
     {"id": "dt-apponly","name": "DT Application Monitoring", "description": "Dynatrace operator + CSI injection",            "arch": "amd64", "needs_creds": True,  "status": "coming_soon", "test_script": None},

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -2984,11 +2984,11 @@ async def api_arena_session_exec(job_id: str, body: ArenaExecRequest):
 # ── Framework test suites ─────────────────────────────────────────────────────
 
 FRAMEWORK_SUITES = [
-    {"id": "bats",      "name": "Unit Tests (bats)",         "description": "Shell unit tests — static, no cluster needed", "arch": "arm64", "needs_creds": False},
-    {"id": "engines",   "name": "Engine Tests",              "description": "k3d + Kind (AMD64; Kind skipped on Orbital)",   "arch": "amd64", "needs_creds": False},
-    {"id": "k3d-apps",  "name": "K3d App Exposure",          "description": "All demo apps deployed + exposed via ingress",  "arch": "amd64", "needs_creds": False},
-    {"id": "dt-apponly","name": "DT Application Monitoring", "description": "Dynatrace operator + CSI injection",            "arch": "amd64", "needs_creds": True,  "status": "coming_soon"},
-    {"id": "dt-cnfs",   "name": "DT CloudNative FullStack",  "description": "OneAgent DaemonSet — needs bare-metal VM",      "arch": "amd64", "needs_creds": True,  "status": "coming_soon", "requires_native": True},
+    {"id": "bats",      "name": "Unit Tests (bats)",         "description": "Shell unit tests — static, no cluster needed", "arch": "arm64", "needs_creds": False, "test_script": None},
+    {"id": "engines",   "name": "Engine Tests",              "description": "k3d + Kind (AMD64; Kind skipped on Orbital)",   "arch": "amd64", "needs_creds": False, "test_script": "bash .devcontainer/test/integration_engines.sh"},
+    {"id": "k3d-apps",  "name": "K3d App Exposure",          "description": "All demo apps deployed + exposed via ingress",  "arch": "amd64", "needs_creds": False, "test_script": "bash .devcontainer/test/integration_k3d_apps.sh"},
+    {"id": "dt-apponly","name": "DT Application Monitoring", "description": "Dynatrace operator + CSI injection",            "arch": "amd64", "needs_creds": True,  "status": "coming_soon", "test_script": None},
+    {"id": "dt-cnfs",   "name": "DT CloudNative FullStack",  "description": "OneAgent DaemonSet — needs bare-metal VM",      "arch": "amd64", "needs_creds": True,  "status": "coming_soon", "requires_native": True, "test_script": None},
 ]
 
 @app.get("/api/framework/suites")
@@ -3019,6 +3019,8 @@ async def api_framework_trigger(request: Request):
         job = {
             "type": "framework-test",
             "suite": s["id"],
+            "test_script": s["test_script"],   # executor uses this instead of integration.sh
+            "framework_suite": s["id"],         # signals executor to save suite result
             "repo": "dynatrace-wwse/codespaces-framework",
             "arch": target_arch,
             "queue": f"test:{target_arch}",

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -2586,7 +2586,7 @@ async def arena_terminal_page(job_id: str, token: str = ""):
     ws_url   = f"wss://autonomous-enablements.whydevslovedynatrace.com/ws/jobs/{job_id}/shell"
     base_url = "https://autonomous-enablements.whydevslovedynatrace.com"
 
-    meta = await pool.hgetall(f"job:running:{job_id}") or {{}}
+    meta = await pool.hgetall(f"job:running:{job_id}") or {}
     repo_full = meta.get("repo", "")
     repo_name = repo_full.split("/")[-1] if repo_full else ""
     docs_url  = f"https://dynatrace-wwse.github.io/{repo_name}/" if repo_name else ""
@@ -2748,12 +2748,32 @@ function switchTab(name) {{
       setTimeout(() => fitAddon && fitAddon.fit(), 50);
     }}
   }}
+  if (name === 'log') {{
+    setTimeout(() => logFit && logFit.fit(), 50);
+  }}
 }}
 
-// ── Log streaming ─────────────────────────────────────────────────────────────
-// Strip ANSI escape codes for plain-text log display
-function stripAnsi(s) {{
-  return s.replace(/\x1b\[[0-9;]*[mGKHFJ]/g, '').replace(/\x1b\][^\x07]*\x07/g, '');
+// ── Log terminal (xterm.js — renders ANSI colors) ────────────────────────────
+let logTerm, logFit;
+
+function initLogTerminal() {{
+  logTerm = new Terminal({{
+    cursorBlink: false,
+    fontSize: 12,
+    fontFamily: '"MesloLGS NF", "Cascadia Code NF", "Hack Nerd Font", ui-monospace, Menlo, monospace',
+    theme: {{
+      background: '#0d1117', foreground: '#d4d4d4', cursor: '#0d1117',
+      selectionBackground: '#264f78',
+    }},
+    scrollback: 20000,
+    convertEol: true,
+    disableStdin: true,
+  }});
+  logFit = new FitAddon.FitAddon();
+  logTerm.loadAddon(logFit);
+  logTerm.loadAddon(new WebLinksAddon.WebLinksAddon());
+  logTerm.open(logOutput);
+  logFit.fit();
 }}
 
 let lastLogLen = 0;
@@ -2767,10 +2787,9 @@ async function pollLivelog() {{
       return;
     }}
     const text = await r.text();
-    if (text.length > lastLogLen) {{
-      const chunk = stripAnsi(text.slice(lastLogLen));
-      logOutput.textContent += chunk;
-      logOutput.scrollTop = logOutput.scrollHeight;
+    if (text.length > lastLogLen && logTerm) {{
+      const chunk = text.slice(lastLogLen);
+      logTerm.write(chunk);
       lastLogLen = text.length;
     }}
     const ready = text.includes('Daemon ready');
@@ -2790,6 +2809,10 @@ async function pollLivelog() {{
     }}
   }} catch {{}}
 }}
+
+window.addEventListener('resize', () => {{
+  if (logFit && document.getElementById('panel-log').style.display !== 'none') logFit.fit();
+}});
 
 // ── xterm — opened lazily when Shell tab first selected ───────────────────────
 let term, fitAddon, ws;
@@ -2871,6 +2894,9 @@ function startAppsPolling() {{
   pollApps();
   appsInterval = setInterval(pollApps, 10000);
 }}
+// Init log terminal immediately (log tab is visible on load)
+document.fonts.load('12px "MesloLGS NF"').then(initLogTerminal).catch(initLogTerminal);
+
 startAppsPolling(); // show docs card immediately
 async function pollApps() {{
   try {{
@@ -2953,6 +2979,150 @@ async def api_arena_session_exec(job_id: str, body: ArenaExecRequest):
         return {"stdout": "", "stderr": "Command timed out after 30 seconds", "exitCode": -1}
     except Exception as exc:
         return {"stdout": "", "stderr": str(exc), "exitCode": -1}
+
+
+# ── Framework test suites ─────────────────────────────────────────────────────
+
+FRAMEWORK_SUITES = [
+    {"id": "bats",      "name": "Unit Tests (bats)",         "description": "Shell unit tests — static, no cluster needed", "arch": "arm64", "needs_creds": False},
+    {"id": "engines",   "name": "Engine Tests",              "description": "k3d + Kind (AMD64; Kind skipped on Orbital)",   "arch": "amd64", "needs_creds": False},
+    {"id": "k3d-apps",  "name": "K3d App Exposure",          "description": "All demo apps deployed + exposed via ingress",  "arch": "amd64", "needs_creds": False},
+    {"id": "dt-apponly","name": "DT Application Monitoring", "description": "Dynatrace operator + CSI injection",            "arch": "amd64", "needs_creds": True,  "status": "coming_soon"},
+    {"id": "dt-cnfs",   "name": "DT CloudNative FullStack",  "description": "OneAgent DaemonSet — needs bare-metal VM",      "arch": "amd64", "needs_creds": True,  "status": "coming_soon", "requires_native": True},
+]
+
+@app.get("/api/framework/suites")
+async def api_framework_suites():
+    """Return framework test suite catalog with last run result from Redis."""
+    results = []
+    for suite in FRAMEWORK_SUITES:
+        last = await pool.hgetall(f"framework:suite:{suite['id']}:last")
+        results.append({**suite, "last": last or None})
+    return {"suites": results}
+
+@app.post("/api/framework/trigger")
+async def api_framework_trigger(request: Request):
+    """Trigger one or all framework test suites. Writer-only."""
+    role = await _require_writer(request)
+    body = await request.json()
+    suite_id = body.get("suite", "all")   # suite id or "all"
+    ref      = body.get("ref", "main")
+    arch     = body.get("arch", "amd64")
+
+    suites_to_run = FRAMEWORK_SUITES if suite_id == "all" else [s for s in FRAMEWORK_SUITES if s["id"] == suite_id]
+    suites_to_run = [s for s in suites_to_run if s.get("status") != "coming_soon"]
+
+    queued = []
+    timestamp = datetime.now(timezone.utc).isoformat()
+    for s in suites_to_run:
+        target_arch = s["arch"] if suite_id == "all" else arch
+        job = {
+            "type": "framework-test",
+            "suite": s["id"],
+            "repo": "dynatrace-wwse/codespaces-framework",
+            "arch": target_arch,
+            "queue": f"test:{target_arch}",
+            "ref": ref,
+            "timestamp": timestamp,
+            "trigger": "framework",
+            "nightly_run_id": f"framework-{int(datetime.now(timezone.utc).timestamp())}",
+            "requested_by": role["user"],
+        }
+        await pool.rpush(f"queue:test:{target_arch}", json.dumps(job))
+        queued.append({"suite": s["id"], "arch": target_arch})
+
+    return {"status": "queued", "ref": ref, "jobs": queued}
+
+@app.get("/api/framework/runs")
+async def api_framework_runs(limit: int = 20):
+    """Recent framework test run results."""
+    raw = await pool.lrange("framework:runs", 0, limit - 1)
+    runs = []
+    for r in raw:
+        try:
+            runs.append(json.loads(r))
+        except Exception:
+            pass
+    return {"runs": runs}
+
+# ── Nightly runs list ─────────────────────────────────────────────────────────
+
+@app.get("/api/nightly/runs")
+async def api_nightly_runs():
+    """List all nightly run IDs with pass/fail summaries (newest first)."""
+    completed_raw = await pool.lrange("jobs:completed", -500, -1)
+    runs: dict[str, dict] = {}
+    for j in completed_raw:
+        job = json.loads(j)
+        if job.get("type") == "integration-test" and job.get("nightly_run_id", "").startswith("nightly-"):
+            rid = job["nightly_run_id"]
+            r = job.get("result", {}) or {}
+            if rid not in runs:
+                runs[rid] = {"run_id": rid, "total": 0, "passed": 0, "failed": 0, "timestamp": job.get("timestamp", "")}
+            runs[rid]["total"] += 1
+            if r.get("passed"):
+                runs[rid]["passed"] += 1
+            else:
+                runs[rid]["failed"] += 1
+    sorted_runs = sorted(runs.values(), key=lambda x: x["run_id"], reverse=True)
+    return {"runs": sorted_runs}
+
+@app.get("/api/nightly/run/{run_id}")
+async def api_nightly_run(run_id: str):
+    """Get nightly results for a specific run_id (or 'latest')."""
+    completed_raw = await pool.lrange("jobs:completed", -500, -1)
+    nightly_jobs = []
+    all_runs: dict[str, list] = {}
+    for j in completed_raw:
+        job = json.loads(j)
+        if job.get("type") == "integration-test" and job.get("nightly_run_id", "").startswith("nightly-"):
+            nightly_jobs.append(job)
+            all_runs.setdefault(job["nightly_run_id"], []).append(job)
+
+    if not all_runs:
+        return {"run_id": None, "results": []}
+
+    if run_id == "latest":
+        target_id = sorted(all_runs.keys())[-1]
+    else:
+        target_id = run_id
+
+    target_jobs = all_runs.get(target_id, [])
+    if not target_jobs:
+        raise HTTPException(404, f"No jobs found for nightly run {run_id}")
+
+    all_run_ids = sorted(all_runs.keys())
+    repo_arch_history: dict[str, list] = {}
+    for rid in all_run_ids:
+        for job in all_runs[rid]:
+            result = job.get("result", {}) or {}
+            repo_k = job.get("repo", "")
+            arch_k = job.get("arch") or result.get("arch") or "arm64"
+            key = f"{repo_k}|{arch_k}"
+            repo_arch_history.setdefault(key, []).append({
+                "passed": bool(result.get("passed")),
+                "status": job.get("status", "completed"),
+                "finished_at": job.get("finished_at", ""),
+                "job_id": job.get("job_id", ""),
+                "run_id": rid,
+            })
+
+    results_out = []
+    for job in sorted(target_jobs, key=lambda j: j.get("repo", "")):
+        result = job.get("result", {}) or {}
+        arch_k = job.get("arch") or result.get("arch") or "arm64"
+        repo_k = job.get("repo", "")
+        key = f"{repo_k}|{arch_k}"
+        hist = [h for h in repo_arch_history.get(key, []) if h["run_id"] != target_id][-7:]
+        results_out.append({**job, "history": hist})
+
+    return {
+        "run_id": target_id,
+        "total": len(target_jobs),
+        "passed": sum(1 for j in target_jobs if j.get("result", {}).get("passed")),
+        "failed": sum(1 for j in target_jobs if not j.get("result", {}).get("passed")),
+        "results": results_out,
+    }
 
 
 @app.get("/api/health")

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -744,6 +744,8 @@ async def api_builds_running():
                 "started_at": meta.get("started_at"),
                 "worker_id": meta.get("worker_id"),
                 "type": meta.get("type", "integration-test"),
+                "arena_user": meta.get("arena_user"),
+                "arena_tenant": meta.get("arena_tenant"),
             })
         elif key_type == "string":
             parts = key.split(":", 3)
@@ -2349,42 +2351,111 @@ async def proxy_job_app(job_id: str, app_name: str, request: Request, path: str 
 # Arena API — training catalog, provisioning, session management
 # ---------------------------------------------------------------------------
 
-_ARENA_TRAININGS_STUB = [
-    {
-        "id": "dt-logs-101",
-        "title": "Dynatrace Log Management 101",
-        "description": "Ingest, parse, and query logs with Dynatrace. Hands-on K3d environment.",
+# Repos in dynatrace-wwse that are available as Arena trainings.
+# Each entry maps repo name → Arena metadata overrides.
+# site_name and tags are scraped from mkdocs.yaml; these values fill gaps.
+_ARENA_REPOS = {
+    "enablement-dynatrace-log-ingest-101": {
+        "id": "log-ingest-101",
         "type": "lab",
         "difficulty": "beginner",
         "estimatedTime": 45,
-        "tags": ["logs", "dql", "opentelemetry"],
-        "repoUrl": "https://github.com/dynatrace-wwse/enablement-logs-101",
-        "branch": "main",
-        "source": "orbital",
+        "tags": ["logs", "log-ingest", "opentelemetry"],
     },
-    {
-        "id": "dt-opentelemetry",
-        "title": "OpenTelemetry with Dynatrace",
-        "description": "Instrument apps with OTel SDK and ship traces/metrics/logs to DT.",
-        "type": "lab-assessment",
+    "enablement-live-debugger-bug-hunting": {
+        "id": "live-debugger",
+        "type": "lab",
+        "difficulty": "beginner",
+        "estimatedTime": 30,
+        "tags": ["live-debugger", "debugging", "code"],
+    },
+    "enablement-gen-ai-llm-observability": {
+        "id": "gen-ai-llm",
+        "type": "lab",
         "difficulty": "intermediate",
-        "estimatedTime": 90,
-        "tags": ["opentelemetry", "traces", "metrics", "logs"],
-        "repoUrl": "https://github.com/dynatrace-wwse/enablement-opentelemetry",
-        "branch": "main",
-        "source": "orbital",
+        "estimatedTime": 60,
+        "tags": ["ai", "llm", "opentelemetry", "genai"],
     },
-]
+    "enablement-dql-fundamentals": {
+        "id": "dql-fundamentals",
+        "type": "lab-assessment",
+        "difficulty": "beginner",
+        "estimatedTime": 45,
+        "tags": ["dql", "logs", "metrics", "traces"],
+    },
+    "enablement-business-observability": {
+        "id": "business-observability",
+        "type": "lab",
+        "difficulty": "intermediate",
+        "estimatedTime": 60,
+        "tags": ["bizevents", "business-observability", "dql"],
+    },
+}
+
+_ARENA_CATALOG_CACHE_KEY = "arena:catalog"
+_ARENA_CATALOG_TTL = 300  # 5 minutes
+
+
+async def _fetch_arena_catalog() -> list[dict]:
+    """Scrape site_name from each repo's mkdocs.yaml via GitHub API.
+
+    Falls back to repo name if mkdocs.yaml is unavailable.
+    Results cached in Redis for 5 minutes to avoid repeated API calls.
+    """
+    import base64 as _b64
+    import re as _re
+
+    async def _get_mkdocs_title(repo: str) -> tuple[str, str]:
+        """Return (site_name, description) from mkdocs.yaml, or sensible defaults."""
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                url = f"{GH_API}/repos/dynatrace-wwse/{repo}/contents/mkdocs.yaml"
+                headers = {"Authorization": f"Bearer {GH_TOKEN}"} if GH_TOKEN else {}
+                resp = await client.get(url, headers=headers)
+                if resp.status_code != 200:
+                    return repo, ""
+                content = _b64.b64decode(resp.json()["content"]).decode("utf-8", errors="replace")
+                name_match = _re.search(r'^site_name:\s*["\']?(.+?)["\']?\s*$', content, _re.MULTILINE)
+                desc_match = _re.search(r'^site_description:\s*["\']?(.+?)["\']?\s*$', content, _re.MULTILINE)
+                title = name_match.group(1).strip() if name_match else repo
+                # Strip "Dynatrace Enablement Lab: " prefix for brevity
+                title = _re.sub(r'^Dynatrace (?:Enablement|Observability) Lab:\s*', '', title)
+                desc = desc_match.group(1).strip() if desc_match else ""
+                return title, desc
+        except Exception:
+            return repo, ""
+
+    trainings = []
+    for repo, meta in _ARENA_REPOS.items():
+        title, desc = await _get_mkdocs_title(repo)
+        trainings.append({
+            "id": meta["id"],
+            "title": title,
+            "description": desc or f"Hands-on {title} lab in a live Kubernetes environment.",
+            "type": meta["type"],
+            "difficulty": meta["difficulty"],
+            "estimatedTime": meta["estimatedTime"],
+            "tags": meta["tags"],
+            "repoUrl": f"https://github.com/dynatrace-wwse/{repo}",
+            "branch": "main",
+            "source": "orbital",
+        })
+    return trainings
 
 
 @app.get("/api/arena/trainings")
 async def api_arena_trainings():
-    """Return available Arena trainings.
+    """Return available Arena trainings scraped from real repos.
 
-    Currently returns a hardcoded stub. Future: scrape mkdocs.yaml from each
-    enablement repo and cache in Redis with a 5-minute TTL.
+    Titles come from mkdocs.yaml site_name. Cached in Redis for 5 minutes.
     """
-    return _ARENA_TRAININGS_STUB
+    cached = await pool.get(_ARENA_CATALOG_CACHE_KEY)
+    if cached:
+        return json.loads(cached)
+
+    trainings = await _fetch_arena_catalog()
+    await pool.set(_ARENA_CATALOG_CACHE_KEY, json.dumps(trainings), ex=_ARENA_CATALOG_TTL)
+    return trainings
 
 
 class ArenaProvisionRequest(BaseModel):
@@ -2395,61 +2466,433 @@ class ArenaProvisionRequest(BaseModel):
 
 @app.post("/api/arena/provision")
 async def api_arena_provision(body: ArenaProvisionRequest):
-    """Provision a training environment for the given user + training.
+    """Provision a training environment — queues a real daemon job on the amd64 worker.
 
-    Currently returns a stub job so Arena can exercise the provisioning state
-    machine end-to-end. Real implementation will queue a daemon job whose
-    executor clones the training repo into a Sysbox container.
-
-    Returns: { jobId, wsUrl, expiresAt, status }
+    Returns: { jobId, wsUrl, expiresAt, status: "provisioning" }
     """
     import uuid as _uuid
-    training = next((t for t in _ARENA_TRAININGS_STUB if t["id"] == body.trainingId), None)
+
+    cached = await pool.get(_ARENA_CATALOG_CACHE_KEY)
+    catalog = json.loads(cached) if cached else await _fetch_arena_catalog()
+    training = next((t for t in catalog if t["id"] == body.trainingId), None)
     if training is None:
         raise HTTPException(status_code=404, detail=f"Training '{body.trainingId}' not found")
 
+    # org/repo format for the executor (e.g. "dynatrace-wwse/enablement-live-debugger-bug-hunting")
+    repo_nwo = "/".join(training["repoUrl"].rstrip("/").split("/")[-2:])
+    repo_name = training["repoUrl"].split("/")[-1]
     job_id = f"arena-{_uuid.uuid4().hex[:12]}"
-    expires_at = (datetime.now(timezone.utc).replace(microsecond=0)
-                  + timedelta(hours=4)).isoformat()
+    now = datetime.now(timezone.utc)
+    expires_at = (now.replace(microsecond=0) + timedelta(hours=4)).isoformat()
 
-    # Write a stub entry so /api/arena/sessions/{job_id} can resolve it.
+    job = {
+        "job_id":        job_id,
+        "type":          "daemon",
+        "repo":          repo_nwo,
+        "arch":          "amd64",
+        "ref":           training["branch"],
+        "timestamp":     now.isoformat(),
+        "trigger":       "arena",
+        "nightly_run_id": f"arena-{body.trainingId}",
+        "requested_by":  body.userId,
+    }
+    # Pre-write so session-status can resolve it before the worker picks it up.
     await pool.hset(f"job:running:{job_id}", mapping={
-        "repo":        training["repoUrl"].split("/")[-1],
-        "branch":      training["branch"],
-        "arch":        "amd64",
-        "started_at":  datetime.now(timezone.utc).isoformat(),
-        "worker_id":   "stub",
-        "arena_user":  body.userId,
+        "job_id":       job_id,
+        "repo":         repo_nwo,
+        "branch":       training["branch"],
+        "arch":         "amd64",
+        "started_at":   now.isoformat(),
+        "worker_id":    "queued",
+        "type":         "daemon",
+        "arena_user":   body.userId,
         "arena_tenant": body.tenantId,
-        "training_id": body.trainingId,
-        "status":      "provisioning",
+        "training_id":  body.trainingId,
+        "expires_at":   expires_at,
     })
     await pool.expire(f"job:running:{job_id}", int(timedelta(hours=4).total_seconds()))
+    await pool.rpush("queue:test:amd64", json.dumps(job))
 
     return {
-        "jobId": job_id,
-        "wsUrl": f"wss://autonomous-enablements.whydevslovedynatrace.com/ws/jobs/{job_id}/shell",
+        "jobId":     job_id,
+        "wsUrl":     f"wss://autonomous-enablements.whydevslovedynatrace.com/ws/jobs/{job_id}/shell",
         "expiresAt": expires_at,
-        "status": "provisioning",
+        "status":    "provisioning",
     }
 
 
 @app.get("/api/arena/sessions/{job_id}")
 async def api_arena_session_status(job_id: str):
-    """Return current status + wsUrl for a provisioned training session."""
+    """Return current session status.
+
+    Status transitions:
+      queued      → worker hasn't picked up the job yet
+      provisioning → worker is running postCreate/postStart (cluster setup, ~5-15 min)
+      ready       → "Daemon ready" appeared in livelog — shell is available
+      expired     → job:running key missing (terminated or TTL elapsed)
+    """
     meta = await pool.hgetall(f"job:running:{job_id}")
     if not meta:
         return {"jobId": job_id, "status": "expired"}
 
-    status = meta.get("status", "provisioning")
+    # Check livelog for readiness signal written by execute_daemon
+    livelog = await pool.get(f"job:livelog:{job_id}")
+    if livelog and "Daemon ready" in livelog:
+        status = "ready"
+    elif meta.get("worker_id") in ("queued", ""):
+        status = "queued"
+    else:
+        status = "provisioning"
+
     return {
-        "jobId": job_id,
-        "status": status,
-        "wsUrl": f"wss://autonomous-enablements.whydevslovedynatrace.com/ws/jobs/{job_id}/shell",
+        "jobId":      job_id,
+        "status":     status,
+        "wsUrl":      f"wss://autonomous-enablements.whydevslovedynatrace.com/ws/jobs/{job_id}/shell",
         "trainingId": meta.get("training_id", ""),
-        "userId": meta.get("arena_user", ""),
-        "expiresAt": meta.get("expires_at", ""),
+        "userId":     meta.get("arena_user", ""),
+        "expiresAt":  meta.get("expires_at", ""),
     }
+
+
+@app.post("/api/arena/sessions/{job_id}/shell-token")
+async def api_arena_shell_token(job_id: str):
+    """Issue a single-use 60-second shell token for an arena session.
+
+    Arena orbital proxy function calls this server-side (no browser OAuth needed).
+    The returned token is passed to the /terminal/{job_id}?token=... page.
+    """
+    meta = await pool.hgetall(f"job:running:{job_id}")
+    if not meta:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+    if meta.get("worker_id") in ("queued", "stub"):
+        raise HTTPException(status_code=409, detail="Session not ready yet")
+
+    token = secrets.token_hex(16)
+    await pool.set(f"shell:token:{token}", job_id, ex=60)
+    return {"token": token}
+
+
+@app.get("/terminal/{job_id}", response_class=HTMLResponse)
+async def arena_terminal_page(job_id: str, token: str = ""):
+    """Standalone xterm.js terminal page for Arena training sessions.
+
+    Tabs: Log (livelog stream, plain text) | Shell (xterm PTY, lazy-opened) | Apps (proxy + docs)
+
+    Shell is opened lazily when the user first clicks the Shell tab and "Daemon ready"
+    has been seen in the log — this avoids xterm measuring 0x0 when hidden.
+
+    Auth: single-use shell token passed as ?token=.
+    """
+    ws_url   = f"wss://autonomous-enablements.whydevslovedynatrace.com/ws/jobs/{job_id}/shell"
+    base_url = "https://autonomous-enablements.whydevslovedynatrace.com"
+
+    meta = await pool.hgetall(f"job:running:{job_id}") or {{}}
+    repo_full = meta.get("repo", "")
+    repo_name = repo_full.split("/")[-1] if repo_full else ""
+    docs_url  = f"https://dynatrace-wwse.github.io/{repo_name}/" if repo_name else ""
+
+    return HTMLResponse(f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Training Environment</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.min.css">
+<style>
+@font-face {{
+  font-family: 'MesloLGS NF';
+  src: url('https://cdn.jsdelivr.net/gh/romkatv/powerlevel10k-media@master/MesloLGS%20NF%20Regular.ttf') format('truetype');
+  font-weight: normal; font-style: normal;
+}}
+@font-face {{
+  font-family: 'MesloLGS NF';
+  src: url('https://cdn.jsdelivr.net/gh/romkatv/powerlevel10k-media@master/MesloLGS%20NF%20Bold.ttf') format('truetype');
+  font-weight: bold; font-style: normal;
+}}
+* {{ margin: 0; padding: 0; box-sizing: border-box; }}
+html, body {{ height: 100%; overflow: hidden; background: #1a1a2e; color: #d4d4d4; }}
+body {{ display: flex; flex-direction: column; font-family: -apple-system, sans-serif; }}
+
+#topbar {{
+  background: #16213e; color: #a0aec0; font-size: 12px; line-height: 38px;
+  padding: 0 16px; display: flex; align-items: center; justify-content: space-between;
+  flex-shrink: 0; border-bottom: 1px solid #0d3460; gap: 16px;
+}}
+#brand {{ display: flex; align-items: center; gap: 8px; }}
+#brand-logo {{ color: #00b4d8; font-size: 18px; }}
+#brand-name {{ color: #e2e8f0; font-weight: 600; font-size: 13px; letter-spacing: 0.3px; }}
+#status {{ font-size: 11px; color: #718096; white-space: nowrap; }}
+#status.ok   {{ color: #48bb78; }}
+#status.err  {{ color: #fc8181; }}
+#status.busy {{ color: #ed8936; }}
+
+#tabbar {{
+  background: #16213e; border-bottom: 1px solid #0d3460;
+  display: flex; flex-shrink: 0; padding: 0 8px;
+}}
+.tab {{
+  padding: 0 20px; line-height: 36px; cursor: pointer;
+  border-bottom: 2px solid transparent; color: #718096;
+  font-size: 12px; user-select: none; transition: color .15s; position: relative;
+}}
+.tab:hover  {{ color: #a0aec0; }}
+.tab.active {{ color: #00b4d8; border-bottom-color: #00b4d8; }}
+.tab.disabled {{ opacity: 0.4; cursor: not-allowed; }}
+.tab .badge {{
+  display: inline-block; margin-left: 6px; padding: 1px 5px; border-radius: 8px;
+  font-size: 10px; background: #48bb78; color: #1a1a2e; font-weight: 700;
+  vertical-align: middle;
+}}
+
+#panels {{ flex: 1; display: flex; flex-direction: column; min-height: 0; }}
+
+/* ── Log panel ── */
+#panel-log {{ flex: 1; display: flex; flex-direction: column; min-height: 0; overflow: hidden; }}
+#log-output {{
+  flex: 1; overflow-y: auto; padding: 12px 16px;
+  font: 12px/1.6 'MesloLGS NF', 'Cascadia Code', monospace;
+  background: #0d1117; white-space: pre-wrap; word-break: break-all;
+}}
+#log-status {{
+  padding: 6px 16px; font-size: 11px; color: #718096; background: #16213e;
+  border-top: 1px solid #0d3460; flex-shrink: 0;
+}}
+
+/* ── Shell panel ── */
+#panel-shell {{ flex: 1; padding: 4px; min-height: 0; display: none; flex-direction: column; }}
+#terminal {{ flex: 1; min-height: 0; }}
+
+/* ── Apps panel ── */
+#panel-apps {{
+  flex: 1; padding: 20px; overflow-y: auto; display: none; background: #1a1a2e;
+}}
+#panel-apps h3 {{ color: #e2e8f0; font-size: 13px; margin-bottom: 16px; }}
+.app-card {{
+  background: #16213e; border: 1px solid #0d3460; border-radius: 6px;
+  padding: 14px 16px; margin-bottom: 10px;
+  display: flex; align-items: center; justify-content: space-between;
+}}
+.app-card.docs-card {{ border-color: #1a4a6b; }}
+.app-name {{ color: #00b4d8; font-size: 13px; font-weight: 600; }}
+.app-sub  {{ color: #718096; font-size: 11px; margin-top: 3px; }}
+.app-btn {{
+  background: #0e639c; color: #fff; padding: 5px 14px; border-radius: 4px;
+  font-size: 12px; text-decoration: none; transition: background .15s; white-space: nowrap;
+}}
+.app-btn:hover {{ background: #1177bb; }}
+.app-btn.docs-btn {{ background: #2d6a4f; }}
+.app-btn.docs-btn:hover {{ background: #40916c; }}
+</style>
+</head>
+<body>
+<div id="topbar">
+  <div id="brand">
+    <span id="brand-logo">⬡</span>
+    <span id="brand-name">Dynatrace Enablements</span>
+  </div>
+  <span id="status" class="busy">Setting up environment…</span>
+</div>
+<div id="tabbar">
+  <div class="tab active" id="tab-log"   onclick="switchTab('log')">📋 Log</div>
+  <div class="tab disabled" id="tab-shell" onclick="switchTab('shell')">⌨ Shell</div>
+  <div class="tab" id="tab-apps" onclick="switchTab('apps')">🚀 Apps</div>
+</div>
+<div id="panels">
+  <div id="panel-log">
+    <div id="log-output"></div>
+    <div id="log-status">Waiting for provisioning log…</div>
+  </div>
+  <div id="panel-shell">
+    <div id="terminal"></div>
+  </div>
+  <div id="panel-apps">
+    <h3>Apps &amp; Resources</h3>
+    <div id="apps-list">
+      {'<div class="app-card docs-card"><div><div class="app-name">📖 Training Documentation</div><div class="app-sub">GitHub Pages</div></div><a class="app-btn docs-btn" href="' + docs_url + '" target="_blank" rel="noopener">Open ↗</a></div>' if docs_url else ''}
+      <div id="dynamic-apps"></div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xterm-addon-web-links@0.9.0/lib/xterm-addon-web-links.min.js"></script>
+<script>
+const JOB_ID   = {json.dumps(job_id)};
+const TOKEN    = {json.dumps(token)};
+const WS_URL   = {json.dumps(ws_url)};
+const BASE_URL = {json.dumps(base_url)};
+
+const statusEl  = document.getElementById('status');
+const logOutput = document.getElementById('log-output');
+const logStatus = document.getElementById('log-status');
+
+// ── Tab switching ─────────────────────────────────────────────────────────────
+let termOpened = false;
+let shellReady = false; // true once "Daemon ready" seen
+
+function switchTab(name) {{
+  if (name === 'shell' && !shellReady) return; // locked until env ready
+
+  ['log','shell','apps'].forEach(n => {{
+    const panel = document.getElementById('panel-' + n);
+    const tab   = document.getElementById('tab-' + n);
+    const show  = n === name;
+    panel.style.display = show ? (n === 'shell' ? 'flex' : (n === 'apps' ? 'block' : 'flex')) : 'none';
+    tab.className = 'tab' + (show ? ' active' : '') +
+                    (n === 'shell' && !shellReady ? ' disabled' : '');
+  }});
+
+  if (name === 'shell') {{
+    if (!termOpened) {{
+      openTerminal();
+    }} else {{
+      setTimeout(() => fitAddon && fitAddon.fit(), 50);
+    }}
+  }}
+}}
+
+// ── Log streaming ─────────────────────────────────────────────────────────────
+// Strip ANSI escape codes for plain-text log display
+function stripAnsi(s) {{
+  return s.replace(/\x1b\[[0-9;]*[mGKHFJ]/g, '').replace(/\x1b\][^\x07]*\x07/g, '');
+}}
+
+let lastLogLen = 0;
+let logTimer   = setInterval(pollLivelog, 2000);
+
+async function pollLivelog() {{
+  try {{
+    const r = await fetch(`${{BASE_URL}}/api/jobs/${{JOB_ID}}/livelog`);
+    if (r.status === 404) {{
+      logStatus.textContent = 'Waiting for container to start…';
+      return;
+    }}
+    const text = await r.text();
+    if (text.length > lastLogLen) {{
+      const chunk = stripAnsi(text.slice(lastLogLen));
+      logOutput.textContent += chunk;
+      logOutput.scrollTop = logOutput.scrollHeight;
+      lastLogLen = text.length;
+    }}
+    const ready = text.includes('Daemon ready');
+    logStatus.textContent = ready
+      ? '✓ Environment ready — click Shell to connect'
+      : `Streaming log… (${{Math.round(lastLogLen / 1024)}} KB)`;
+
+    if (ready && !shellReady) {{
+      clearInterval(logTimer); logTimer = null;
+      shellReady = true;
+      // Unlock Shell tab
+      const shellTab = document.getElementById('tab-shell');
+      shellTab.className = 'tab';
+      shellTab.innerHTML = '⌨ Shell <span class="badge">Ready</span>';
+      statusEl.textContent = 'Environment ready';
+      statusEl.className   = 'ok';
+    }}
+  }} catch {{}}
+}}
+
+// ── xterm — opened lazily when Shell tab first selected ───────────────────────
+let term, fitAddon, ws;
+
+async function openTerminal() {{
+  termOpened = true;
+  statusEl.textContent = 'Fetching shell token…';
+  statusEl.className   = 'busy';
+
+  // Always fetch a fresh token right before connecting — the URL token (if any)
+  // has a 60s TTL and will have expired if the user waited for provisioning.
+  let token = TOKEN; // fallback to URL param
+  try {{
+    const tr = await fetch(`${{BASE_URL}}/api/arena/sessions/${{JOB_ID}}/shell-token`, {{ method: 'POST' }});
+    if (tr.ok) {{ const j = await tr.json(); token = j.token; }}
+  }} catch {{ /* use URL token as fallback */ }}
+
+  statusEl.textContent = 'Connecting shell…';
+
+  document.fonts.load('13px "MesloLGS NF"').then(() => {{
+    term = new Terminal({{
+      cursorBlink: true,
+      fontSize: 13,
+      fontFamily: '"MesloLGS NF", "Cascadia Code NF", "Hack Nerd Font", ui-monospace, Menlo, monospace',
+      theme: {{
+        background: '#1a1a2e', foreground: '#d4d4d4', cursor: '#00b4d8',
+        selectionBackground: '#264f78',
+      }},
+      scrollback: 5000,
+      convertEol: false,
+    }});
+    fitAddon = new FitAddon.FitAddon();
+    term.loadAddon(fitAddon);
+    term.loadAddon(new WebLinksAddon.WebLinksAddon());
+
+    term.open(document.getElementById('terminal'));
+    fitAddon.fit(); // panel-shell is VISIBLE at this point — correct dimensions
+
+    const rows = term.rows, cols = term.cols;
+    ws = new WebSocket(`${{WS_URL}}?token=${{encodeURIComponent(token)}}&rows=${{rows}}&cols=${{cols}}`);
+    ws.binaryType = 'arraybuffer';
+
+    ws.onopen = () => {{
+      statusEl.textContent = 'Connected';
+      statusEl.className   = 'ok';
+      ws.send(JSON.stringify({{ type: 'resize', rows, cols }}));
+    }};
+    ws.onmessage = (e) => {{
+      if (e.data instanceof ArrayBuffer) term.write(new Uint8Array(e.data));
+      else term.write(e.data);
+    }};
+    ws.onclose = (e) => {{
+      statusEl.textContent = `Disconnected (${{e.code}})`;
+      statusEl.className   = 'err';
+      term.writeln('\r\n\x1b[31mSession closed.\x1b[0m');
+    }};
+    ws.onerror = () => {{
+      statusEl.textContent = 'Connection error';
+      statusEl.className   = 'err';
+    }};
+
+    const encoder = new TextEncoder();
+    term.onData(d => {{ if (ws.readyState === WebSocket.OPEN) ws.send(encoder.encode(d)); }});
+    term.onResize(sz => {{
+      if (ws.readyState === WebSocket.OPEN)
+        ws.send(JSON.stringify({{ type: 'resize', rows: sz.rows, cols: sz.cols }}));
+    }});
+  }});
+}}
+
+window.addEventListener('resize', () => {{
+  if (termOpened && fitAddon) fitAddon.fit();
+}});
+
+// ── Apps polling — starts on page load, not just when shell connects ──────────
+let appsInterval = null;
+function startAppsPolling() {{
+  if (appsInterval) return;
+  pollApps();
+  appsInterval = setInterval(pollApps, 10000);
+}}
+startAppsPolling(); // show docs card immediately
+async function pollApps() {{
+  try {{
+    const r = await fetch(`${{BASE_URL}}/api/jobs/${{JOB_ID}}/apps`);
+    if (!r.ok) return;
+    const {{apps}} = await r.json();
+    const el = document.getElementById('dynamic-apps');
+    el.innerHTML = (apps || []).map(a => `
+      <div class="app-card">
+        <div>
+          <div class="app-name">${{a.name}}</div>
+          <div class="app-sub">port ${{a.port}}</div>
+        </div>
+        <a class="app-btn" href="${{BASE_URL}}${{a.proxy_url}}" target="_blank" rel="noopener">Open ↗</a>
+      </div>`).join('');
+  }} catch {{}}
+}}
+</script>
+</body>
+</html>""")
 
 
 class ArenaExecRequest(BaseModel):

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -2649,9 +2649,7 @@ body {{ display: flex; flex-direction: column; font-family: -apple-system, sans-
 /* ── Log panel ── */
 #panel-log {{ flex: 1; display: flex; flex-direction: column; min-height: 0; overflow: hidden; }}
 #log-output {{
-  flex: 1; overflow-y: auto; padding: 12px 16px;
-  font: 12px/1.6 'MesloLGS NF', 'Cascadia Code', monospace;
-  background: #0d1117; white-space: pre-wrap; word-break: break-all;
+  flex: 1; min-height: 0; padding: 4px;
 }}
 #log-status {{
   padding: 6px 16px; font-size: 11px; color: #718096; background: #16213e;
@@ -2920,18 +2918,22 @@ async def api_arena_session_exec(job_id: str, body: ArenaExecRequest):
 
     worker_id = meta.get("worker_id", "")
     repo = meta.get("repo", "")
+    # repo is stored as "org/repo-name"; workspace only uses the repo-name part
+    repo_name = repo.split("/")[-1] if "/" in repo else repo
     container = f"sb-{job_id[-32:]}"
 
     # Build the exec command (same pattern as PTY bridge, without -t for non-interactive)
-    inner_cmd = _shlex.join(["docker", "exec", "-w", f"/workspaces/{repo}", "dt",
+    inner_cmd = _shlex.join(["docker", "exec", "-w", f"/workspaces/{repo_name}", "dt",
                               "sh", "-c", body.command])
     outer_cmd = ["docker", "exec", container, "sh", "-c", inner_cmd]
 
     worker_rec = await pool.hgetall(f"worker:{worker_id}") if worker_id.startswith("worker-") else {}
     ssh_host = worker_rec.get("ssh_host", "")
     if ssh_host:
+        # SSH concatenates list args with spaces, breaking `sh -c {inner_cmd}`.
+        # Pass the entire remote command as a single shlex-quoted string instead.
         full_cmd = ["ssh", "-o", "StrictHostKeyChecking=no", "-o", "ConnectTimeout=10",
-                    ssh_host] + outer_cmd
+                    ssh_host, _shlex.join(outer_cmd)]
     else:
         full_cmd = outer_cmd
 

--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -1201,7 +1201,11 @@ async function loadRunningDetail() {
                     <td>${escapeHtml(r.branch || r.ref || '')}</td>
                     <td><span class="arch-badge">${escapeHtml(r.arch || '')}</span></td>
                     <td style="font-size:0.8rem;color:var(--text-2)">${escapeHtml(formatJobType(r.type))}</td>
-                    <td><span style="font-size:0.75rem;color:var(--text-muted)">${escapeHtml(r.worker_id || '')}</span></td>
+                    <td>
+                        <span style="font-size:0.75rem;color:var(--text-muted)">${escapeHtml(r.worker_id || '')}</span>
+                        ${r.arena_user ? `<br><span style="font-size:0.7rem;color:#4ec9b0" title="Arena session">👤 ${escapeHtml(r.arena_user)}</span>` : ''}
+                        ${r.arena_tenant ? `<br><span style="font-size:0.7rem;color:var(--text-2)" title="Tenant">${escapeHtml(r.arena_tenant.replace(/\.apps\.dynatrace\.com$/, ''))}</span>` : ''}
+                    </td>
                     <td title="${escapeHtml(r.started_at || '')}">${formatTime(r.started_at)}</td>
                     <td>${formatDuration(elapsed)}</td>
                     <td>${termBtn}</td>

--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -711,14 +711,23 @@ function openLiveLog(jobId, title, isAgent = false) {
 
     const fetchOnce = async () => {
         try {
-            // Try livelog first (running). 404 → fall back to final log + stop polling.
+            // Try livelog first (running job). On 404 try the final log.
+            // If the final log is also absent the job is still setting up —
+            // keep polling so we don't go dark during the Sysbox setup phase.
             let res = await fetch(`/api/jobs/${jobId}/livelog`);
             if (res.status === 404) {
-                res = await fetch(`/api/jobs/${jobId}/log`);
-                if (livelogPoll) { clearInterval(livelogPoll); livelogPoll = null; }
-                currentJobIsLive = false;
-                if (termBtn) termBtn.hidden = true;
-                if (shellBtn) shellBtn.hidden = true;
+                const finalRes = await fetch(`/api/jobs/${jobId}/log`);
+                if (finalRes.ok) {
+                    // Job finished — show final log and stop polling.
+                    res = finalRes;
+                    if (livelogPoll) { clearInterval(livelogPoll); livelogPoll = null; }
+                    currentJobIsLive = false;
+                    if (termBtn) termBtn.hidden = true;
+                    if (shellBtn) shellBtn.hidden = true;
+                } else {
+                    // Both 404 — job is still in setup phase. Keep polling.
+                    return;
+                }
             } else if (res.ok) {
                 currentJobIsLive = true;
                 if (!isAgent) {

--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -98,6 +98,7 @@ function activateTab(view) {
     if (view === 'running') loadRunningDetail();
     if (view === 'sync') loadSyncTab();
     if (view === 'agentic') loadAgentic();
+    if (view === 'framework') loadFramework();
 }
 
 document.querySelectorAll('.tab').forEach(tab => {
@@ -1024,8 +1025,25 @@ async function loadWorkers() {
 
 // ── Nightly View ────────────────────────────────────────────────────────────
 
-async function loadNightly() {
-    const res = await fetch(`${API}/api/nightly/latest`);
+let _nightlyAllResults = [];
+
+async function loadNightlyRuns() {
+    const res = await fetch(`${API}/api/nightly/runs`);
+    const data = await res.json();
+    const sel = document.getElementById('nightly-run-select');
+    if (!sel) return;
+    const runs = data.runs || [];
+    sel.innerHTML = `<option value="latest">Latest run</option>` +
+        runs.map(r => {
+            const d = r.run_id.replace('nightly-', '').replace(/-\d{6}$/, '');
+            return `<option value="${escapeHtml(r.run_id)}">${escapeHtml(d)} (${r.passed}✓ ${r.failed}✗)</option>`;
+        }).join('');
+}
+
+async function loadNightly(runId) {
+    runId = runId || document.getElementById('nightly-run-select')?.value || 'latest';
+    const endpoint = runId === 'latest' ? `${API}/api/nightly/latest` : `${API}/api/nightly/run/${encodeURIComponent(runId)}`;
+    const res = await fetch(endpoint);
     const data = await res.json();
 
     const summary = document.getElementById('nightly-summary');
@@ -1042,16 +1060,34 @@ async function loadNightly() {
         <div style="color:var(--text-muted);font-size:0.8rem">${data.run_id}</div>
     `;
 
+    _nightlyAllResults = data.results || [];
+    applyNightlyFilter();
+}
+
+function applyNightlyFilter() {
+    const filter = document.getElementById('nightly-status-filter')?.value || 'all';
+    const filtered = filter === 'all' ? _nightlyAllResults
+        : _nightlyAllResults.filter(j => {
+            const passed = j.result?.passed;
+            const term = j.status === 'terminated';
+            if (filter === 'passed') return passed && !term;
+            if (filter === 'failed') return !passed || term;
+            return true;
+        });
+
     const tbody = document.getElementById('nightly-body');
-    tbody.innerHTML = data.results.map(job => {
+    if (!filtered.length) {
+        tbody.innerHTML = `<tr><td colspan="6" class="loading">No results match filter</td></tr>`;
+        return;
+    }
+    tbody.innerHTML = filtered.map(job => {
         const r = job.result || {};
         const arch = r.arch || job.worker_arch || '?';
         const isTerminated = job.status === 'terminated';
         const cls = isTerminated ? 'status-terminated' : (r.passed ? 'status-pass' : 'status-fail');
         const label = isTerminated ? 'TERM' : (r.passed ? 'PASS' : 'FAIL');
         const status = job.job_id
-            ? `<a href="#" class="${cls} log-link" data-final-job="${escapeHtml(job.job_id)}"
-                  title="View log">${label}</a>`
+            ? `<a href="#" class="${cls} log-link" data-final-job="${escapeHtml(job.job_id)}" title="View log">${label}</a>`
             : `<span class="${cls}">${label}</span>`;
         const historyHtml = (job.history && job.history.length > 0)
             ? `<div class="build-spark">${renderBuildSpark(job.history)}</div>` : '—';
@@ -1065,6 +1101,125 @@ async function loadNightly() {
         </tr>`;
     }).join('');
 }
+
+// ── Framework View ───────────────────────────────────────────────────────────
+
+let _frameworkSuitesData = [];
+
+async function loadFramework() {
+    const [suitesRes, runsRes] = await Promise.all([
+        fetch(`${API}/api/framework/suites`),
+        fetch(`${API}/api/framework/runs`),
+    ]);
+    const suitesData = await suitesRes.json();
+    const runsData = await runsRes.json();
+    _frameworkSuitesData = suitesData.suites || [];
+    renderFrameworkSuites(_frameworkSuitesData);
+    renderFrameworkRuns(runsData.runs || []);
+}
+
+function renderFrameworkSuites(suites) {
+    const grid = document.getElementById('framework-suite-grid');
+    if (!grid) return;
+    grid.innerHTML = suites.map(s => {
+        const last = s.last;
+        const comingSoon = s.status === 'coming_soon';
+        const needsVM = s.requires_native;
+        let resultHtml = '<span class="status-terminated">—</span>';
+        let metaHtml = '<span style="color:var(--text-muted);font-size:0.75rem">Never run</span>';
+        if (last) {
+            const passed = last.passed === 'true';
+            resultHtml = passed
+                ? `<a href="#" class="status-pass log-link" data-job-id="${escapeHtml(last.job_id)}" title="View log">✅ PASS</a>`
+                : `<a href="#" class="status-fail log-link" data-job-id="${escapeHtml(last.job_id)}" title="View log">❌ FAIL</a>`;
+            const ts = last.timestamp ? formatTime(last.timestamp) : '';
+            metaHtml = `<span style="color:var(--text-muted);font-size:0.75rem">${escapeHtml(last.arch)} · ${last.duration_s}s · ${ts}</span>`;
+        }
+        const badges = [
+            needsVM ? '<span class="badge badge-warn">needs VM</span>' : null,
+            s.needs_creds ? '<span class="badge badge-info">DT creds</span>' : null,
+            comingSoon ? '<span class="badge badge-muted">coming soon</span>' : null,
+        ].filter(Boolean).join(' ');
+        const btnAttrs = comingSoon ? 'disabled title="Not yet implemented"' : `data-action data-suite="${escapeHtml(s.id)}"`;
+        return `<div class="framework-card">
+            <div class="framework-card-header">
+                <span class="framework-card-name">${escapeHtml(s.name)}</span>
+                ${badges}
+            </div>
+            <p class="framework-card-desc">${escapeHtml(s.description)}</p>
+            <div class="framework-card-footer">
+                <div>${resultHtml}<br>${metaHtml}</div>
+                <button class="btn btn-small ${comingSoon ? 'btn-secondary' : ''} framework-run-btn" ${btnAttrs}>▶ Run</button>
+            </div>
+        </div>`;
+    }).join('');
+}
+
+function renderFrameworkRuns(runs) {
+    const tbody = document.getElementById('framework-runs-body');
+    if (!tbody) return;
+    if (!runs.length) {
+        tbody.innerHTML = '<tr><td colspan="6" class="loading">No framework runs yet</td></tr>';
+        return;
+    }
+    tbody.innerHTML = runs.map(r => {
+        const cls = r.passed ? 'status-pass' : 'status-fail';
+        const label = r.passed ? 'PASS' : 'FAIL';
+        const logLink = r.job_id
+            ? `<a href="#" class="log-link" data-job-id="${escapeHtml(r.job_id)}" title="View log">log</a>`
+            : '—';
+        return `<tr>
+            <td>${formatTime(r.timestamp)}</td>
+            <td>${escapeHtml(r.suite)}</td>
+            <td><span class="arch-badge">${escapeHtml(r.arch)}</span></td>
+            <td><span class="${cls}">${label}</span></td>
+            <td>${r.duration_s || 0}s</td>
+            <td>${logLink}</td>
+        </tr>`;
+    }).join('');
+}
+
+async function triggerFrameworkSuite(suiteId, ref) {
+    if (!isWriter()) { alert('Sign in as a writer to trigger tests.'); return; }
+    ref = ref || document.getElementById('framework-ref')?.value || 'main';
+    try {
+        const res = await fetch(`${API}/api/framework/trigger`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ suite: suiteId, ref, arch: suiteId === 'bats' ? 'arm64' : 'amd64' }),
+        });
+        if (!res.ok) { alert(`Error ${res.status}: ${await res.text()}`); return; }
+        const data = await res.json();
+        alert(`Queued: ${data.jobs.map(j => `${j.suite} (${j.arch})`).join(', ')}`);
+        setTimeout(loadFramework, 2000);
+    } catch (e) { alert(`Error: ${e}`); }
+}
+
+// Framework tab events
+document.addEventListener('click', e => {
+    const runBtn = e.target.closest('.framework-run-btn[data-suite]');
+    if (runBtn) {
+        e.preventDefault();
+        triggerFrameworkSuite(runBtn.dataset.suite);
+        return;
+    }
+    const runAll = e.target.closest('#framework-run-all');
+    if (runAll) {
+        e.preventDefault();
+        triggerFrameworkSuite('all');
+        return;
+    }
+    const triggerFw = e.target.closest('#nightly-trigger-framework');
+    if (triggerFw) {
+        e.preventDefault();
+        const ref = prompt('Branch to test?', 'feature/k3d-default-kind-cnfs');
+        if (ref) triggerFrameworkSuite('all', ref);
+        return;
+    }
+});
+
+document.getElementById('nightly-run-select')?.addEventListener('change', () => loadNightly());
+document.getElementById('nightly-status-filter')?.addEventListener('change', applyNightlyFilter);
 
 // ── History View ────────────────────────────────────────────────────────────
 
@@ -2754,6 +2909,7 @@ async function triggerAgentFixCI(failedJobId, repo, branch, arch, failedStep, bt
     loadFleetTriggerPanel();
     loadWorkers();
     loadNightly();
+    loadNightlyRuns();
 })();
 
 // Auto-refresh

--- a/ops-server/dashboard/static/style.css
+++ b/ops-server/dashboard/static/style.css
@@ -1344,4 +1344,71 @@ a.spark-bar:hover { opacity: .75; }
 .audit-issue  { color: var(--red); }
 .audit-ok     { color: var(--green); }
 .audit-warn   { color: var(--yellow); }
+
+/* Framework tab */
+.framework-toolbar {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+}
+.framework-suite-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 16px;
+    margin-bottom: 8px;
+}
+.framework-card {
+    background: var(--panel-bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.framework-card-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+.framework-card-name {
+    font-weight: 600;
+    font-size: 0.9rem;
+    flex: 1;
+}
+.framework-card-desc {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin: 0;
+}
+.framework-card-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: auto;
+    padding-top: 8px;
+    border-top: 1px solid var(--border);
+}
+.badge {
+    font-size: 0.7rem;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-weight: 500;
+}
+.badge-warn  { background: rgba(251,191,36,.15); color: #fbbf24; }
+.badge-info  { background: rgba(99,102,241,.15); color: #818cf8; }
+.badge-muted { background: rgba(255,255,255,.05); color: var(--text-muted); }
+
+/* Nightly toolbar */
+.nightly-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+}
 .audit-header { color: var(--accent); font-weight: 700; }

--- a/ops-server/dashboard/templates/index.html
+++ b/ops-server/dashboard/templates/index.html
@@ -48,6 +48,7 @@
             <button class="tab" data-view="sync">Synchronizer</button>
             <button class="tab" data-view="agentic">Agentic</button>
             <button class="tab" data-view="workers">Workers</button>
+            <button class="tab" data-view="framework">Framework</button>
             <button class="tab" data-view="nightly">Nightly</button>
         </div>
     </nav>
@@ -573,7 +574,20 @@
 
         <!-- Nightly View -->
         <section id="view-nightly" class="view">
-            <div id="nightly-summary" class="nightly-header"></div>
+            <div class="nightly-toolbar">
+                <div id="nightly-summary" class="nightly-header" style="flex:1;margin-bottom:0;"></div>
+                <div style="display:flex;gap:8px;align-items:center;flex-shrink:0">
+                    <select id="nightly-run-select" title="Select nightly run">
+                        <option value="latest">Latest run</option>
+                    </select>
+                    <select id="nightly-status-filter" title="Filter by status">
+                        <option value="all">All</option>
+                        <option value="passed">Passed</option>
+                        <option value="failed">Failed</option>
+                    </select>
+                    <button class="btn btn-small" id="nightly-trigger-framework" data-action title="Trigger engine + app tests on AMD64">⚡ Framework Tests</button>
+                </div>
+            </div>
             <table id="nightly-table">
                 <thead>
                     <tr>
@@ -587,6 +601,39 @@
                 </thead>
                 <tbody id="nightly-body">
                     <tr><td colspan="6" class="loading">Loading nightly results…</td></tr>
+                </tbody>
+            </table>
+        </section>
+
+        <!-- Framework Tests View -->
+        <section id="view-framework" class="view">
+            <div class="framework-toolbar">
+                <div>
+                    <h2 style="margin:0;font-size:1rem;font-weight:600">Framework Tests</h2>
+                    <p style="margin:2px 0 0;font-size:0.8rem;color:var(--text-muted)">Test the framework itself: unit tests, cluster engines, app exposure, Dynatrace components</p>
+                </div>
+                <div style="display:flex;gap:8px;align-items:center">
+                    <input type="text" id="framework-ref" value="feature/k3d-default-kind-cnfs" style="width:240px" placeholder="Branch or ref">
+                    <button class="btn btn-small" id="framework-run-all" data-action>▶ Run All</button>
+                </div>
+            </div>
+            <div id="framework-suite-grid" class="framework-suite-grid">
+                <p class="loading">Loading suites…</p>
+            </div>
+            <h3 style="margin:24px 0 8px">Recent Framework Runs</h3>
+            <table id="framework-runs-table">
+                <thead>
+                    <tr>
+                        <th>Timestamp</th>
+                        <th>Suite</th>
+                        <th>Arch</th>
+                        <th>Result</th>
+                        <th>Duration</th>
+                        <th>Log</th>
+                    </tr>
+                </thead>
+                <tbody id="framework-runs-body">
+                    <tr><td colspan="6" class="loading">—</td></tr>
                 </tbody>
             </table>
         </section>

--- a/ops-server/nginx/ops-server.conf
+++ b/ops-server/nginx/ops-server.conf
@@ -221,6 +221,20 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    location ~ ^/api/framework/ {
+        auth_request /oauth2/auth;
+        error_page 401 = @json_unauthorized;
+        auth_request_set $user  $upstream_http_x_auth_request_user;
+        auth_request_set $email $upstream_http_x_auth_request_email;
+        proxy_set_header X-Auth-User  $user;
+        proxy_set_header X-Auth-Email $email;
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location @json_unauthorized {
         default_type application/json;
         return 401 '{"error":"unauthorized","sign_in":"/oauth2/sign_in"}';

--- a/ops-server/worker-agent/agent.py
+++ b/ops-server/worker-agent/agent.py
@@ -219,11 +219,12 @@ class WorkerAgent:
                 _, job_json = result
                 job = json.loads(job_json)
                 import uuid
-                job_id = (
-                    f"{WORKER_ID}-{job['repo'].split('/')[-1]}"
-                    f"-{int(time.time() * 1000)}-{uuid.uuid4().hex[:6]}"
-                )
-                job["job_id"] = job_id
+                # Honor a pre-set job_id (e.g. from Arena provision); otherwise generate one.
+                if not job.get("job_id"):
+                    job["job_id"] = (
+                        f"{WORKER_ID}-{job['repo'].split('/')[-1]}"
+                        f"-{int(time.time() * 1000)}-{uuid.uuid4().hex[:6]}"
+                    )
                 job["worker_id"] = WORKER_ID
                 job["worker_arch"] = WORKER_ARCH
 
@@ -246,32 +247,36 @@ class WorkerAgent:
             self.active_jobs[job_id] = job
             log.info("Starting: %s (%s)", job_id, job["repo"])
 
-            # Pickup-time concurrency lock per (repo, branch, arch). If held,
-            # defer this job; the holder drains the deferred list on completion.
             arch = job.get("arch", WORKER_ARCH)
             triple = _triple_of(job, WORKER_ARCH)
-            lock_key = f"running:lock:{triple}"
-            acquired = await self.pool.set(
-                lock_key, job_id, nx=True, ex=LOCK_TTL_SECONDS
-            )
-            if not acquired:
-                log.info("Lock held for %s — deferring job %s", triple, job_id)
-                await self.pool.rpush(f"deferred:{triple}", json.dumps(job))
-                self.active_jobs.pop(job_id, None)
-                return
+            lock_key = None
+
+            # Concurrency lock: integration-tests only. Daemon jobs (training sessions)
+            # are allowed to run concurrently for the same repo — each user gets their own container.
+            if job.get("type") != "daemon":
+                lock_key = f"running:lock:{triple}"
+                acquired = await self.pool.set(
+                    lock_key, job_id, nx=True, ex=LOCK_TTL_SECONDS
+                )
+                if not acquired:
+                    log.info("Lock held for %s — deferring job %s", triple, job_id)
+                    await self.pool.rpush(f"deferred:{triple}", json.dumps(job))
+                    self.active_jobs.pop(job_id, None)
+                    return
 
             running_key = f"job:running:{job_id}"
             await self.pool.hset(running_key, mapping={
-                "job_id": job_id,
-                "repo": job["repo"],
-                "branch": _branch_of(job),
-                "arch": arch,
-                "ref": _branch_of(job),
+                "job_id":     job_id,
+                "repo":       job["repo"],
+                "branch":     _branch_of(job),
+                "arch":       arch,
+                "ref":        _branch_of(job),
                 "started_at": datetime.now(timezone.utc).isoformat(),
-                "worker_id": WORKER_ID,
-                "type": job.get("type", "integration-test"),
+                "worker_id":  WORKER_ID,
+                "type":       job.get("type", "integration-test"),
             })
-            await self.pool.expire(running_key, LOCK_TTL_SECONDS)
+            ttl = 86400 if job.get("type") == "daemon" else LOCK_TTL_SECONDS
+            await self.pool.expire(running_key, ttl)
 
             try:
                 if job.get("type") == "daemon":
@@ -295,7 +300,8 @@ class WorkerAgent:
                 await self.pool.rpush("jobs:completed", json.dumps(job))
                 await self.pool.ltrim("jobs:completed", -500, -1)
                 await self.pool.delete(running_key)
-                await self.pool.delete(lock_key)
+                if lock_key:
+                    await self.pool.delete(lock_key)
                 # Drain anything deferred for this triple back into the queue.
                 deferred_key = f"deferred:{triple}"
                 while True:

--- a/ops-server/worker-agent/executor.py
+++ b/ops-server/worker-agent/executor.py
@@ -115,6 +115,23 @@ async def execute_integration_test(job: dict, redis_pool=None) -> dict:
     app_port: int | None = None
 
     try:
+        # Initialize livelog immediately so the dashboard shows setup progress
+        # instead of a 404 during the ~10-minute Sysbox setup phase.
+        livelog_key = f"job:livelog:{job_id}" if redis_pool is not None else None
+        if livelog_key:
+            await redis_pool.set(
+                livelog_key,
+                f"=== JOB: {job_id} ===\n"
+                f"=== REPO: {head_repo}@{ref} | ARCH: {WORKER_ARCH} ===\n"
+                f"\n[setup] Starting Sysbox container...\n",
+                ex=3600,
+            )
+
+        async def _setup_log(msg: str) -> None:
+            if livelog_key and redis_pool is not None:
+                ts = time.strftime("%H:%M:%S", time.gmtime())
+                await redis_pool.append(livelog_key, f"[{ts}] [setup] {msg}\n")
+
         # 1. Start outer Sysbox container running docker:25-dind
         app_port = await _alloc_app_port(redis_pool)
         run_cmd = [
@@ -139,9 +156,11 @@ async def execute_integration_test(job: dict, redis_pool=None) -> dict:
         if app_port and redis_pool:
             await redis_pool.hset(f"job:running:{job_id}", "app_proxy_port", str(app_port))
 
+        await _setup_log("Sysbox container started — waiting for inner Docker daemon...")
         # 2. Wait for the Sysbox's inner dockerd to be ready
         await _wait_for_inner_docker(sb_name)
 
+        await _setup_log("Inner Docker ready — loading test image into Sysbox...")
         # 3. Inject dt-enablement into the inner Sysbox dockerd.
         #    Pull once to the outer daemon (cached on host); then stream
         #    save→load so we never hit Docker Hub rate limits per container.
@@ -150,6 +169,7 @@ async def execute_integration_test(job: dict, redis_pool=None) -> dict:
             stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
         )
         if await outer_inspect.wait() != 0:
+            await _setup_log("Pulling test image from registry (first run — cached after this)...")
             outer_pull = await asyncio.create_subprocess_exec(
                 "docker", "pull", TEST_IMAGE,
                 stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
@@ -174,6 +194,7 @@ async def execute_integration_test(job: dict, redis_pool=None) -> dict:
         finally:
             await asyncio.gather(save_proc.wait(), load_proc.wait())
 
+        await _setup_log("Test image loaded — starting test container...")
         # 4. Start the inner dt-enablement container (bind-mount workspace
         #    from the Sysbox's view, mount the inner docker.sock so k3d can
         #    operate inside the Sysbox).
@@ -201,12 +222,14 @@ async def execute_integration_test(job: dict, redis_pool=None) -> dict:
             rc = proc.returncode
             raise RuntimeError("inner container start failed")
 
+        await _setup_log("Container started — waiting for docker group membership...")
         # 5. Wait for vscode (inside dt) to have docker access. The dt-enablement
         #    entrypoint adds vscode to the docker group asynchronously after
         #    `docker run -d` returns; if we exec before that finishes, k3d
         #    fails with EACCES on docker.sock.
         await _wait_for_inner_dt_ready(sb_name, inner_name)
 
+        await _setup_log("Environment ready — starting test steps")
         # 6. Run each step via nested docker exec, streaming output to Redis.
         custom_script = job.get("test_script") or "zsh .devcontainer/test/integration.sh"
         test_label = f"frameworkTest:{job['suite']}" if job.get("suite") else "integrationTest"
@@ -215,9 +238,6 @@ async def execute_integration_test(job: dict, redis_pool=None) -> dict:
             ("postStartCommand",  "./.devcontainer/post-start.sh"),
             (test_label,          custom_script),
         ]
-        livelog_key = f"job:livelog:{job_id}" if redis_pool is not None else None
-        if livelog_key:
-            await redis_pool.set(livelog_key, "", ex=3600)
 
         for label, script in steps:
             header = f"\n=== {label} ===\n"

--- a/ops-server/worker-agent/executor.py
+++ b/ops-server/worker-agent/executor.py
@@ -210,6 +210,11 @@ async def execute_integration_test(job: dict, redis_pool=None) -> dict:
             "-e", "GIT_CONFIG_COUNT=1",
             "-e", "GIT_CONFIG_KEY_0=safe.directory",
             "-e", "GIT_CONFIG_VALUE_0=*",
+            # Tell the framework it is running inside Orbital (Sysbox) so that
+            # detectRunEnvironment() returns "orbital" and guards like the Kind
+            # engine skip in integration_engines.sh fire correctly.
+            "-e", "ORBITAL_ENVIRONMENT=true",
+            "-e", f"ARCH={WORKER_ARCH}",
             TEST_IMAGE,
             "sleep", "infinity",
         ]
@@ -434,6 +439,8 @@ async def execute_daemon(job: dict, redis_pool=None) -> dict:
             "-e", "GIT_CONFIG_COUNT=1",
             "-e", "GIT_CONFIG_KEY_0=safe.directory",
             "-e", "GIT_CONFIG_VALUE_0=*",
+            "-e", "ORBITAL_ENVIRONMENT=true",
+            "-e", f"ARCH={WORKER_ARCH}",
             TEST_IMAGE, "sleep", "infinity",
         ]
         proc = await asyncio.create_subprocess_exec(

--- a/ops-server/worker-agent/executor.py
+++ b/ops-server/worker-agent/executor.py
@@ -208,10 +208,12 @@ async def execute_integration_test(job: dict, redis_pool=None) -> dict:
         await _wait_for_inner_dt_ready(sb_name, inner_name)
 
         # 6. Run each step via nested docker exec, streaming output to Redis.
+        custom_script = job.get("test_script") or "zsh .devcontainer/test/integration.sh"
+        test_label = f"frameworkTest:{job['suite']}" if job.get("suite") else "integrationTest"
         steps = [
             ("postCreateCommand", "./.devcontainer/post-create.sh"),
             ("postStartCommand",  "./.devcontainer/post-start.sh"),
-            ("integrationTest",   "zsh .devcontainer/test/integration.sh"),
+            (test_label,          custom_script),
         ]
         livelog_key = f"job:livelog:{job_id}" if redis_pool is not None else None
         if livelog_key:
@@ -302,6 +304,22 @@ async def execute_integration_test(job: dict, redis_pool=None) -> dict:
     # No host-level cleanup needed — Sysbox container teardown above already
     # took the inner dockerd, dt-enablement, and k3d cluster with it.
     shutil.rmtree(work_dir, ignore_errors=True)
+
+    # Persist result for framework suite cards
+    if redis_pool and job.get("framework_suite"):
+        suite = job["framework_suite"]
+        import json as _json
+        now = __import__("datetime").datetime.now(__import__("datetime").timezone.utc).isoformat()
+        log_tail = "".join(sections)[-4000:]
+        await redis_pool.hset(f"framework:suite:{suite}:last", mapping={
+            "job_id": job_id, "timestamp": now,
+            "exit_code": str(rc), "passed": "true" if rc == 0 else "false",
+            "duration_s": str(duration), "arch": WORKER_ARCH, "log_tail": log_tail,
+        })
+        run_entry = _json.dumps({"suite": suite, "job_id": job_id, "timestamp": now,
+                                  "passed": rc == 0, "arch": WORKER_ARCH, "duration_s": duration})
+        await redis_pool.lpush("framework:runs", run_entry)
+        await redis_pool.ltrim("framework:runs", 0, 99)
 
     return {
         "test": "integration",

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -1483,7 +1483,7 @@ class WorkerManager:
     async def _cleanup_clusters(self):
         """Wipe stale clusters / containers / kubeconfig (best-effort)."""
         cmds = [
-            ["bash", "-c", "k3d cluster list -o name 2>/dev/null | xargs -r -I{} k3d cluster delete {}"],
+            ["bash", "-c", "k3d cluster list -o json 2>/dev/null | python3 -c \"import sys,json; [print(c['name']) for c in json.load(sys.stdin)]\" 2>/dev/null | xargs -r k3d cluster delete 2>/dev/null || true"],
             ["bash", "-c", "kind get clusters 2>/dev/null | xargs -r -I{} kind delete cluster --name {}"],
             ["bash", "-c", "docker rm -f dt-enablement 2>/dev/null || true"],
             ["bash", "-c", "docker ps -aq --filter 'ancestor=rancher/k3s' | xargs -r docker rm -f 2>/dev/null || true"],

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -548,6 +548,9 @@ class WorkerManager:
         elif job_type == "daemon":
             return await self._run_daemon(job)
 
+        elif job_type == "framework-test":
+            return await self._run_framework_test(job)
+
         elif job_type == "deploy-ghpages":
             return await self._run_deploy_ghpages(job)
 
@@ -1224,6 +1227,227 @@ class WorkerManager:
             "failed_step": failed_step or "",
             "log_file": str(log_file),
         }
+
+    async def _run_framework_test(self, job: dict) -> dict:
+        """Run a framework test suite (bats on host, or Sysbox for engine/app tests)."""
+        suite = job.get("suite", "bats")
+        if suite == "bats":
+            return await self._run_framework_bats(job)
+        else:
+            return await self._run_framework_sysbox(job)
+
+    async def _run_framework_bats(self, job: dict) -> dict:
+        """Run bats unit tests directly on the ops server (no Sysbox needed)."""
+        import shutil
+        job_id   = job["job_id"]
+        ref      = job.get("ref", "main")
+        repo     = job.get("repo", "dynatrace-wwse/codespaces-framework")
+        repo_name = repo.split("/")[-1]
+        suite    = "bats"
+
+        work_dir = WORKDIR / job_id
+        repo_dir = work_dir / repo_name
+        if work_dir.exists():
+            shutil.rmtree(work_dir, ignore_errors=True)
+        work_dir.mkdir(parents=True, exist_ok=True)
+
+        log_file = LOGS_DIR / f"{job_id}.log"
+        livelog_key = f"job:livelog:{job_id}"
+        await self.pool.set(livelog_key, "", ex=3600)
+
+        log.info("Running framework bats for %s @ %s", repo, ref)
+        await self._git_clone(repo, ref, repo_dir)
+
+        start = time.time()
+        proc = await asyncio.create_subprocess_exec(
+            "bats", ".devcontainer/test/unit/", "--tap",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            cwd=str(repo_dir),
+        )
+        output = await self._stream_to_redis(proc, livelog_key, 300)
+        rc = proc.returncode or 0
+        duration = int(time.time() - start)
+
+        full_log = f"=== framework-bats @ {ref} ===\n{output}"
+        log_file.write_text(full_log)
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+        await self._save_framework_suite_result(suite, job_id, rc, duration, "arm64", output)
+        return {"suite": suite, "exit_code": rc, "passed": rc == 0, "duration_seconds": duration, "arch": "arm64"}
+
+    async def _run_framework_sysbox(self, job: dict) -> dict:
+        """Run engines/k3d-apps/dt-* test via Sysbox + dt-enablement (AMD64 path)."""
+        import shutil
+
+        suite     = job.get("suite", "engines")
+        script_map = {
+            "engines":   "bash .devcontainer/test/integration_engines.sh",
+            "k3d-apps":  "bash .devcontainer/test/integration_k3d_apps.sh",
+        }
+        test_script = script_map.get(suite)
+        if not test_script:
+            return {"error": f"Unsupported suite for Sysbox: {suite}"}
+
+        repo      = job.get("repo", "dynatrace-wwse/codespaces-framework")
+        ref       = job.get("ref", "main")
+        repo_name = repo.split("/")[-1]
+        job_id    = job["job_id"]
+        arch      = job.get("arch", "amd64")
+        log_file  = LOGS_DIR / f"{job_id}.log"
+
+        work_dir = WORKDIR / job_id
+        repo_dir = work_dir / repo_name
+        if work_dir.exists():
+            shutil.rmtree(work_dir, ignore_errors=True)
+        work_dir.mkdir(parents=True, exist_ok=True)
+
+        log.info("Cloning %s @ %s for framework-sysbox %s (%s)", repo, ref, suite, job_id)
+        await self._git_clone(repo, ref, repo_dir)
+        await self._make_world_writable(repo_dir)
+        self._write_env_file(repo_dir / ".devcontainer" / ".env", arch="arm64")
+
+        workspace  = f"/workspaces/{repo_name}"
+        env_file_inside = f"{workspace}/.devcontainer/.env"
+        sb_name    = f"sb-{job_id[-32:]}"
+        inner_name = "dt"
+
+        sections: list[str] = []
+        rc = 0
+        timed_out = False
+        failed_step = None
+        TEST_TIMEOUT = 1800
+        start_time = time.time()
+        deadline = start_time + TEST_TIMEOUT
+        livelog_key = f"job:livelog:{job_id}"
+        await self.pool.set(livelog_key, "", ex=3600)
+
+        try:
+            # 1. Sysbox outer container
+            run_cmd = [
+                "docker", "run", "-d", "--runtime=sysbox-runc",
+                "--name", sb_name,
+                "-v", f"{repo_dir}:{workspace}",
+                "docker:25-dind",
+            ]
+            proc = await asyncio.create_subprocess_exec(*run_cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+            _, err = await proc.communicate()
+            if proc.returncode != 0:
+                sections.append(f"=== sysbox docker run failed ===\n{err.decode(errors='replace')}")
+                rc = proc.returncode
+                raise RuntimeError("sysbox start failed")
+
+            # 2. Wait for inner dockerd
+            await self._wait_for_inner_docker(sb_name)
+
+            # 3. Load dt-enablement image
+            _DT_IMAGE = "shinojosa/dt-enablement:v1.2"
+            outer_inspect = await asyncio.create_subprocess_exec("docker", "image", "inspect", _DT_IMAGE, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL)
+            if await outer_inspect.wait() != 0:
+                outer_pull = await asyncio.create_subprocess_exec("docker", "pull", _DT_IMAGE, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL)
+                await outer_pull.wait()
+            save_proc = await asyncio.create_subprocess_exec("docker", "save", _DT_IMAGE, stdout=asyncio.subprocess.PIPE)
+            load_proc = await asyncio.create_subprocess_exec("docker", "exec", "-i", sb_name, "docker", "load", stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL)
+            try:
+                while True:
+                    chunk = await save_proc.stdout.read(65536)
+                    if not chunk: break
+                    load_proc.stdin.write(chunk)
+                load_proc.stdin.close()
+            finally:
+                await asyncio.gather(save_proc.wait(), load_proc.wait())
+
+            # 4. Start dt-enablement container
+            inner_run = [
+                "docker", "exec", sb_name,
+                "docker", "run", "-d",
+                "--init", "--privileged", "--network=host",
+                "--name", inner_name,
+                "--env-file", env_file_inside,
+                "-v", "/var/run/docker.sock:/var/run/docker.sock",
+                "-v", f"{workspace}:{workspace}",
+                "-w", workspace,
+                "-e", "GIT_CONFIG_COUNT=1", "-e", "GIT_CONFIG_KEY_0=safe.directory", "-e", "GIT_CONFIG_VALUE_0=*",
+                _DT_IMAGE, "sleep", "infinity",
+            ]
+            proc = await asyncio.create_subprocess_exec(*inner_run, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+            _, err = await proc.communicate()
+            if proc.returncode != 0:
+                sections.append(f"=== inner docker run failed ===\n{err.decode(errors='replace')}")
+                rc = proc.returncode
+                raise RuntimeError("inner container start failed")
+
+            # 5. Wait for dt readiness
+            await self._wait_for_inner_dt_ready(sb_name, inner_name)
+
+            # 6. Run post-create, post-start, then the framework test script
+            steps = [
+                ("postCreateCommand", "./.devcontainer/post-create.sh"),
+                ("postStartCommand",  "./.devcontainer/post-start.sh"),
+                (f"frameworkTest:{suite}", test_script),
+            ]
+            for label, script in steps:
+                header = f"\n=== {label} ===\n"
+                sections.append(header)
+                await self.pool.append(livelog_key, header)
+                remaining = max(60, int(deadline - time.time()))
+                exec_cmd = ["docker", "exec", sb_name, "docker", "exec", "-w", workspace, inner_name, "bash", "-lc", script]
+                try:
+                    proc = await asyncio.create_subprocess_exec(*exec_cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT)
+                    step_out = await self._stream_to_redis(proc, livelog_key, remaining)
+                    sections.append(step_out)
+                    if proc.returncode != 0:
+                        rc = proc.returncode
+                        failed_step = label
+                        msg = f"\n=== {label} exited rc={rc} — stopping ===\n"
+                        sections.append(msg)
+                        await self.pool.append(livelog_key, msg)
+                        break
+                except asyncio.TimeoutError:
+                    proc.kill()
+                    sections.append(f"\n=== {label} timed out ===\n")
+                    rc = 124
+                    timed_out = True
+                    break
+
+        except Exception as e:
+            sections.append(f"\n=== executor error: {e} ===\n")
+            if rc == 0:
+                rc = 1
+        finally:
+            try:
+                kill_proc = await asyncio.create_subprocess_exec("docker", "rm", "-f", sb_name, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL)
+                await asyncio.wait_for(kill_proc.wait(), timeout=60)
+            except Exception:
+                pass
+
+        duration = int(time.time() - start_time)
+        full_log = f"=== framework-sysbox:{suite} @ {ref} ===\n" + "".join(sections)
+        log_file.write_text(self._mask_secrets(full_log))
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+        await self._save_framework_suite_result(suite, job_id, rc, duration, arch, "".join(sections))
+        return {"suite": suite, "exit_code": rc, "passed": rc == 0, "duration_seconds": duration, "arch": arch, "timed_out": timed_out}
+
+    async def _save_framework_suite_result(self, suite: str, job_id: str, rc: int, duration: int, arch: str, log_text: str):
+        """Store last result for a framework suite in Redis."""
+        now = datetime.now(timezone.utc).isoformat()
+        await self.pool.hset(f"framework:suite:{suite}:last", mapping={
+            "job_id": job_id,
+            "timestamp": now,
+            "exit_code": str(rc),
+            "passed": "true" if rc == 0 else "false",
+            "duration_s": str(duration),
+            "arch": arch,
+            "log_tail": log_text[-4000:],
+        })
+        run_entry = json.dumps({
+            "suite": suite, "job_id": job_id,
+            "timestamp": now, "passed": rc == 0,
+            "arch": arch, "duration_s": duration,
+        })
+        await self.pool.lpush("framework:runs", run_entry)
+        await self.pool.ltrim("framework:runs", 0, 99)
 
     async def _stream_agent_to_redis(self, proc, livelog_key: str, timeout_s: int) -> str:
         """Parse stream-json claude output, extract text events, append token summary."""

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -1455,6 +1455,7 @@ class WorkerManager:
             f"K3D_LB_HTTPS_PORT=30443\n"
             f"K3D_API_PORT=6444\n"
             f"EXTERNAL_HOSTNAME={external_hostname}\n"
+            f"ORBITAL_ENVIRONMENT=true\n"
         )
 
     async def _git_clone(self, repo: str, ref: str, dest: Path):


### PR DESCRIPTION
## Summary

- **k3d is now the default cluster engine** — `startK3dCluster` replaces `startKindCluster` in all labs that don't require Cloud Native FullStack (OneAgent DaemonSet / host monitoring). k3d is lighter, faster, and works identically for application-level observability.
- **Kind reserved for CNFS labs** — `bug-busters`, `enablement-live-debugger-bug-hunting`, and `demo-astroshop-runtime-optimization` keep Kind because their docs explicitly require FullStack mode.
- **Orbital environment detection** — new `detectRunEnvironment()` function in `functions.sh` returns `"orbital"`, `"codespaces"`, or `"local"`. Detected via `ORBITAL_ENVIRONMENT=true` env var (set by worker manager) or `K3D_CLUSTER_NAME=master-*` pattern.
- **Tracker payload updated** — `postCodespaceTracker` now sends `run.environment` field so The Hub can distinguish Orbital vs Codespaces vs local sessions.
- **Orbital warnings** — `startKindCluster` and `deployCloudNative` both warn explicitly when running on Orbital (Sysbox) that OneAgent DaemonSet will fail; code injection via CSI still works.
- **Kind node v1.32.11** — upgraded from v1.30.0, pinned with SHA256 digest for reproducibility.
- **Framework version 1.3.2** — `source_framework.sh` default bumped from 1.3.0 → 1.3.2.
- **New integration test** — `integration_k3d_apps.sh` (AMD64-only): starts k3d, deploys todoapp / astroshop / astronomy-shop / aitraveladvisor, asserts ingress exposure for each.
- **`integration_engines.sh` updated** — Kind test is now AMD64-gated.

## Consumer repo changes (branches, no PRs)

| Repo | Branch | Change |
|------|--------|--------|
| ace-integration | `fix/k3d-default` | `startKindCluster` → `startK3dCluster` |
| demo-opentelemetry | `fix/k3d-default` | `startKindCluster` → `startK3dCluster` |
| enablement-codespaces-template | `fix/k3d-default` | `startKindCluster` → `startK3dCluster` |
| enablement-dynatrace-log-ingest-101 | `fix/k3d-default` | `startKindCluster` → `startK3dCluster` |
| enablement-gen-ai-llm-observability | `fix/k3d-default` | `startKindCluster` → `startK3dCluster` |
| enablement-kubernetes-opentelemetry-openpipeline | `fix/k3d-default` | `startKindCluster` → `startK3dCluster` |
| enablement-kubernetes-opentelemetry | `fix/k3d-default` | `startKindCluster` → `startK3dCluster` |
| remote-environment | `fix/k3d-default` | `startKindCluster` → `startK3dCluster` |
| workshop-dynatrace-log-analytics | `fix/k3d-default` | `startKindCluster` → `startK3dCluster` |
| enablement-business-observability | `fix/k3d-app-monitoring` | Kind → k3d + `deployCloudNative` → `deployApplicationMonitoring` (BizEvents work with CSI injection) |

## Labs that keep Kind

| Repo | Reason |
|------|--------|
| bug-busters | Docs require FullStack mode for Live Debugger |
| enablement-live-debugger-bug-hunting | Docs require FullStack mode for Live Debugger |
| demo-astroshop-runtime-optimization | Host-level runtime metrics need OneAgent DaemonSet |

## Test plan

- [ ] Run `integration_engines.sh` on AMD64 Orbital worker — both Kind and k3d should pass
- [ ] Run `integration_k3d_apps.sh` on AMD64 Orbital worker — all apps should deploy and be reachable
- [ ] Trigger `enablement-dynatrace-log-ingest-101` job on Orbital to confirm k3d works
- [ ] Confirm `run.environment: orbital` appears in tracker payload after a job run
- [ ] Confirm `run.environment: codespaces` appears after a real Codespace launch
- [ ] Check `kind-cluster.yml` still works for bug-busters on AMD64

🤖 Generated with [Claude Code](https://claude.com/claude-code)