### PR TITLE
fix(kind): disable UserNamespacesSupport to fix FailedCreatePodSandBox in DinD + Astroshop test

### DIFF
--- a/.devcontainer/test/integration_kind_astroshop.sh
+++ b/.devcontainer/test/integration_kind_astroshop.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Kind + Astroshop integration test.
+#
+# Starts a Kind cluster, deploys Astroshop, and validates that:
+#   - The frontend is reachable via nginx ingress
+#   - The root path serves valid HTML with expected shop content
+#   - Static assets (images, CSS, JS) load with HTTP 200/304
+#
+# Guards:
+#   - AMD64 only: Astroshop images are x86 only
+#   - Skipped on Orbital/Sysbox: pod nesting depth exceeds what Sysbox can virtualise
+#
+# Run: bash .devcontainer/test/integration_kind_astroshop.sh
+source .devcontainer/util/source_framework.sh
+
+if [[ "$ARCH" != "x86_64" ]]; then
+  printWarn "Skipping — Astroshop is AMD64 only (arch: $ARCH)"
+  exit 0
+fi
+
+_run_env=$(detectRunEnvironment)
+if [[ "$_run_env" == "orbital" ]]; then
+  printWarn "Skipping — Kind pods stuck ContainerCreating on Orbital/Sysbox"
+  printWarn "Use integration_k3d_apps.sh for Astroshop testing on Orbital"
+  exit 0
+fi
+
+# Remove any pre-existing kind clusters so port bindings don't conflict
+printInfo "Pre-test cleanup: removing existing Kind clusters..."
+kind get clusters 2>/dev/null | xargs -r -I{} kind delete cluster --name {} 2>/dev/null || true
+
+# -------------------------------------------------------------------
+printInfoSection "1/4  Starting Kind cluster"
+export CLUSTER_ENGINE=kind
+startKindCluster
+
+# -------------------------------------------------------------------
+printInfoSection "2/4  Deploying Astroshop"
+deployAstroshop
+
+# -------------------------------------------------------------------
+printInfoSection "3/4  Asserting ingress reachability"
+assertRunningApp astroshop
+
+# -------------------------------------------------------------------
+printInfoSection "4/4  Asserting HTML and static asset content"
+assertAstroshopContent
+
+# -------------------------------------------------------------------
+printInfoSection "Cleaning up Kind cluster"
+deleteKindCluster
+
+printInfoSection "✅  Astroshop on Kind: HTML and assets validated"

--- a/.devcontainer/test/test_functions.sh
+++ b/.devcontainer/test/test_functions.sh
@@ -198,6 +198,85 @@ assertAppDeployed(){
   printInfo "✅ App '$app_name' fully deployed and accessible"
 }
 
