### PR TITLE
chore: disable nightly CI for workshop-destination-automation

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -164,6 +164,7 @@ repos:
     maintainer: "@shinojosa, @popecruzdt"
     description: "Workshop on destination automation with Dynatrace Workflows. Build end-to-end automated pipelines for alerting, ticketing, and remediation."
     sync_managed: false
+    ci: false
     tags: [workflows, ansible]
     title: "Destination Automation Workshop"
     primary_tag: workflows


### PR DESCRIPTION
## Summary
- Add `ci: false` to `workshop-destination-automation` in `repos.yaml`

## Why
The repo has no `.devcontainer` on `main` (it lives on a separate `devcontainer` branch). `postCreateCommand` there is just a welcome `echo` — no cluster setup, no integration tests possible. With `sync_managed: false` this is a special Ansible/AAP workshop that doesn't follow the standard devcontainer enablement pattern. It was failing with exit 127 on every nightly run for at least 3 consecutive nights.

## Test plan
- [ ] Nightly run no longer includes `workshop-destination-automation`
- [ ] Total failures drop by 2 (arm64 + amd64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)