+assertAstroshopContent() {
+  # Validates the Astroshop frontend:
+  #   1. Root path returns valid HTML
+  #   2. Page contains expected shop-related keywords
+  #   3. At least one static asset (img/css/js) loads with HTTP 200/304
+  # Call after assertRunningApp confirms the ingress is up.
+  local app_name="astroshop"
+  local detected_ip port ip_host
+  detected_ip=$(detectIP)
+  port="${K3D_LB_HTTP_PORT:-80}"
+  ip_host="${app_name}.${detected_ip}.${MAGIC_DOMAIN}"
+  local target="http://localhost:${port}"
+
+  printInfoSection "Asserting Astroshop HTML + assets via ${target} (Host: ${ip_host})"
+
+  # Fetch main page with retries — Next.js SSR can be slow on first hit
+  local html i
+  for i in $(seq 1 8); do
+    html=$(curl --silent --fail --max-time 20 -L -H "Host: ${ip_host}" "${target}/" 2>/dev/null)
+    [[ -n "$html" ]] && break
+    printInfo "Attempt ${i}/8 — page not ready, waiting 5s..."
+    sleep 5
+  done
+
+  if [[ -z "$html" ]]; then
+    printError "❌ Astroshop root page returned empty response after 8 attempts"
+    exit 1
+  fi
+
+  # 1. Valid HTML structure
+  if echo "$html" | grep -qi '<html'; then
+    printInfo "✅ Root page returns valid HTML document"
+  else
+    printError "❌ Root page missing <html> tag"
+    printError "First 300 chars: ${html:0:300}"
+    exit 1
+  fi
+
+  # 2. Expected shop content keywords
+  if echo "$html" | grep -qiE 'astro|opentelemetry|shop|telescope|astronomy|cart|product'; then
+    printInfo "✅ Root page contains expected shop content"
+  else
+    printWarn "⚠️  Root page does not match expected shop keywords (may be a proxy/loading page)"
+    printWarn "Page excerpt: $(echo "$html" | head -3)"
+  fi
+
+  # 3. Static asset reachability — extract src/href pointing to relative asset paths
+  local assets asset_url status ok=0 fail=0
+  assets=$(echo "$html" | \
+    grep -oiE '(src|href)="(/[^"]+\.(png|jpg|jpeg|gif|webp|svg|css|js|woff2?))"' | \
+    grep -oE '"[^"]+"' | tr -d '"' | sort -u | head -10)
+
+  if [[ -z "$assets" ]]; then
+    printWarn "No static asset URLs found in HTML — skipping asset HTTP checks"
+  else
+    while IFS= read -r asset_url; do
+      status=$(curl --silent --output /dev/null \
+        --write-out "%{http_code}" \
+        --max-time 10 \
+        -H "Host: ${ip_host}" \
+        "${target}${asset_url}" 2>/dev/null)
+      if [[ "$status" =~ ^(200|304)$ ]]; then
+        printInfo "✅ ${asset_url} → HTTP ${status}"
+        ok=$((ok + 1))
+      else
+        printWarn "⚠️  ${asset_url} → HTTP ${status}"
+        fail=$((fail + 1))
+      fi
+    done <<< "$assets"
+
+    if [[ "$ok" -gt 0 ]]; then
+      printInfo "✅ ${ok} asset(s) loaded successfully (${fail} unexpected)"
+    else
+      printError "❌ No static assets loaded — checked ${fail} URLs, all failed"
+      exit 1
+    fi
+  fi
+}
+
 assertEnvVariable(){
   # Assert an environment variable is set and optionally matches a pattern
   # Usage: assertEnvVariable <var-name> [pattern]

--- a/.devcontainer/yaml/kind/kind-cluster.yml
+++ b/.devcontainer/yaml/kind/kind-cluster.yml
@@ -29,7 +29,7 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         node-labels: "ingress-ready=true"
-  # 
+  #
   # Start cleaning unused images when disk usage exceeds 85%
   # Stop cleaning once it drops below 80%
   # Remove any unused image older than 7 days regardless of disk pressure
@@ -38,6 +38,22 @@ nodes:
     imageGCHighThresholdPercent: 85
     imageGCLowThresholdPercent: 80
     imageMaximumGCAge: 168h
+    # K8s 1.31+ enables UserNamespacesSupport (beta) by default.
+    # Kubelet writes net.ipv4.ip_unprivileged_port_start per pod sandbox via
+    # runc openat2(RESOLVE_NO_XDEV). In Docker-in-Docker (Codespace devcontainers)
+    # /proc/sys is a bind mount on a different device → EXDEV → FailedCreatePodSandBox.
+    # Disable the feature to suppress the sysctl write. Also skip kernel-default
+    # enforcement so kubelet doesn't fight read-only procfs at node startup.
+    protectKernelDefaults: false
+    featureGates:
+      UserNamespacesSupport: false
+  # Propagate the feature gate to the API server so it doesn't advertise
+  # user-namespace fields that the kubelet won't honour.
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        feature-gates: "UserNamespacesSupport=false"
   extraMounts:
   - hostPath: /
     containerPath: /mnt/root

--- a/ops-server/monitoring/dashboards/cicd.json
+++ b/ops-server/monitoring/dashboards/cicd.json
@@ -8,22 +8,23 @@
     "tiles": {
       "0": {
         "type": "markdown",
-        "content": "## CI/CD & Orbital\nIntegration test runs from Orbital workers and GitHub Actions. Pass/fail by repo, arch, and run type.\n\n**Types:** `local-docker-container` = Orbital | `github-workflow` = GitHub Actions"
+        "content": "# CI/CD & Orbital\n\nIntegration test runs from Orbital (local-docker-container) and GitHub Actions (github-workflow) across all [dynatrace-wwse](https://github.com/dynatrace-wwse) enablement repos.\n\n[← Overview](https://geu80787.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/27ea9191-533f-4911-89ae-ef96fe63c7ef) · [Instantiations →](https://geu80787.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/48b50182-c097-47a3-b864-1b72eb234946)"
       },
       "1": {
-        "title": "Total CI Runs (7d)",
+        "title": "Total CI Runs",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter in(`content.codespace.type`, \"local-docker-container\", \"github-workflow\")\n| summarize total = count()",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter in(content.codespace.type, \"local-docker-container\", \"github-workflow\")\n| summarize total = count()",
         "visualization": "singleValue",
         "visualizationSettings": {
           "singleValue": { "label": "CI Runs", "prefixIcon": "PipelineIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "2": {
-        "title": "Pass Rate (7d)",
+        "title": "Pass Rate %",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter in(`content.codespace.type`, \"local-docker-container\", \"github-workflow\")\n| summarize total = count(), passed = countIf(`content.codespace.errors` == \"0\")\n| fieldsAdd passRate = round(toDouble(passed) / toDouble(total) * 100, decimals: 1)\n| fields passRate",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter in(content.codespace.type, \"local-docker-container\", \"github-workflow\")\n| summarize total = count(), passed = countIf(content.codespace.errors == \"0\")\n| fieldsAdd passRate = round(toDouble(passed) / toDouble(total) * 100, decimals: 1)\n| fields passRate",
         "visualization": "singleValue",
         "visualizationSettings": {
           "singleValue": { "label": "Pass Rate %", "prefixIcon": "CheckmarkIcon", "showLabel": true },
@@ -33,75 +34,144 @@
             { "color": "#4fd5e0", "value": 90 }
           ]
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "3": {
-        "title": "Orbital Runs (7d)",
+        "title": "Orbital Runs",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter `content.codespace.type` == \"local-docker-container\"\n| summarize total = count()",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter content.codespace.type == \"local-docker-container\"\n| summarize total = count()",
         "visualization": "singleValue",
         "visualizationSettings": {
-          "singleValue": { "label": "Orbital", "prefixIcon": "ServerIcon", "showLabel": true }
+          "singleValue": { "label": "Orbital (local)", "prefixIcon": "ServerIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "4": {
-        "title": "GitHub Actions Runs (7d)",
+        "title": "GitHub Actions Runs",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter `content.codespace.type` == \"github-workflow\"\n| summarize total = count()",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter content.codespace.type == \"github-workflow\"\n| summarize total = count()",
         "visualization": "singleValue",
         "visualizationSettings": {
           "singleValue": { "label": "GH Actions", "prefixIcon": "GitHubIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "5": {
-        "title": "Avg Build Duration (minutes)",
+        "title": "Failed Runs",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter in(`content.codespace.type`, \"local-docker-container\", \"github-workflow\")\n| filter isNotNull(`content.codespace.creation`)\n| summarize avgSec = avg(toLong(`content.codespace.creation`))\n| fieldsAdd avgMin = round(toDouble(avgSec) / 60, decimals: 1)\n| fields avgMin",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter in(content.codespace.type, \"local-docker-container\", \"github-workflow\")\n| summarize failed = countIf(content.codespace.errors != \"0\")",
         "visualization": "singleValue",
         "visualizationSettings": {
-          "singleValue": { "label": "Avg Minutes", "prefixIcon": "ClockIcon", "showLabel": true }
+          "singleValue": { "label": "Failures", "prefixIcon": "WarningIcon", "showLabel": true },
+          "thresholds": [
+            { "color": "#4fd5e0", "value": 0 },
+            { "color": "#f5d565", "value": 5 },
+            { "color": "#ec6868", "value": 20 }
+          ]
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "6": {
-        "title": "CI Results by Repository",
+        "title": "CI Runs Over Time",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter in(`content.codespace.type`, \"local-docker-container\", \"github-workflow\")\n| summarize passed = countIf(`content.codespace.errors` == \"0\"), failed = countIf(`content.codespace.errors` != \"0\"), by:{`content.repository.name`}\n| sort passed + failed desc\n| limit 20",
-        "visualization": "barChart",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter in(content.codespace.type, \"local-docker-container\", \"github-workflow\")\n| makeTimeseries count = count(), by: { content.codespace.type }, interval: 1d",
+        "visualization": "areaChart",
         "visualizationSettings": {
-          "barChart": { "categoryAxis": { "fieldName": "content.repository.name" }, "valueAxes": [{ "fieldName": "passed" }, { "fieldName": "failed" }] }
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "7": {
-        "title": "CI Results Over Time (daily)",
+        "title": "Pass vs Fail Over Time",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter in(`content.codespace.type`, \"local-docker-container\", \"github-workflow\")\n| summarize passed = countIf(`content.codespace.errors` == \"0\"), failed = countIf(`content.codespace.errors` != \"0\"), by:{bin(timestamp, 1d)}",
-        "visualization": "lineChart",
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter in(content.codespace.type, \"local-docker-container\", \"github-workflow\")\n| makeTimeseries passed = countIf(content.codespace.errors == \"0\"), failed = countIf(content.codespace.errors != \"0\"), interval: 1d",
+        "visualization": "barChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "8": {
-        "title": "Runs by Architecture",
+        "title": "Runs by Repository",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter in(`content.codespace.type`, \"local-docker-container\", \"github-workflow\")\n| summarize count = count(), passed = countIf(`content.codespace.errors` == \"0\"), by:{`content.codespace.arch`}",
-        "visualization": "barChart",
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter in(content.codespace.type, \"local-docker-container\", \"github-workflow\")\n| summarize count = count(), by: { content.repository.name }\n| sort count desc\n| limit 25",
+        "visualization": "categoricalBarChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "9": {
-        "title": "Failed Runs — Details",
+        "title": "Run Type",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter in(`content.codespace.type`, \"local-docker-container\", \"github-workflow\")\n| filter `content.codespace.errors` != \"0\"\n| fields timestamp, `content.repository.name`, `content.codespace.type`, `content.codespace.arch`, `content.codespace.errors`, `content.codespace.creation`\n| sort timestamp desc\n| limit 50",
-        "visualization": "table",
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter in(content.codespace.type, \"local-docker-container\", \"github-workflow\")\n| summarize count = count(), by: { content.codespace.type }",
+        "visualization": "donutChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "10": {
-        "title": "Build Duration Distribution (seconds)",
+        "title": "Architecture",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter in(`content.codespace.type`, \"local-docker-container\", \"github-workflow\")\n| filter isNotNull(`content.codespace.creation`)\n| summarize avgDuration = avg(toLong(`content.codespace.creation`)), maxDuration = max(toLong(`content.codespace.creation`)), minDuration = min(toLong(`content.codespace.creation`)), by:{`content.repository.name`}\n| sort avgDuration desc\n| limit 20",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter in(content.codespace.type, \"local-docker-container\", \"github-workflow\")\n| summarize count = count(), by: { content.codespace.arch }",
+        "visualization": "donutChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
+      },
+      "11": {
+        "title": "Failures by Repository",
+        "type": "data",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter in(content.codespace.type, \"local-docker-container\", \"github-workflow\")\n| filter content.codespace.errors != \"0\"\n| summarize count = count(), by: { content.repository.name }\n| sort count desc\n| limit 20",
+        "visualization": "categoricalBarChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "red" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
+      },
+      "12": {
+        "title": "Failure Details",
+        "type": "data",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter in(content.codespace.type, \"local-docker-container\", \"github-workflow\")\n| filter content.codespace.errors != \"0\"\n| fields timestamp, content.repository.name, content.codespace.type, content.codespace.arch, content.codespace.errors\n| sort timestamp desc\n| limit 50",
         "visualization": "table",
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "visualizationSettings": {},
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
+      },
+      "13": {
+        "title": "Pass Rate by Repository",
+        "type": "data",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter in(content.codespace.type, \"local-docker-container\", \"github-workflow\")\n| summarize total = count(), passed = countIf(content.codespace.errors == \"0\"), failed = countIf(content.codespace.errors != \"0\"), by: { content.repository.name }\n| fieldsAdd passRate = round(toDouble(passed) / toDouble(total) * 100, decimals: 1)\n| sort total desc\n| limit 25",
+        "visualization": "table",
+        "visualizationSettings": {
+          "table": { "sortBy": [{ "columnId": "[\"total\"]", "direction": "descending" }] }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       }
     }
   }

--- a/ops-server/monitoring/dashboards/instantiations.json
+++ b/ops-server/monitoring/dashboards/instantiations.json
@@ -8,103 +8,210 @@
     "tiles": {
       "0": {
         "type": "markdown",
-        "content": "## Instantiations & Adoption\nAll codespace instantiation events — real users, Orbital CI, GitHub Actions CI, and local containers. Geo-located by IP."
+        "content": "# Instantiations & Adoption\n\nAll codespace instantiations across the [dynatrace-wwse](https://github.com/dynatrace-wwse) enablement framework — real users, CI runs, and global reach.\n\n[← CI/CD](https://geu80787.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/14e4b002-1b7d-4543-927b-cd0497ee8a2e) · [← Overview](https://geu80787.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/27ea9191-533f-4911-89ae-ef96fe63c7ef) · [GitHub Pages →](https://geu80787.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/a20a6def-bbb5-46da-a0c9-1b7e2566e4af)"
       },
       "1": {
-        "title": "Total Instantiations (7d)",
+        "title": "Total Instantiations",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| summarize total = count()",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| summarize total = count()",
         "visualization": "singleValue",
         "visualizationSettings": {
-          "singleValue": { "label": "Total", "prefixIcon": "ComputerIcon", "showLabel": true }
+          "singleValue": { "label": "Instantiations", "prefixIcon": "ComputerIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "2": {
-        "title": "Real User Codespaces (7d)",
+        "title": "Real User Codespaces",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter `content.codespace.type` == \"github-codespaces\"\n| summarize total = count()",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter content.codespace.type == \"github-codespaces\"\n| summarize total = count()",
         "visualization": "singleValue",
         "visualizationSettings": {
           "singleValue": { "label": "Real Users", "prefixIcon": "UserIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "3": {
-        "title": "Error Rate (7d)",
+        "title": "Error Rate %",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| summarize total = count(), errors = countIf(`content.codespace.errors` != \"0\" and isNotNull(`content.codespace.errors`))\n| fieldsAdd errorRate = round(toDouble(errors) / toDouble(total) * 100, decimals: 1)\n| fields errorRate",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| summarize total = count(), errors = countIf(content.codespace.errors != \"0\")\n| fieldsAdd errorRate = round(toDouble(errors) / toDouble(total) * 100, decimals: 1)\n| fields errorRate",
         "visualization": "singleValue",
         "visualizationSettings": {
           "singleValue": { "label": "Error Rate %", "prefixIcon": "WarningIcon", "showLabel": true },
           "thresholds": [
             { "color": "#4fd5e0", "value": 0 },
             { "color": "#f5d565", "value": 5 },
-            { "color": "#ec6868", "value": 15 }
+            { "color": "#ec6868", "value": 10 }
           ]
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "4": {
-        "title": "Active Repositories (7d)",
+        "title": "Active Repositories",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| summarize repos = countDistinct(`content.repository.name`)",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| summarize repos = countDistinct(content.repository.name)",
         "visualization": "singleValue",
         "visualizationSettings": {
-          "singleValue": { "label": "Repos", "prefixIcon": "FolderIcon", "showLabel": true }
+          "singleValue": { "label": "Repositories", "prefixIcon": "FolderIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "5": {
-        "title": "Instantiations by Type",
+        "title": "Countries Reached",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| summarize count = count(), by:{`content.codespace.type`}\n| sort count desc",
-        "visualization": "barChart",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter isNotNull(content.geo.country.name)\n| summarize countries = countDistinct(content.geo.country.name)",
+        "visualization": "singleValue",
         "visualizationSettings": {
-          "barChart": { "categoryAxis": { "fieldName": "content.codespace.type" }, "valueAxes": [{ "fieldName": "count" }] }
+          "singleValue": { "label": "Countries", "prefixIcon": "GlobeIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "6": {
-        "title": "Instantiations Over Time (by type)",
+        "title": "Instantiations Over Time",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| summarize count = count(), by:{bin(timestamp, 1d), `content.codespace.type`}",
-        "visualization": "lineChart",
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| makeTimeseries count = count(), by: { content.codespace.type }, interval: 1d",
+        "visualization": "areaChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "7": {
-        "title": "By Repository (top 20)",
+        "title": "City-Level Instantiations",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| summarize count = count(), errors = countIf(`content.codespace.errors` != \"0\" and isNotNull(`content.codespace.errors`)), by:{`content.repository.name`}\n| sort count desc\n| limit 20",
-        "visualization": "barChart",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter isNotNull(content.geo.latitude) and content.geo.latitude != 0\n| summarize count = count(), by: { content.geo.city.name, content.geo.latitude, content.geo.longitude }\n| fields content.geo.latitude, content.geo.longitude, count, content.geo.city.name",
+        "visualization": "bubbleMap",
         "visualizationSettings": {
-          "barChart": { "categoryAxis": { "fieldName": "content.repository.name" }, "valueAxes": [{ "fieldName": "count" }, { "fieldName": "errors" }] }
+          "mapView": { "defaultZoom": "world" },
+          "autoSelectVisualization": false
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "8": {
-        "title": "By Country (real user + GH Actions)",
+        "title": "Instantiations by Country",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter in(`content.codespace.type`, \"github-codespaces\", \"github-workflow\", \"local-docker-container\")\n| filter isNotNull(`content.geo.country.name`)\n| summarize count = count(), by:{`content.geo.country.name`, `content.geo.continent.name`}\n| sort count desc\n| limit 25",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter isNotNull(content.geo.country.name)\n| fieldsAdd countryCode = coalesce(content.geo.country.isoCode, if(content.geo.country.name == \"United States\", \"US\", else: if(content.geo.country.name == \"United Kingdom\", \"GB\", else: if(contains(content.geo.country.name, \"Netherlands\"), \"NL\", else: if(content.geo.country.name == \"Australia\", \"AU\", else: if(content.geo.country.name == \"New Zealand\", \"NZ\", else: if(content.geo.country.name == \"Singapore\", \"SG\", else: if(content.geo.country.name == \"Spain\", \"ES\", else: if(content.geo.country.name == \"Germany\", \"DE\", else: if(content.geo.country.name == \"France\", \"FR\", else: if(content.geo.country.name == \"India\", \"IN\", else: if(content.geo.country.name == \"Japan\", \"JP\", else: if(content.geo.country.name == \"Brazil\", \"BR\", else: if(content.geo.country.name == \"Canada\", \"CA\", else: \"XX\")))))))))))))\n| summarize count = count(), by: { countryCode }\n| fields countryCode, count",
         "visualization": "table",
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "visualizationSettings": {},
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "9": {
-        "title": "Real Codespace Instantiations — Location Detail",
+        "title": "By Repository",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter `content.codespace.type` == \"github-codespaces\"\n| fields timestamp, `content.repository.name`, `content.codespace.arch`, `content.codespace.creation`, `content.codespace.errors`, `content.geo.city.name`, `content.geo.country.name`, `content.geo.continent.name`\n| sort timestamp desc",
-        "visualization": "table",
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| summarize count = count(), by: { content.repository.name }\n| sort count desc\n| limit 25",
+        "visualization": "categoricalBarChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "10": {
-        "title": "Errors by Repository",
+        "title": "Instantiation Type",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter `content.codespace.errors` != \"0\"\n| filter isNotNull(`content.codespace.errors`)\n| summarize errors = count(), by:{`content.repository.name`, `content.codespace.type`}\n| sort errors desc\n| limit 20",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| summarize count = count(), by: { content.codespace.type }",
+        "visualization": "donutChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
+      },
+      "11": {
+        "title": "OS Architecture",
+        "type": "data",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| summarize count = count(), by: { content.codespace.arch }",
+        "visualization": "donutChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
+      },
+      "12": {
+        "title": "Top Countries",
+        "type": "data",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter isNotNull(content.geo.country.name)\n| summarize count = count(), by: { content.geo.country.name }\n| sort count desc\n| limit 15",
+        "visualization": "categoricalBarChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
+      },
+      "13": {
+        "title": "Errors Over Time",
+        "type": "data",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| makeTimeseries total = count(), errors = countIf(content.codespace.errors != \"0\"), interval: 1d",
         "visualization": "barChart",
         "visualizationSettings": {
-          "barChart": { "categoryAxis": { "fieldName": "content.repository.name" }, "valueAxes": [{ "fieldName": "errors" }] }
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "red" }]
+          }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
+      },
+      "14": {
+        "title": "Error Details",
+        "type": "data",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter content.codespace.errors != \"0\"\n| fields timestamp, content.repository.name, content.codespace.errors, content.codespace.type, content.geo.city.name, content.geo.country.name\n| sort timestamp desc\n| limit 30",
+        "visualization": "table",
+        "visualizationSettings": {},
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
+      },
+      "15": {
+        "title": "Dynatrace Tenants Used",
+        "type": "data",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter isNotNull(content.tenant) and content.tenant != \"\"\n| summarize count = count(), by: { content.tenant, content.codespace.type }\n| sort count desc\n| limit 30",
+        "visualization": "table",
+        "visualizationSettings": {
+          "table": { "sortBy": [{ "columnId": "[\"count\"]", "direction": "descending" }] }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
+      },
+      "16": {
+        "title": "Repos by Country",
+        "type": "data",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter isNotNull(content.geo.country.name)\n| summarize count = count(), by: { content.repository.name, content.geo.country.name }\n| sort count desc\n| limit 40",
+        "visualization": "table",
+        "visualizationSettings": {
+          "table": { "sortBy": [{ "columnId": "[\"count\"]", "direction": "descending" }] }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
+      },
+      "17": {
+        "title": "Instantiations by Repository Over Time",
+        "type": "data",
+        "query": "fetch bizevents\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| makeTimeseries count = count(), by: { content.repository.name }, interval: 1d\n| sort count desc\n| limit 10",
+        "visualization": "barChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       }
     }
   }

--- a/ops-server/monitoring/dashboards/overview.json
+++ b/ops-server/monitoring/dashboards/overview.json
@@ -15,138 +15,182 @@
         "content": "### CI/CD & Orbital\n[→ Full Dashboard](https://geu80787.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/14e4b002-1b7d-4543-927b-cd0497ee8a2e)"
       },
       "2": {
-        "title": "CI Runs (7d)",
+        "title": "CI Runs",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter in(`content.codespace.type`, \"local-docker-container\", \"github-workflow\")\n| summarize total = count()",
+        "query": "fetch bizevents, from:now()-7d\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter in(content.codespace.type, \"local-docker-container\", \"github-workflow\")\n| summarize total = count()",
         "visualization": "singleValue",
         "visualizationSettings": {
-          "singleValue": { "label": "CI Runs", "prefixIcon": "PipelineIcon", "showLabel": true }
+          "singleValue": { "label": "CI Runs (7d)", "prefixIcon": "PipelineIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "3": {
-        "title": "CI Pass Rate (7d)",
+        "title": "Pass Rate %",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter in(`content.codespace.type`, \"local-docker-container\", \"github-workflow\")\n| summarize total = count(), passed = countIf(`content.codespace.errors` == \"0\")\n| fieldsAdd passRate = round(toDouble(passed) / toDouble(total) * 100, decimals: 1)\n| fields passRate",
+        "query": "fetch bizevents, from:now()-7d\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter in(content.codespace.type, \"local-docker-container\", \"github-workflow\")\n| summarize total = count(), passed = countIf(content.codespace.errors == \"0\")\n| fieldsAdd passRate = round(toDouble(passed) / toDouble(total) * 100, decimals: 1)\n| fields passRate",
         "visualization": "singleValue",
         "visualizationSettings": {
-          "singleValue": { "label": "Pass Rate %", "prefixIcon": "CheckmarkIcon", "showLabel": true },
+          "singleValue": { "label": "Pass Rate % (7d)", "prefixIcon": "CheckmarkIcon", "showLabel": true },
           "thresholds": [
             { "color": "#ec6868", "value": 0 },
             { "color": "#f5d565", "value": 70 },
             { "color": "#4fd5e0", "value": 90 }
           ]
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "4": {
         "title": "CI Trend (7d)",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter in(`content.codespace.type`, \"local-docker-container\", \"github-workflow\")\n| summarize passed = countIf(`content.codespace.errors` == \"0\"), failed = countIf(`content.codespace.errors` != \"0\"), by:{bin(timestamp, 1d)}",
-        "visualization": "lineChart",
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "query": "fetch bizevents, from:now()-7d\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter in(content.codespace.type, \"local-docker-container\", \"github-workflow\")\n| makeTimeseries passed = countIf(content.codespace.errors == \"0\"), failed = countIf(content.codespace.errors != \"0\"), interval: 1d",
+        "visualization": "barChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "5": {
         "type": "markdown",
         "content": "### Instantiations & Adoption\n[→ Full Dashboard](https://geu80787.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/48b50182-c097-47a3-b864-1b72eb234946)"
       },
       "6": {
-        "title": "Total Instantiations (7d)",
+        "title": "Total Instantiations",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| summarize total = count()",
+        "query": "fetch bizevents, from:now()-7d\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| summarize total = count()",
         "visualization": "singleValue",
         "visualizationSettings": {
-          "singleValue": { "label": "Total", "prefixIcon": "ComputerIcon", "showLabel": true }
+          "singleValue": { "label": "Total (7d)", "prefixIcon": "ComputerIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "7": {
-        "title": "Real User Codespaces (7d)",
+        "title": "Real User Codespaces",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| filter `content.codespace.type` == \"github-codespaces\"\n| summarize total = count()",
+        "query": "fetch bizevents, from:now()-7d\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter content.codespace.type == \"github-codespaces\"\n| summarize total = count()",
         "visualization": "singleValue",
         "visualizationSettings": {
-          "singleValue": { "label": "Real Users", "prefixIcon": "UserIcon", "showLabel": true }
+          "singleValue": { "label": "Real Users (7d)", "prefixIcon": "UserIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "8": {
-        "title": "Instantiations by Type (7d)",
+        "title": "Countries Reached",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"codespacestracker.creation\"\n| summarize count = count(), by:{`content.codespace.type`}\n| sort count desc",
-        "visualization": "barChart",
+        "query": "fetch bizevents, from:now()-7d\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| filter isNotNull(content.geo.country.name)\n| summarize countries = countDistinct(content.geo.country.name)",
+        "visualization": "singleValue",
         "visualizationSettings": {
-          "barChart": { "categoryAxis": { "fieldName": "content.codespace.type" }, "valueAxes": [{ "fieldName": "count" }] }
+          "singleValue": { "label": "Countries (7d)", "prefixIcon": "GlobeIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "9": {
+        "title": "Instantiation Type (7d)",
+        "type": "data",
+        "query": "fetch bizevents, from:now()-7d\n| filter event.provider == \"com.dynatracewwse.codespacestracker\"\n| summarize count = count(), by: { content.codespace.type }",
+        "visualization": "donutChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
+      },
+      "10": {
         "type": "markdown",
         "content": "### GitHub Pages & RUM\n[→ Full Dashboard](https://geu80787.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/a20a6def-bbb5-46da-a0c9-1b7e2566e4af)"
       },
-      "10": {
-        "title": "Page Views (7d)",
-        "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"page_load\"\n| summarize total = count()",
-        "visualization": "singleValue",
-        "visualizationSettings": {
-          "singleValue": { "label": "Page Views", "prefixIcon": "EyeOpenIcon", "showLabel": true }
-        },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
-      },
       "11": {
-        "title": "Unique Sessions (7d)",
+        "title": "Page Views",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"page_load\"\n| summarize sessions = countDistinct(`dt.rum.session.id`)",
+        "query": "fetch bizevents, from:now()-7d\n| filter event.provider == \"dynatrace-wwse.github.io\"\n| summarize total = count()",
         "visualization": "singleValue",
         "visualizationSettings": {
-          "singleValue": { "label": "Sessions", "prefixIcon": "UserIcon", "showLabel": true }
+          "singleValue": { "label": "Page Views (7d)", "prefixIcon": "EyeOpenIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "12": {
-        "title": "Top Pages (7d)",
+        "title": "Unique Sessions",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"page_load\"\n| summarize views = count(), by:{page}\n| sort views desc\n| limit 15",
-        "visualization": "barChart",
+        "query": "fetch bizevents, from:now()-7d\n| filter event.provider == \"dynatrace-wwse.github.io\"\n| summarize sessions = countDistinct(dt.rum.session.id)",
+        "visualization": "singleValue",
         "visualizationSettings": {
-          "barChart": { "categoryAxis": { "fieldName": "page" }, "valueAxes": [{ "fieldName": "views" }] }
+          "singleValue": { "label": "Sessions (7d)", "prefixIcon": "UserIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "13": {
+        "title": "Page Views Over Time (7d)",
+        "type": "data",
+        "query": "fetch bizevents, from:now()-7d\n| filter event.provider == \"dynatrace-wwse.github.io\"\n| makeTimeseries views = count(), interval: 1d",
+        "visualization": "areaChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
+      },
+      "14": {
         "type": "markdown",
         "content": "### Orbital Fleet Health\nHost metrics from master (autonomous-enablements) and workers (ip-172-31-10-70, ip-172-31-9-59). Pushed every 60s via orbital-metrics.timer — no OneAgent."
       },
-      "14": {
+      "15": {
         "title": "CPU % — All Hosts",
         "type": "data",
         "query": "timeseries avg(`orbital.host.cpu.pct`), from:now()-1h, by:{host}",
         "visualization": "lineChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
         "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
       },
-      "15": {
+      "16": {
         "title": "Memory % — All Hosts",
         "type": "data",
         "query": "timeseries avg(`orbital.host.memory.used_pct`), from:now()-1h, by:{host}",
         "visualization": "lineChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
         "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
       },
-      "16": {
+      "17": {
         "title": "Disk % — All Hosts",
         "type": "data",
         "query": "timeseries avg(`orbital.host.disk.used_pct`), from:now()-1h, by:{host}",
         "visualization": "lineChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
         "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
       },
-      "17": {
+      "18": {
         "title": "Redis — Queue Depth & Active Jobs",
         "type": "data",
         "query": "timeseries amd64=avg(`orbital.redis.queue.amd64`), arm64=avg(`orbital.redis.queue.arm64`), active=avg(`orbital.redis.active_jobs`), from:now()-1h",
         "visualization": "lineChart",
         "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
       },
-      "18": {
+      "19": {
         "title": "Registered Workers",
         "type": "data",
         "query": "timeseries avg(`orbital.redis.workers`), from:now()-1h",

--- a/ops-server/monitoring/dashboards/rum.json
+++ b/ops-server/monitoring/dashboards/rum.json
@@ -8,98 +8,134 @@
     "tiles": {
       "0": {
         "type": "markdown",
-        "content": "## GitHub Pages & Real User Monitoring\nPage load BizEvents from all `dynatrace-wwse.github.io` documentation sites. App ID: `ff78563295ff1e42`."
+        "content": "# GitHub Pages & RUM\n\nDocumentation engagement across [dynatrace-wwse.github.io](https://dynatrace-wwse.github.io) — page views, sessions, and geographic reach.\n\n[← Instantiations](https://geu80787.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/48b50182-c097-47a3-b864-1b72eb234946) · [← Overview](https://geu80787.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/27ea9191-533f-4911-89ae-ef96fe63c7ef)"
       },
       "1": {
-        "title": "Page Views (7d)",
+        "title": "Page Views",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"page_load\"\n| summarize total = count()",
+        "query": "fetch bizevents\n| filter event.provider == \"dynatrace-wwse.github.io\"\n| summarize total = count()",
         "visualization": "singleValue",
         "visualizationSettings": {
           "singleValue": { "label": "Page Views", "prefixIcon": "EyeOpenIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "2": {
-        "title": "Unique Sessions (7d)",
+        "title": "Unique Sessions",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"page_load\"\n| summarize sessions = countDistinct(`dt.rum.session.id`)",
+        "query": "fetch bizevents\n| filter event.provider == \"dynatrace-wwse.github.io\"\n| summarize sessions = countDistinct(dt.rum.session.id)",
         "visualization": "singleValue",
         "visualizationSettings": {
           "singleValue": { "label": "Sessions", "prefixIcon": "UserIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "3": {
-        "title": "Countries Reached (7d)",
+        "title": "Countries",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"page_load\"\n| summarize countries = countDistinct(`geo.country.name`)",
+        "query": "fetch bizevents\n| filter event.provider == \"dynatrace-wwse.github.io\"\n| filter isNotNull(geo.country.name)\n| summarize countries = countDistinct(geo.country.name)",
         "visualization": "singleValue",
         "visualizationSettings": {
           "singleValue": { "label": "Countries", "prefixIcon": "GlobeIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "4": {
-        "title": "Docs Sites Active (7d)",
+        "title": "Documentation Sites",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"page_load\"\n| summarize sites = countDistinct(`event.provider`)",
+        "query": "fetch bizevents\n| filter event.provider == \"dynatrace-wwse.github.io\"\n| filter isNotNull(dt.rum.application.id)\n| summarize sites = countDistinct(dt.rum.application.id)",
         "visualization": "singleValue",
         "visualizationSettings": {
           "singleValue": { "label": "Sites", "prefixIcon": "FolderIcon", "showLabel": true }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "5": {
-        "title": "Page Views Over Time (daily)",
+        "title": "Page Views Over Time",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"page_load\"\n| summarize views = count(), by:{bin(timestamp, 1d)}",
-        "visualization": "lineChart",
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "query": "fetch bizevents\n| filter event.provider == \"dynatrace-wwse.github.io\"\n| makeTimeseries views = count(), interval: 1d",
+        "visualization": "areaChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "6": {
-        "title": "Top Pages",
+        "title": "Most Viewed Pages",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"page_load\"\n| summarize views = count(), by:{page}\n| sort views desc\n| limit 20",
-        "visualization": "barChart",
+        "query": "fetch bizevents\n| filter event.provider == \"dynatrace-wwse.github.io\"\n| filter isNotNull(page)\n| summarize views = count(), by: { page, dt.rum.application.id }\n| sort views desc\n| limit 20",
+        "visualization": "table",
         "visualizationSettings": {
-          "barChart": { "categoryAxis": { "fieldName": "page" }, "valueAxes": [{ "fieldName": "views" }] }
+          "autoSelectVisualization": false
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "7": {
-        "title": "Views by Country",
+        "title": "Top Documentation Pages",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"page_load\"\n| summarize views = count(), sessions = countDistinct(`dt.rum.session.id`), by:{`geo.country.name`, `geo.continent.name`}\n| sort views desc\n| limit 20",
-        "visualization": "table",
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "query": "fetch bizevents\n| filter event.provider == \"dynatrace-wwse.github.io\"\n| filter isNotNull(page)\n| summarize views = count(), by: { page }\n| sort views desc\n| limit 15",
+        "visualization": "categoricalBarChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "8": {
-        "title": "Views by Device Type",
+        "title": "Page Views by Country",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"page_load\"\n| summarize views = count(), by:{`device.type`}\n| sort views desc",
-        "visualization": "barChart",
+        "query": "fetch bizevents\n| filter event.provider == \"dynatrace-wwse.github.io\"\n| filter isNotNull(geo.country.name)\n| summarize views = count(), by: { geo.country.name }\n| sort views desc\n| limit 15",
+        "visualization": "categoricalBarChart",
         "visualizationSettings": {
-          "barChart": { "categoryAxis": { "fieldName": "device.type" }, "valueAxes": [{ "fieldName": "views" }] }
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
         },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "9": {
-        "title": "Views by Browser",
+        "title": "Country Reach",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"page_load\"\n| summarize views = count(), by:{`browser.name`}\n| sort views desc",
-        "visualization": "barChart",
-        "visualizationSettings": {
-          "barChart": { "categoryAxis": { "fieldName": "browser.name" }, "valueAxes": [{ "fieldName": "views" }] }
-        },
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "query": "fetch bizevents\n| filter event.provider == \"dynatrace-wwse.github.io\"\n| filter isNotNull(geo.country.name)\n| fieldsAdd countryCode = coalesce(geo.country.isoCode, if(geo.country.name == \"United States\", \"US\", else: if(geo.country.name == \"United Kingdom\", \"GB\", else: if(contains(geo.country.name, \"Netherlands\"), \"NL\", else: if(geo.country.name == \"Australia\", \"AU\", else: if(geo.country.name == \"New Zealand\", \"NZ\", else: if(geo.country.name == \"Singapore\", \"SG\", else: if(geo.country.name == \"Spain\", \"ES\", else: if(geo.country.name == \"Germany\", \"DE\", else: if(geo.country.name == \"France\", \"FR\", else: if(geo.country.name == \"India\", \"IN\", else: if(geo.country.name == \"Japan\", \"JP\", else: if(geo.country.name == \"Brazil\", \"BR\", else: if(geo.country.name == \"Canada\", \"CA\", else: \"XX\")))))))))))))\n| summarize count = count(), by: { countryCode }\n| fields countryCode, count",
+        "visualization": "table",
+        "visualizationSettings": {},
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       },
       "10": {
-        "title": "Sessions by Page — Detail",
+        "title": "RUM Apps — Page Views & Performance",
         "type": "data",
-        "query": "fetch bizevents, from:now()-7d\n| filter event.type == \"page_load\"\n| summarize views = count(), sessions = countDistinct(`dt.rum.session.id`), by:{page, `event.provider`}\n| sort views desc\n| limit 30",
+        "query": "fetch user.events\n| summarize views = count(), avgDuration = avg(duration), by: { dt.rum.application.id }\n| lookup [data\n  record(id = \"0300531523b332e3\", name = \"demo-mcp-unguard\"),\n  record(id = \"1551d00ab46737d4\", name = \"log-ingest-101\"),\n  record(id = \"50e6d81a11783485\", name = \"demo-nvidia-agent\"),\n  record(id = \"59b0b1c4d53a32f5\", name = \"browser-dem-biz\"),\n  record(id = \"640a44336fc29980\", name = \"bug-busters\"),\n  record(id = \"6c332b985a9890d6\", name = \"live-debugger\"),\n  record(id = \"6f303dd9fa111f82\", name = \"dql-fundamentals\"),\n  record(id = \"7c50bce5c0cc890f\", name = \"codespaces-template\"),\n  record(id = \"8d3a8e2f85a94d58\", name = \"k8s-otel-openpipeline\"),\n  record(id = \"a8e749099685c188\", name = \"workflow-essentials\"),\n  record(id = \"ad7b68fd2b9d9448\", name = \"k8s-opentelemetry\"),\n  record(id = \"d6a688035595a70d\", name = \"log-analytics-ws\"),\n  record(id = \"e1da735db6894c6c\", name = \"remote-environment\"),\n  record(id = \"e4d90cc9ebfea2e7\", name = \"gen-ai-llm\"),\n  record(id = \"e6d3d89f79f14be8\", name = \"wwse.github.io\"),\n  record(id = \"ec2456210a428096\", name = \"dql-301\"),\n  record(id = \"f0e597e550cc03f6\", name = \"business-obs\"),\n  record(id = \"ff78563295ff1e42\", name = \"codespaces-framework\")],\n  sourceField: dt.rum.application.id, lookupField: id, prefix: \"app.\"\n| fieldsAdd appName = coalesce(app.name, dt.rum.application.id)\n| fields appName, views, avgDuration\n| sort views desc\n| limit 20",
         "visualization": "table",
-        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false }
+        "visualizationSettings": {
+          "table": { "columnWidths": { "[\"appName\"]": 388, "[\"avgDuration\"]": 150, "[\"views\"]": 100 }, "sortBy": [{ "columnId": "[\"views\"]", "direction": "descending" }] }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
+      },
+      "11": {
+        "title": "Views Over Time by Site",
+        "type": "data",
+        "query": "fetch bizevents\n| filter event.provider == \"dynatrace-wwse.github.io\"\n| makeTimeseries views = count(), by: { dt.rum.application.id }, interval: 1d",
+        "visualization": "lineChart",
+        "visualizationSettings": {
+          "coloring": {
+            "colorRules": [{ "field": "DT.name", "comparator": "= *value*", "value": "", "type": "string", "colorMode": "color-palette", "colorPalette": "blue-moss" }]
+          }
+        },
+        "querySettings": { "maxResultRecords": 1000, "defaultScanLimitGbytes": 500, "maxResultMegaBytes": 1, "defaultSamplingRatio": 10, "enableSampling": false },
+        "davis": { "davisVisualization": { "isAvailable": true } }
       }
     }
   }


### PR DESCRIPTION
## Problem

K8s 1.31+ enables `UserNamespacesSupport` as a **beta feature (on by default)**. The kubelet writes `net.ipv4.ip_unprivileged_port_start = 0` into each pod sandbox network namespace via containerd → runc. runc uses `openat2(RESOLVE_NO_XDEV)` which refuses cross-device traversal.

In GitHub Codespaces devcontainers (Docker-in-Docker), `/proc/sys` is a bind mount from a different device than `/proc`, so every sandbox creation fails:

```
FailedCreatePodSandBox: runc create failed: unable to start container process:
error during container init: open sysctl net.ipv4.ip_unprivileged_port_start file:
unsafe procfs detected: openat2 /proc/./sys/net/ipv4/ip_unprivileged_port_start:
invalid cross-device link
```

This blocks all pods from starting on any repo still using Kind as the cluster engine.

## Fix — `kind-cluster.yml`

- `featureGates: UserNamespacesSupport: false` in `KubeletConfiguration` — suppresses the sysctl write per sandbox
- `protectKernelDefaults: false` — stops kubelet from validating/setting kernel defaults against a read-only procfs at node startup
- New `ClusterConfiguration` patch — propagates the feature gate to the API server so kubelet and API server stay in sync

## Test — Astroshop on Kind

New `integration_kind_astroshop.sh`:
- Start Kind cluster → deploy Astroshop → assert ingress reachable → assert HTML + assets → teardown
- Guards: AMD64 only, skip on Orbital/Sysbox

New `assertAstroshopContent()` in `test_functions.sh`:
- Fetches root page, checks valid HTML and shop keywords
- Extracts `src`/`href` asset URLs from HTML, verifies each returns HTTP 200/304
- 8 retries with 5s backoff (Next.js SSR slow on cold start)

## Test plan
- [ ] Trigger a CI run on a repo that uses Kind — pods should no longer get stuck `ContainerCreating`/`FailedCreatePodSandBox`
- [ ] Run `bash .devcontainer/test/integration_kind_astroshop.sh` in a Codespace on an AMD64 runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)