### PR TITLE
feat(orbital): dashboard improvements + arena token provisioning

### DIFF
--- a/.devcontainer/yaml/dt-tokens.yaml
+++ b/.devcontainer/yaml/dt-tokens.yaml
@@ -1,0 +1,29 @@
+# Default Dynatrace API token definitions for Enablement Framework training sessions.
+#
+# Used by the Arena provisioner to auto-create scoped, time-limited tokens in the
+# attendee's DT tenant before post-create.sh runs. No manual token copy-paste needed.
+#
+# Repos can override with their own .devcontainer/yaml/dt-tokens.yaml.
+# Only specify the tokens your repo actually needs — the provisioner creates exactly these.
+#
+# Token naming: enbl-{repo}-{user}-{name_suffix}  (auto-prefixed, max 100 chars)
+# Token expiry: matches training session TTL (default 4h)
+
+tokens:
+  - name_suffix: operator
+    env_var: DT_OPERATOR_TOKEN
+    scopes:
+      - activeGateTokenManagement.write
+      - entities.read
+      - settings.read
+      - settings.write
+      - DataExport
+      - InstallerDownload
+
+  - name_suffix: ingest
+    env_var: DT_INGEST_TOKEN
+    scopes:
+      - metrics.ingest
+      - logs.ingest
+      - events.ingest
+      - openTelemetryTrace.ingest

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -1,0 +1,33 @@
+name: Framework Unit Tests
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'functions.sh'
+      - 'my_functions.sh'
+      - '.devcontainer/test/unit/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'functions.sh'
+      - 'my_functions.sh'
+      - '.devcontainer/test/unit/**'
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  bats:
+    name: Bats unit tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install bats
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y bats
+
+      - name: Run framework unit tests
+        run: bats .devcontainer/test/unit/ --tap

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -819,6 +819,24 @@ async def api_terminate_job(job_id: str, request: Request):
         )
         raise HTTPException(404, detail)
     requested_by = role["user"]
+
+    # Revoke provisioned DT tokens for this session (best-effort, non-blocking)
+    meta = await pool.hgetall(f"job:running:{job_id}")
+    if meta.get("dt_token_ids") and meta.get("dt_tenant_url"):
+        from provisioning import DTTokenProvisioner
+        try:
+            token_ids = json.loads(meta["dt_token_ids"])
+            provisioner = DTTokenProvisioner(
+                tenant_url=meta["dt_tenant_url"],
+                api_token=meta.get("dt_auth_token", ""),
+                oauth_client_id=meta.get("dt_oauth_client_id", ""),
+                oauth_client_secret=meta.get("dt_oauth_client_secret", ""),
+            )
+            asyncio.create_task(provisioner.revoke_tokens(token_ids))
+            log.info("Revoking %d DT token(s) for session %s", len(token_ids), job_id)
+        except Exception as exc:
+            log.warning("Could not initiate token revocation for %s: %s", job_id, exc)
+
     await pool.publish("ops:terminate", job_id)
     log.info("Termination requested for %s by %s", job_id, requested_by)
     return {"status": "termination_requested", "job_id": job_id, "requested_by": requested_by}
@@ -2668,15 +2686,26 @@ class ArenaProvisionRequest(BaseModel):
     trainingId: str
     userId: str
     tenantId: str = ""
+    # DT tenant for this session — if omitted, falls back to worker static creds.
+    tenantUrl: str = ""
+    # Auth for token provisioning: OAuth2 (preferred, app-installed flow) OR existing API token.
+    oauthClientId: str = ""
+    oauthClientSecret: str = ""
+    apiToken: str = ""          # existing token with apiTokens.write scope
 
 
 @app.post("/api/arena/provision")
 async def api_arena_provision(body: ArenaProvisionRequest):
     """Provision a training environment — queues a real daemon job on the amd64 worker.
 
-    Returns: { jobId, wsUrl, expiresAt, status: "provisioning" }
+    If tenantUrl + auth credentials are provided, auto-creates scoped DT API tokens
+    for this session (named enbl-{repo}-{user}-{suffix}, expiry = session TTL).
+    Token IDs are stored in Redis so they can be revoked on session termination.
+
+    Returns: { jobId, wsUrl, expiresAt, status: "provisioning", tokenProvisioned: bool }
     """
     import uuid as _uuid
+    from provisioning import DTTokenProvisioner, load_token_specs
 
     cached = await pool.get(_ARENA_CATALOG_CACHE_KEY)
     catalog = json.loads(cached) if cached else await _fetch_arena_catalog()
@@ -2684,12 +2713,43 @@ async def api_arena_provision(body: ArenaProvisionRequest):
     if training is None:
         raise HTTPException(status_code=404, detail=f"Training '{body.trainingId}' not found")
 
-    # org/repo format for the executor (e.g. "dynatrace-wwse/enablement-live-debugger-bug-hunting")
     repo_nwo = "/".join(training["repoUrl"].rstrip("/").split("/")[-2:])
-    repo_name = training["repoUrl"].split("/")[-1]
     job_id = f"enablement-{_uuid.uuid4().hex[:12]}"
     now = datetime.now(timezone.utc)
-    expires_at = (now.replace(microsecond=0) + timedelta(hours=4)).isoformat()
+    session_hours = 4
+    expires_at = (now.replace(microsecond=0) + timedelta(hours=session_hours)).isoformat()
+
+    # --- Token provisioning ---
+    dt_env: dict[str, str] = {}
+    provisioned_token_ids: list[str] = []
+    token_provisioned = False
+
+    tenant_url = body.tenantUrl.rstrip("/") if body.tenantUrl else ""
+    if tenant_url and (body.apiToken or (body.oauthClientId and body.oauthClientSecret)):
+        try:
+            provisioner = DTTokenProvisioner(
+                tenant_url=tenant_url,
+                api_token=body.apiToken,
+                oauth_client_id=body.oauthClientId,
+                oauth_client_secret=body.oauthClientSecret,
+            )
+            specs = await load_token_specs(repo_nwo, ref=training["branch"])
+            result = await provisioner.create_tokens(
+                repo=repo_nwo,
+                user_id=body.userId,
+                specs=specs,
+                expires_in_hours=session_hours,
+            )
+            dt_env = result.env
+            provisioned_token_ids = result.token_ids
+            token_provisioned = True
+        except Exception as exc:
+            # Non-fatal: log and fall back to worker static creds
+            import logging as _log
+            _log.getLogger("ops-dashboard").warning(
+                "Token provisioning failed for %s / %s: %s — falling back to worker creds",
+                repo_nwo, body.userId, exc,
+            )
 
     job = {
         "job_id":        job_id,
@@ -2702,8 +2762,10 @@ async def api_arena_provision(body: ArenaProvisionRequest):
         "nightly_run_id": f"enablement-{body.trainingId}",
         "requested_by":  body.userId,
     }
-    # Pre-write so session-status can resolve it before the worker picks it up.
-    await pool.hset(f"job:running:{job_id}", mapping={
+    if dt_env:
+        job["dt_env"] = dt_env
+
+    redis_meta = {
         "job_id":       job_id,
         "repo":         repo_nwo,
         "branch":       training["branch"],
@@ -2712,18 +2774,33 @@ async def api_arena_provision(body: ArenaProvisionRequest):
         "worker_id":    "queued",
         "type":         "daemon",
         "arena_user":   body.userId,
-        "arena_tenant": body.tenantId,
+        "arena_tenant": body.tenantId or tenant_url,
         "training_id":  body.trainingId,
         "expires_at":   expires_at,
-    })
-    await pool.expire(f"job:running:{job_id}", int(timedelta(hours=4).total_seconds()))
+        "token_provisioned": "1" if token_provisioned else "0",
+    }
+    if provisioned_token_ids:
+        redis_meta["dt_token_ids"] = json.dumps(provisioned_token_ids)
+    if tenant_url:
+        redis_meta["dt_tenant_url"] = tenant_url
+    # Store auth so terminate can revoke tokens. Token has apiTokens.read+write only.
+    if token_provisioned:
+        if body.apiToken:
+            redis_meta["dt_auth_token"] = body.apiToken
+        elif body.oauthClientId:
+            redis_meta["dt_oauth_client_id"] = body.oauthClientId
+            redis_meta["dt_oauth_client_secret"] = body.oauthClientSecret
+
+    await pool.hset(f"job:running:{job_id}", mapping=redis_meta)
+    await pool.expire(f"job:running:{job_id}", int(timedelta(hours=session_hours).total_seconds()))
     await pool.rpush("queue:test:amd64", json.dumps(job))
 
     return {
-        "jobId":     job_id,
-        "wsUrl":     f"wss://autonomous-enablements.whydevslovedynatrace.com/ws/jobs/{job_id}/shell",
-        "expiresAt": expires_at,
-        "status":    "provisioning",
+        "jobId":            job_id,
+        "wsUrl":            f"wss://autonomous-enablements.whydevslovedynatrace.com/ws/jobs/{job_id}/shell",
+        "expiresAt":        expires_at,
+        "status":           "provisioning",
+        "tokenProvisioned": token_provisioned,
     }
 
 
@@ -3265,14 +3342,14 @@ async def api_arena_session_exec(job_id: str, body: ArenaExecRequest):
             stdout=_asyncio.subprocess.PIPE,
             stderr=_asyncio.subprocess.PIPE,
         )
-        stdout_b, stderr_b = await _asyncio.wait_for(proc.communicate(), timeout=30)
+        stdout_b, stderr_b = await _asyncio.wait_for(proc.communicate(), timeout=120)
         return {
             "stdout": stdout_b.decode("utf-8", errors="replace"),
             "stderr": stderr_b.decode("utf-8", errors="replace"),
             "exitCode": proc.returncode,
         }
     except _asyncio.TimeoutError:
-        return {"stdout": "", "stderr": "Command timed out after 30 seconds", "exitCode": -1}
+        return {"stdout": "", "stderr": "Command timed out after 120 seconds", "exitCode": -1}
     except Exception as exc:
         return {"stdout": "", "stderr": str(exc), "exitCode": -1}
 

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -1501,13 +1501,17 @@ async def api_sync_prs():
             pr["_ci"] = None
             return
         conclusions = [c.get("conclusion") or c.get("status") or "" for c in checks]
-        failed = [c for c in checks if c.get("conclusion") in ("FAILURE", "ERROR", "TIMED_OUT")]
+        failed = [c for c in checks if c.get("conclusion") in ("FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "STARTUP_FAILURE")]
         if all(c in ("SUCCESS", "NEUTRAL", "SKIPPED") for c in conclusions):
             overall = "pass"
-        elif any(c in ("FAILURE", "ERROR", "TIMED_OUT") for c in conclusions):
+        elif any(c in ("FAILURE", "ERROR", "TIMED_OUT", "STARTUP_FAILURE") for c in conclusions):
             overall = "fail"
-        elif any(c in ("IN_PROGRESS", "QUEUED", "PENDING", "WAITING") for c in conclusions):
+        elif any(c in ("IN_PROGRESS", "QUEUED", "PENDING", "WAITING", "REQUESTED") for c in conclusions):
             overall = "pending"
+        elif any(c == "CANCELLED" for c in conclusions):
+            # CANCELLED after IN_PROGRESS is already caught above; reaching here means
+            # the run was cancelled with no new run in flight — treat as failed.
+            overall = "fail"
         else:
             overall = "pending"
         pr["_ci"] = {

--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -1009,6 +1009,28 @@ async function loadWorkers() {
             const statusKey = stale ? 'offline' : (w.status || 'offline');
             const statusLabel = stale ? `stale (${ageSec}s)` : statusKey;
             const statusPill = `<span class="worker-status-pill ${statusKey}">${escapeHtml(statusLabel)}</span>`;
+            const _pctBar = (val, label, warnAt = 80) => {
+                if (val == null || val === '') return '';
+                const pct = parseFloat(val);
+                if (isNaN(pct)) return '';
+                const color = pct >= warnAt ? 'var(--red)' : pct >= 60 ? 'var(--yellow, #f5a623)' : 'var(--green)';
+                return `<div style="margin-top:4px">
+                    <div style="display:flex;justify-content:space-between;font-size:0.72rem;color:var(--text-muted)">
+                        <span>${label}</span><span>${pct}%</span>
+                    </div>
+                    <div style="background:var(--bg-2);border-radius:3px;height:5px;overflow:hidden">
+                        <div style="width:${Math.min(pct,100)}%;height:100%;background:${color};transition:width 1s"></div>
+                    </div>
+                </div>`;
+            };
+            const metricsHtml = [
+                _pctBar(w.cpu_pct, 'CPU'),
+                _pctBar(w.mem_pct, `Mem${w.mem_used_gb ? ` (${w.mem_used_gb}/${w.mem_total_gb} GB)` : ''}`),
+                _pctBar(w.disk_pct, 'Disk', 90),
+                w.containers_running != null && w.containers_running !== ''
+                    ? `<div style="font-size:0.72rem;color:var(--text-muted);margin-top:4px">Containers: ${escapeHtml(String(w.containers_running))}</div>`
+                    : '',
+            ].filter(Boolean).join('');
             return `
                 <div class="worker-card ${isMaster ? 'is-master' : ''} ${stale ? 'offline' : ''}">
                     <h4>${escapeHtml(w.worker_id)} ${badge} ${statusPill}</h4>
@@ -1018,6 +1040,7 @@ async function loadWorkers() {
                         <div>Last heartbeat: ${formatTime(w.last_heartbeat)}</div>
                         ${masterExtras}
                     </div>
+                    ${metricsHtml}
                 </div>
             `;
         }).join('');
@@ -1071,6 +1094,19 @@ async function loadNightly(runId) {
 
     _nightlyAllResults = data.results || [];
     applyNightlyFilter();
+
+    // Load common-error summary if there are failures
+    const failCount = data.failed || 0;
+    const panel = document.getElementById('nightly-errors-panel');
+    if (panel) {
+        if (failCount > 0 && data.run_id) {
+            panel.hidden = false;
+            document.getElementById('nightly-errors-body').innerHTML = '<span style="color:var(--text-muted)">Analysing failure patterns…</span>';
+            loadNightlyErrorSummary(data.run_id);
+        } else {
+            panel.hidden = true;
+        }
+    }
 }
 
 function applyNightlyFilter() {
@@ -1109,6 +1145,28 @@ function applyNightlyFilter() {
             <td>${formatTime(job.finished_at)}</td>
         </tr>`;
     }).join('');
+}
+
+async function loadNightlyErrorSummary(runId) {
+    const body = document.getElementById('nightly-errors-body');
+    if (!body) return;
+    try {
+        const res = await fetch(`${API}/api/nightly/run/${encodeURIComponent(runId)}/summary`);
+        if (!res.ok) { body.innerHTML = '<span style="color:var(--text-muted)">Could not load error summary.</span>'; return; }
+        const data = await res.json();
+        const patterns = data.patterns || [];
+        if (!patterns.length) {
+            body.innerHTML = '<span style="color:var(--text-muted)">No common patterns found in failure logs.</span>';
+            return;
+        }
+        body.innerHTML = patterns.map(p => `
+            <div style="display:flex;gap:8px;align-items:baseline;margin-bottom:4px;border-left:3px solid var(--red);padding-left:8px">
+                <span class="status-fail" style="font-size:0.75rem;flex-shrink:0">${p.count}×</span>
+                <code style="font-size:0.75rem;color:var(--text-2);white-space:pre-wrap;word-break:break-all">${escapeHtml(p.line)}</code>
+            </div>`).join('');
+    } catch (e) {
+        body.innerHTML = `<span style="color:var(--text-muted)">Error: ${escapeHtml(String(e))}</span>`;
+    }
 }
 
 // ── Framework View ───────────────────────────────────────────────────────────
@@ -1221,7 +1279,7 @@ document.addEventListener('click', e => {
     const triggerFw = e.target.closest('#nightly-trigger-framework');
     if (triggerFw) {
         e.preventDefault();
-        const ref = prompt('Branch to test?', 'feature/k3d-default-kind-cnfs');
+        const ref = prompt('Branch to test?', 'main');
         if (ref) triggerFrameworkSuite('all', ref);
         return;
     }
@@ -1868,7 +1926,7 @@ document.getElementById('sync-audit-refresh').addEventListener('click', async ()
 
 // ── Fix with AI modal ────────────────────────────────────────────────────────
 
-let fixAiContext = null;  // { type: 'pr'|'issue', repo, number, branch?, ciJobId? }
+let fixAiContext = null;  // { type: 'pr'|'issue'|'ci', repo, ... }
 
 function openFixWithAI(type, data) {
     fixAiContext = { type, ...data };
@@ -1887,6 +1945,12 @@ function openFixWithAI(type, data) {
         } else {
             ciInfo.hidden = true;
         }
+    } else if (type === 'ci') {
+        const repoShort = data.repo.split('/').pop();
+        title.textContent = `Fix with AI — ${repoShort} [${data.arch}]`;
+        desc.textContent = `The AI agent will read the failed test log, determine whether the root cause is in this repo or the shared framework, then commit a surgical fix to a new branch and open a PR.`;
+        ciInfo.hidden = false;
+        ciInfo.textContent = `Job: ${data.jobId || '—'} · Branch: ${data.branch || 'main'} · Step: ${data.failedStep || '—'}`;
     } else {
         title.textContent = `Fix with AI — Issue #${data.number} · ${data.repo.split('/').pop()}`;
         desc.textContent = 'The AI agent will read this issue, understand the problem, and commit a fix to a new branch in the repo, then open a pull request.';
@@ -1917,6 +1981,16 @@ async function submitFixWithAI() {
                 repo: fixAiContext.repo,
                 pr_number: fixAiContext.number,
                 branch: fixAiContext.branch || 'main',
+                instructions,
+            };
+        } else if (fixAiContext.type === 'ci') {
+            endpoint = '/api/agent/fix-ci';
+            payload = {
+                failed_job_id: fixAiContext.jobId,
+                repo: fixAiContext.repo,
+                branch: fixAiContext.branch || 'main',
+                arch: fixAiContext.arch,
+                failed_step: fixAiContext.failedStep,
                 instructions,
             };
         } else {
@@ -1954,6 +2028,17 @@ async function submitFixWithAI() {
         const ctx = fixAiContext;
         closeFixWithAI();
         const repoShort = ctx.repo.split('/').pop();
+        // Update the originating CI table button if present
+        if (ctx.type === 'ci' && ctx._btn) {
+            ctx._btn.textContent = '✓ Queued';
+            ctx._btn.classList.add('btn-success');
+            ctx._btn.disabled = true;
+            const td = ctx._btn.closest('td');
+            if (td && data.job_id) {
+                td.insertAdjacentHTML('beforeend',
+                    ` <a href="#" class="log-link" data-job-id="${escapeHtml(data.job_id)}" data-agent="true" title="View log">log</a>`);
+            }
+        }
         activateTab('agentic');
         setTimeout(loadAgenticRunning, 1200);
         showToast(`Agent queued for ${repoShort} — visible in the Agentic tab`);
@@ -2869,43 +2954,9 @@ function renderAgentIssues(limit = 10) {
 document.getElementById('agent-issues-filter')?.addEventListener('input', () => renderAgentIssues());
 document.getElementById('agent-issues-refresh')?.addEventListener('click', () => { agentIssuesData = []; loadAgentIssues(); });
 
-async function triggerAgentFixCI(failedJobId, repo, branch, arch, failedStep, btnEl) {
+function triggerAgentFixCI(failedJobId, repo, branch, arch, failedStep, btnEl) {
     if (!isWriter()) { alert('Sign in as a writer to trigger agent runs.'); return; }
-    btnEl.disabled = true;
-    btnEl.textContent = 'Queuing…';
-    try {
-        const res = await fetch(`${API}/api/agent/fix-ci`, {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({
-                failed_job_id: failedJobId,
-                repo, branch, arch,
-                failed_step: failedStep,
-            }),
-        });
-        if (!res.ok) {
-            const txt = await res.text();
-            btnEl.disabled = false;
-            btnEl.textContent = 'Fix with AI';
-            alert(`Error ${res.status}: ${txt}`);
-            return;
-        }
-        const data = await res.json();
-        btnEl.textContent = '✓ Queued';
-        btnEl.classList.add('btn-success');
-        // Show a link to the live log next to the button
-        const td = btnEl.closest('td');
-        if (td) {
-            td.insertAdjacentHTML('beforeend',
-                ` <a href="#" class="log-link" data-job-id="${escapeHtml(data.job_id)}" data-agent="true" title="View log">log</a>`);
-        }
-        // Refresh running agents section
-        setTimeout(loadAgenticRunning, 1500);
-    } catch (e) {
-        btnEl.disabled = false;
-        btnEl.textContent = 'Fix with AI';
-        alert(`Error: ${e}`);
-    }
+    openFixWithAI('ci', { jobId: failedJobId, repo, branch, arch, failedStep, _btn: btnEl });
 }
 
 // ── Init ────────────────────────────────────────────────────────────────────

--- a/ops-server/dashboard/templates/index.html
+++ b/ops-server/dashboard/templates/index.html
@@ -601,6 +601,11 @@
                     <tr><td colspan="6" class="loading">Loading nightly results…</td></tr>
                 </tbody>
             </table>
+            <!-- Nightly common-error summary (shown only when failures exist) -->
+            <div id="nightly-errors-panel" hidden style="margin-top:16px">
+                <h3 style="margin:0 0 8px;font-size:0.9rem;font-weight:600">Common failure patterns</h3>
+                <div id="nightly-errors-body" style="font-size:0.8rem"></div>
+            </div>
         </section>
 
         <!-- Framework Tests View -->
@@ -611,7 +616,7 @@
                     <p style="margin:2px 0 0;font-size:0.8rem;color:var(--text-muted)">Test the framework itself: unit tests, cluster engines, app exposure, Dynatrace components</p>
                 </div>
                 <div style="display:flex;gap:8px;align-items:center">
-                    <input type="text" id="framework-ref" value="feature/k3d-default-kind-cnfs" style="width:240px" placeholder="Branch or ref">
+                    <input type="text" id="framework-ref" value="main" style="width:240px" placeholder="Branch or ref">
                     <button class="btn btn-small" id="framework-run-all" data-action>▶ Run All</button>
                 </div>
             </div>

--- a/ops-server/nightly/scheduler.py
+++ b/ops-server/nightly/scheduler.py
@@ -81,6 +81,7 @@ async def run_nightly(
     stagger_minutes: int = 5,
     parallel: int = 6,
     dry_run: bool = False,
+    include_framework: bool = False,
 ):
     """Execute the nightly test schedule."""
     repos = load_testable_repos()
@@ -143,6 +144,45 @@ async def run_nightly(
             log.info("Queued: %s → queue:test:%s (order %d)", entry["name"], a, entry["order"])
 
     log.info("All %d repos queued for nightly run %s", len(schedule), run_id)
+
+    if include_framework:
+        log.info("Queueing framework tests (bats on arm64, k3d-basic + k3d-apps on amd64)…")
+        fw_timestamp = datetime.now(timezone.utc).isoformat()
+        fw_nightly_id = f"framework-nightly-{run_id}"
+        # bats unit tests — run on ARM master (no Sysbox needed)
+        await pool.rpush("queue:test:arm64", json.dumps({
+            "type": "framework-test",
+            "suite": "bats",
+            "test_script": "bats .devcontainer/test/unit/ --tap",
+            "framework_suite": "bats",
+            "repo": "dynatrace-wwse/codespaces-framework",
+            "arch": "arm64",
+            "queue": "test:arm64",
+            "ref": "main",
+            "timestamp": fw_timestamp,
+            "trigger": "nightly",
+            "nightly_run_id": fw_nightly_id,
+        }))
+        # k3d-basic and k3d-apps — run on AMD64 workers (need Sysbox)
+        for suite_id, script in [
+            ("k3d-basic", "bash .devcontainer/test/integration_k3d_basic.sh"),
+            ("k3d-apps",  "bash .devcontainer/test/integration_k3d_apps.sh"),
+        ]:
+            await pool.rpush("queue:test:amd64", json.dumps({
+                "type": "framework-test",
+                "suite": suite_id,
+                "test_script": script,
+                "framework_suite": suite_id,
+                "repo": "dynatrace-wwse/codespaces-framework",
+                "arch": "amd64",
+                "queue": "test:amd64",
+                "ref": "main",
+                "timestamp": fw_timestamp,
+                "trigger": "nightly",
+                "nightly_run_id": fw_nightly_id,
+            }))
+        log.info("Framework test jobs queued under %s", fw_nightly_id)
+
     await pool.aclose()
 
 
@@ -186,6 +226,7 @@ def main():
     n.add_argument("--stagger", type=int, default=5, help="Minutes between test starts (default: 5)")
     n.add_argument("--parallel", type=int, default=6, help="Max parallel workers (default: 6)")
     n.add_argument("--dry-run", action="store_true", help="Print schedule without running")
+    n.add_argument("--include-framework", action="store_true", help="Also queue framework tests (bats, k3d-basic, k3d-apps)")
 
     # single
     s = sub.add_parser("single", help="Run a single repo test")
@@ -200,7 +241,7 @@ def main():
     args = parser.parse_args()
 
     if args.command == "nightly":
-        asyncio.run(run_nightly(args.stagger, args.parallel, args.dry_run))
+        asyncio.run(run_nightly(args.stagger, args.parallel, args.dry_run, args.include_framework))
     elif args.command == "single":
         asyncio.run(run_single(args.repo))
     elif args.command == "schedule":

--- a/ops-server/provisioning/__init__.py
+++ b/ops-server/provisioning/__init__.py
@@ -1,0 +1,5 @@
+"Dynatrace token provisioning for training sessions."
+from .dt_token_provisioner import DTTokenProvisioner, ProvisionedTokens
+from .token_specs import TokenSpec, load_token_specs, DEFAULT_SPECS
+
+__all__ = ["DTTokenProvisioner", "ProvisionedTokens", "TokenSpec", "load_token_specs", "DEFAULT_SPECS"]

--- a/ops-server/provisioning/dt_token_provisioner.py
+++ b/ops-server/provisioning/dt_token_provisioner.py
@@ -1,0 +1,177 @@
+"""Dynatrace API token provisioner for training sessions.
+
+Creates scoped, time-limited API tokens on behalf of a training user.
+Supports two auth modes:
+
+  oauth2    — client_credentials flow. Used when the Arena app is installed on
+              a tenant and provides its OAuth2 client ID + secret. The app must
+              have the token:write scope declared in its manifest.
+
+  api_token — an existing API token with apiTokens.write scope. Used for the
+              QA validation tenant and for manual/bootstrap flows.
+
+Token naming:  enablement-{repo_short}-{user_short}-{suffix}
+Token expiry:  matches the training session TTL (default 4h)
+
+Created token IDs are returned so they can be stored in Redis and revoked
+when the session terminates.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone, timedelta
+from typing import Optional
+
+import httpx
+
+from .token_specs import TokenSpec
+
+log = logging.getLogger("ops-provisioning")
+
+_TOKEN_API = "{tenant}/api/v2/apiTokens"
+_OAUTH_TOKEN_URL = "{tenant}/sso/oauth2/token"
+_OAUTH_SCOPES = "token:write offline_access"
+
+
+@dataclass
+class ProvisionedTokens:
+    env: dict[str, str]       # env_var → token_value  (e.g. DT_OPERATOR_TOKEN → "dt0c01...")
+    token_ids: list[str]      # DT token IDs for revocation
+    expires_at: str           # ISO-8601 UTC
+    tenant_url: str
+
+
+class DTTokenProvisioner:
+    """Create and revoke DT API tokens for a training session.
+
+    Instantiate with ONE of:
+      - api_token  → existing token with apiTokens.write scope
+      - oauth_client_id + oauth_client_secret  → OAuth2 app credentials
+    """
+
+    def __init__(
+        self,
+        tenant_url: str,
+        api_token: str = "",
+        oauth_client_id: str = "",
+        oauth_client_secret: str = "",
+    ):
+        self.tenant_url = tenant_url.rstrip("/")
+        self._api_token = api_token
+        self._oauth_client_id = oauth_client_id
+        self._oauth_client_secret = oauth_client_secret
+        self._bearer: Optional[str] = None
+        self._bearer_expiry: Optional[datetime] = None
+
+        if not api_token and not (oauth_client_id and oauth_client_secret):
+            raise ValueError("Provide either api_token or oauth_client_id + oauth_client_secret")
+
+    async def _auth_headers(self) -> dict[str, str]:
+        if self._api_token:
+            return {"Authorization": f"Api-Token {self._api_token}",
+                    "Content-Type": "application/json"}
+
+        now = datetime.now(timezone.utc)
+        if not self._bearer or (self._bearer_expiry and now >= self._bearer_expiry):
+            await self._refresh_bearer()
+
+        return {"Authorization": f"Bearer {self._bearer}",
+                "Content-Type": "application/json"}
+
+    async def _refresh_bearer(self):
+        url = _OAUTH_TOKEN_URL.format(tenant=self.tenant_url)
+        async with httpx.AsyncClient(timeout=15) as client:
+            r = await client.post(url, data={
+                "grant_type": "client_credentials",
+                "client_id": self._oauth_client_id,
+                "client_secret": self._oauth_client_secret,
+                "scope": _OAUTH_SCOPES,
+            })
+            r.raise_for_status()
+            data = r.json()
+            self._bearer = data["access_token"]
+            # Conservative expiry: shave 60s off expires_in
+            expires_in = int(data.get("expires_in", 3600))
+            self._bearer_expiry = datetime.now(timezone.utc) + timedelta(seconds=expires_in - 60)
+            log.debug("Refreshed OAuth2 bearer token (expires_in=%ds)", expires_in)
+
+    async def create_tokens(
+        self,
+        repo: str,
+        user_id: str,
+        specs: list[TokenSpec],
+        expires_in_hours: int = 4,
+    ) -> ProvisionedTokens:
+        """Create all tokens defined in specs and return them as env vars.
+
+        Token name format: enablement-{repo_short}-{user_short}-{suffix}
+        """
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=expires_in_hours)
+        expires_iso = expires_at.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+        # Build a safe prefix — no slashes, max 30 chars total
+        repo_short = repo.split("/")[-1][:20].replace("_", "-")
+        user_short = user_id.split("@")[0][:10].replace("_", "-").replace(".", "-")
+        prefix = f"enbl-{repo_short}-{user_short}"
+
+        headers = await self._auth_headers()
+        token_api = _TOKEN_API.format(tenant=self.tenant_url)
+
+        env: dict[str, str] = {}
+        token_ids: list[str] = []
+        errors: list[str] = []
+
+        async with httpx.AsyncClient(timeout=20) as client:
+            for spec in specs:
+                name = f"{prefix}-{spec.name_suffix}"[:100]
+                payload = {
+                    "name": name,
+                    "expirationDate": expires_iso,
+                    "scopes": spec.scopes,
+                }
+                try:
+                    r = await client.post(token_api, headers=headers, json=payload)
+                    r.raise_for_status()
+                    data = r.json()
+                    env[spec.env_var] = data["token"]
+                    token_ids.append(data["id"])
+                    log.info("Created token '%s' (id=%s, expiry=%s)", name, data["id"], expires_iso)
+                except httpx.HTTPStatusError as exc:
+                    msg = f"Failed to create token '{name}': HTTP {exc.response.status_code} — {exc.response.text[:200]}"
+                    log.error(msg)
+                    errors.append(msg)
+
+        if errors:
+            # Revoke any tokens already created before raising
+            if token_ids:
+                await self.revoke_tokens(token_ids)
+            raise RuntimeError(f"Token provisioning failed:\n" + "\n".join(errors))
+
+        # Also expose DT_ENVIRONMENT so executor can write a complete .env
+        env["DT_ENVIRONMENT"] = self.tenant_url
+
+        return ProvisionedTokens(
+            env=env,
+            token_ids=token_ids,
+            expires_at=expires_iso,
+            tenant_url=self.tenant_url,
+        )
+
+    async def revoke_tokens(self, token_ids: list[str]):
+        """Revoke all provisioned tokens. Best-effort — logs but does not raise."""
+        if not token_ids:
+            return
+        headers = await self._auth_headers()
+        token_api = _TOKEN_API.format(tenant=self.tenant_url)
+
+        async with httpx.AsyncClient(timeout=15) as client:
+            for tid in token_ids:
+                try:
+                    r = await client.delete(f"{token_api}/{tid}", headers=headers)
+                    if r.status_code in (200, 204, 404):
+                        log.info("Revoked token %s (status=%d)", tid, r.status_code)
+                    else:
+                        log.warning("Unexpected status revoking token %s: %d", tid, r.status_code)
+                except Exception as exc:
+                    log.warning("Could not revoke token %s: %s", tid, exc)

--- a/ops-server/provisioning/token_specs.py
+++ b/ops-server/provisioning/token_specs.py
@@ -1,0 +1,100 @@
+"""Token spec definitions and per-repo loader.
+
+Each repo can declare what API tokens it needs in .devcontainer/yaml/dt-tokens.yaml.
+Falls back to the framework default (DEFAULT_SPECS) if no repo file exists.
+
+Spec file format (YAML):
+    tokens:
+      - name_suffix: operator       # appended to the token name prefix
+        env_var: DT_OPERATOR_TOKEN  # env var written to .devcontainer/.env
+        scopes:
+          - activeGateTokenManagement.write
+          - DataExport
+          - ...
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+import yaml
+
+log = logging.getLogger("ops-provisioning")
+
+_GH_RAW = "https://raw.githubusercontent.com/{repo}/{ref}/.devcontainer/yaml/dt-tokens.yaml"
+_FW_RAW = "https://raw.githubusercontent.com/dynatrace-wwse/codespaces-framework/main/.devcontainer/yaml/dt-tokens.yaml"
+
+
+@dataclass
+class TokenSpec:
+    name_suffix: str    # e.g. "operator"
+    env_var: str        # e.g. "DT_OPERATOR_TOKEN"
+    scopes: list[str]
+
+
+# Standard DT Operator + Ingest tokens — used by all K8s enablement repos.
+DEFAULT_SPECS: list[TokenSpec] = [
+    TokenSpec(
+        name_suffix="operator",
+        env_var="DT_OPERATOR_TOKEN",
+        scopes=[
+            "activeGateTokenManagement.write",
+            "entities.read",
+            "settings.read",
+            "settings.write",
+            "DataExport",
+            "InstallerDownload",
+        ],
+    ),
+    TokenSpec(
+        name_suffix="ingest",
+        env_var="DT_INGEST_TOKEN",
+        scopes=[
+            "metrics.ingest",
+            "logs.ingest",
+            "events.ingest",
+            "openTelemetryTrace.ingest",
+        ],
+    ),
+]
+
+
+def _parse_yaml(content: str) -> list[TokenSpec]:
+    data = yaml.safe_load(content)
+    specs = []
+    for t in data.get("tokens", []):
+        specs.append(TokenSpec(
+            name_suffix=t["name_suffix"],
+            env_var=t["env_var"],
+            scopes=t.get("scopes", []),
+        ))
+    return specs or DEFAULT_SPECS
+
+
+async def load_token_specs(repo: str, ref: str = "main") -> list[TokenSpec]:
+    """Fetch token spec for a repo from GitHub, fall back to framework default.
+
+    Resolution order:
+      1. {repo}/.devcontainer/yaml/dt-tokens.yaml  (repo-specific)
+      2. codespaces-framework/.devcontainer/yaml/dt-tokens.yaml  (framework default)
+      3. Hardcoded DEFAULT_SPECS  (offline fallback)
+    """
+    urls = [
+        _GH_RAW.format(repo=repo, ref=ref),
+        _FW_RAW,
+    ]
+    async with httpx.AsyncClient(timeout=10) as client:
+        for url in urls:
+            try:
+                r = await client.get(url)
+                if r.status_code == 200:
+                    specs = _parse_yaml(r.text)
+                    log.info("Loaded token specs from %s (%d tokens)", url, len(specs))
+                    return specs
+            except Exception as exc:
+                log.debug("Could not fetch %s: %s", url, exc)
+
+    log.info("Using hardcoded DEFAULT_SPECS (no remote spec found)")
+    return DEFAULT_SPECS

--- a/ops-server/requirements.txt
+++ b/ops-server/requirements.txt
@@ -7,3 +7,4 @@ httpx>=0.28.0
 python-dotenv>=1.0.1
 pydantic>=2.10.0
 jinja2>=3.1.0
+psutil>=5.9.0

--- a/ops-server/systemd/ops-nightly.service
+++ b/ops-server/systemd/ops-nightly.service
@@ -8,7 +8,7 @@ Type=oneshot
 User=ops
 Group=ops
 WorkingDirectory=/home/ops/enablement-framework/codespaces-framework/ops-server
-ExecStart=/home/ops/ops-venv/bin/python -m nightly.scheduler nightly --stagger 5 --parallel 6
+ExecStart=/home/ops/ops-venv/bin/python -m nightly.scheduler nightly --stagger 5 --parallel 6 --include-framework
 Environment=PYTHONPATH=/home/ops/enablement-framework/codespaces-framework/ops-server
 EnvironmentFile=/home/ops/.env
 TimeoutStartSec=7200

--- a/ops-server/tools/docs_crawler.py
+++ b/ops-server/tools/docs_crawler.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+Docs crawler for dynatrace-wwse.github.io/{repo}/.
+
+Fetches pages in nav order, strips HTML, and extracts structured steps.
+
+Usage:
+  python3 docs_crawler.py --repo enablement-dql-fundamentals
+  python3 docs_crawler.py --repo enablement-dql-fundamentals --base-url https://dynatrace-wwse.github.io
+
+Returns JSON list of:
+  [{ "page": "Page Title", "url": "https://...", "steps": [
+      { "type": "shell|ui|verify", "content": "..." }
+  ]}]
+
+Step detection heuristics:
+  - <code> / <pre> blocks → type "shell"
+  - Text containing UI action keywords (click, navigate, open, go to) → type "ui"
+  - Text containing assertion keywords (verify, confirm, check, assert, expect) → type "verify"
+  - Everything else → type "info"
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from typing import NamedTuple
+from urllib.parse import urljoin, urlparse
+
+try:
+    import requests
+    from bs4 import BeautifulSoup
+except ImportError:
+    print("Missing deps: pip install requests beautifulsoup4", file=sys.stderr)
+    sys.exit(1)
+
+
+BASE_URL = "https://dynatrace-wwse.github.io"
+
+_UI_KEYWORDS = re.compile(
+    r"\b(click|navigate|open|go to|visit|select|choose|enter|type in|fill in|set|toggle|enable|disable|create|add|delete|search for|log in|sign in)\b",
+    re.IGNORECASE,
+)
+_VERIFY_KEYWORDS = re.compile(
+    r"\b(verify|confirm|check|assert|expect|should see|validate|ensure|make sure|observe)\b",
+    re.IGNORECASE,
+)
+
+
+class Step(NamedTuple):
+    type: str   # shell | ui | verify | info
+    content: str
+
+
+class PageDoc(NamedTuple):
+    page: str
+    url: str
+    steps: list[Step]
+
+    def to_dict(self) -> dict:
+        return {
+            "page": self.page,
+            "url": self.url,
+            "steps": [{"type": s.type, "content": s.content} for s in self.steps],
+        }
+
+
+def _classify_text(text: str) -> str:
+    if _VERIFY_KEYWORDS.search(text):
+        return "verify"
+    if _UI_KEYWORDS.search(text):
+        return "ui"
+    return "info"
+
+
+def _extract_steps(soup: BeautifulSoup) -> list[Step]:
+    """Walk the main content area and extract steps."""
+    steps: list[Step] = []
+
+    # MkDocs Material uses <article> or .md-content
+    content = (
+        soup.find("article")
+        or soup.find(class_="md-content__inner")
+        or soup.find(class_="md-content")
+        or soup.find("main")
+        or soup.body
+    )
+    if not content:
+        return steps
+
+    for el in content.find_all(["p", "li", "pre", "code", "h2", "h3", "h4"]):
+        tag = el.name
+
+        # Code/pre → shell step
+        if tag in ("pre", "code"):
+            code_text = el.get_text(strip=True)
+            if not code_text or len(code_text) < 3:
+                continue
+            # Avoid duplicating nested code inside pre
+            if tag == "code" and el.parent and el.parent.name == "pre":
+                continue
+            steps.append(Step(type="shell", content=code_text))
+            continue
+
+        text = el.get_text(" ", strip=True)
+        if not text or len(text) < 10:
+            continue
+
+        # Skip if this element contains a <pre>/<code> child (already captured above)
+        if el.find(["pre", "code"]):
+            continue
+
+        kind = _classify_text(text)
+        steps.append(Step(type=kind, content=text))
+
+    return steps
+
+
+def _nav_urls(base_url: str, repo: str, session: requests.Session) -> list[str]:
+    """Return ordered page URLs from the MkDocs nav sidebar."""
+    index_url = f"{base_url}/{repo}/"
+    try:
+        r = session.get(index_url, timeout=15)
+        r.raise_for_status()
+    except requests.RequestException as exc:
+        print(f"[warn] Cannot fetch index {index_url}: {exc}", file=sys.stderr)
+        return [index_url]
+
+    soup = BeautifulSoup(r.text, "html.parser")
+
+    # MkDocs Material: nav links are in <nav class="md-nav md-nav--primary">
+    nav = soup.find("nav", class_=re.compile(r"md-nav"))
+    if not nav:
+        nav = soup
+
+    seen: set[str] = set()
+    urls: list[str] = []
+
+    for a in nav.find_all("a", href=True):
+        href = a["href"]
+        # Resolve relative links
+        full = urljoin(index_url, href)
+        parsed = urlparse(full)
+        # Only same-origin, same-path-prefix links
+        if parsed.netloc != urlparse(index_url).netloc:
+            continue
+        if not parsed.path.startswith(f"/{repo}/"):
+            continue
+        # Drop anchors and query strings for dedup
+        canonical = parsed.scheme + "://" + parsed.netloc + parsed.path
+        if canonical not in seen:
+            seen.add(canonical)
+            urls.append(canonical)
+
+    return urls if urls else [index_url]
+
+
+def crawl_repo(
+    repo: str,
+    base_url: str = BASE_URL,
+    session: requests.Session | None = None,
+) -> list[dict]:
+    """Crawl all pages of a repo's docs site.
+
+    Returns a list of PageDoc dicts in nav order.
+    """
+    if session is None:
+        session = requests.Session()
+        session.headers["User-Agent"] = "DT-QA-Crawler/1.0"
+
+    urls = _nav_urls(base_url, repo, session)
+    results: list[dict] = []
+
+    for url in urls:
+        try:
+            r = session.get(url, timeout=15)
+            if r.status_code == 404:
+                continue
+            r.raise_for_status()
+        except requests.RequestException as exc:
+            print(f"[warn] Skip {url}: {exc}", file=sys.stderr)
+            continue
+
+        soup = BeautifulSoup(r.text, "html.parser")
+
+        # Page title: <h1> or <title>
+        h1 = soup.find("h1")
+        title_tag = soup.find("title")
+        page_title = (
+            h1.get_text(strip=True) if h1
+            else title_tag.get_text(strip=True) if title_tag
+            else url
+        )
+
+        steps = _extract_steps(soup)
+        doc = PageDoc(page=page_title, url=url, steps=steps)
+        results.append(doc.to_dict())
+
+    return results
+
+
+def main():
+    p = argparse.ArgumentParser(description="Crawl dynatrace-wwse.github.io docs")
+    p.add_argument("--repo", required=True, help="Repo name, e.g. enablement-dql-fundamentals")
+    p.add_argument("--base-url", default=BASE_URL, help="Docs site base URL")
+    p.add_argument("--output", default=None, help="Write JSON to file instead of stdout")
+    p.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    args = p.parse_args()
+
+    pages = crawl_repo(args.repo, base_url=args.base_url)
+    out = json.dumps(pages, indent=2 if args.pretty else None, ensure_ascii=False)
+
+    if args.output:
+        from pathlib import Path
+        Path(args.output).write_text(out)
+        print(f"Wrote {len(pages)} pages → {args.output}", file=sys.stderr)
+    else:
+        print(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/ops-server/tools/stress_test.py
+++ b/ops-server/tools/stress_test.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+Worker stress test — measures maximum concurrent DinD training capacity.
+
+Launches integration-test jobs in escalating waves on a target worker and
+monitors CPU, memory, responsiveness, and job throughput until saturation.
+
+Usage:
+  python3 stress_test.py --api https://autonomous-enablements.whydevslovedynatrace.com \\
+      --arch amd64 --max-jobs 14 --step 2 --wave-minutes 5 \\
+      --repo dynatrace-wwse/dt-k8s-operator-enablement-new
+
+Results are written to stress-test-<timestamp>.json.
+
+The saturation point is declared when ANY of:
+  - cpu_pct >= CPU_SATURATION_PCT sustained for two consecutive polls
+  - mem_pct >= MEM_SATURATION_PCT sustained for two consecutive polls
+  - A worker heartbeat becomes stale (> 90s old)
+  - Job queue stops draining (no new completions in DRAIN_TIMEOUT_MINUTES)
+"""
+import argparse
+import json
+import time
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import requests
+except ImportError:
+    print("requests not installed: pip install requests", file=sys.stderr)
+    sys.exit(1)
+
+CPU_SATURATION_PCT = 90.0
+MEM_SATURATION_PCT = 90.0
+DRAIN_TIMEOUT_MINUTES = 15
+POLL_INTERVAL_SECONDS = 30
+
+
+def ts() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def get_workers(api: str, session: requests.Session) -> list[dict]:
+    r = session.get(f"{api}/api/workers", timeout=10)
+    r.raise_for_status()
+    return r.json().get("workers", [])
+
+
+def queue_job(api: str, session: requests.Session, repo: str, arch: str) -> str | None:
+    """Trigger an integration test job and return its job_id, or None on error."""
+    r = session.post(
+        f"{api}/api/builds/trigger",
+        json={"repo": repo, "arch": arch, "branch": "main"},
+        timeout=10,
+    )
+    if r.status_code == 401:
+        print("AUTH REQUIRED: visit the dashboard and re-run with a valid session cookie")
+        sys.exit(1)
+    if not r.ok:
+        print(f"  [warn] Trigger failed {r.status_code}: {r.text[:200]}")
+        return None
+    data = r.json()
+    return data.get("job_id")
+
+
+def poll_worker_metrics(api: str, session: requests.Session, arch: str) -> list[dict]:
+    workers = get_workers(api, session)
+    return [w for w in workers if w.get("arch") == arch]
+
+
+def heartbeat_age_seconds(w: dict) -> float:
+    hb = w.get("last_heartbeat")
+    if not hb:
+        return 999.0
+    try:
+        hb_ts = datetime.fromisoformat(hb.replace("Z", "+00:00"))
+        return (datetime.now(timezone.utc) - hb_ts).total_seconds()
+    except Exception:
+        return 999.0
+
+
+def run_stress_test(
+    api: str,
+    repo: str,
+    arch: str,
+    max_jobs: int,
+    step: int,
+    wave_minutes: int,
+    cookie: str | None,
+    output: Path,
+):
+    session = requests.Session()
+    if cookie:
+        # Paste your browser _oauth2_proxy cookie value here or pass via --cookie
+        session.cookies.set("_oauth2_proxy", cookie, domain=api.split("//")[-1].split("/")[0])
+
+    results = {
+        "started_at": ts(),
+        "api": api,
+        "repo": repo,
+        "arch": arch,
+        "max_jobs": max_jobs,
+        "step": step,
+        "wave_minutes": wave_minutes,
+        "waves": [],
+        "saturation_point": None,
+        "saturation_reason": None,
+        "finished_at": None,
+    }
+
+    print(f"Stress test: {repo} [{arch}] | waves 1→{max_jobs} step={step} | {wave_minutes}min per wave")
+    print(f"Polling every {POLL_INTERVAL_SECONDS}s | saturation: CPU>{CPU_SATURATION_PCT}% or Mem>{MEM_SATURATION_PCT}%")
+    print("─" * 72)
+
+    saturated = False
+    prev_high_cpu = False
+    prev_high_mem = False
+    last_completion_count = 0
+    last_drain_check = time.monotonic()
+
+    for concurrency in range(step, max_jobs + step, step):
+        if saturated:
+            break
+        concurrency = min(concurrency, max_jobs)
+        wave_info = {
+            "concurrency": concurrency,
+            "started_at": ts(),
+            "jobs_queued": [],
+            "polls": [],
+            "saturation_triggered": False,
+        }
+
+        print(f"\nWave: {concurrency} concurrent jobs")
+        for _ in range(concurrency):
+            jid = queue_job(api, session, repo, arch)
+            if jid:
+                wave_info["jobs_queued"].append(jid)
+                print(f"  → queued {jid}")
+
+        deadline = time.monotonic() + wave_minutes * 60
+        while time.monotonic() < deadline:
+            time.sleep(POLL_INTERVAL_SECONDS)
+            workers = poll_worker_metrics(api, session, arch)
+            if not workers:
+                print("  [warn] No workers found for arch", arch)
+                continue
+
+            poll_entry = {"timestamp": ts(), "workers": []}
+            for w in workers:
+                age = heartbeat_age_seconds(w)
+                cpu = float(w.get("cpu_pct") or 0)
+                mem = float(w.get("mem_pct") or 0)
+                disk = float(w.get("disk_pct") or 0)
+                containers = w.get("containers_running", "?")
+                active = int(w.get("active_jobs") or 0)
+                entry = {
+                    "worker_id": w.get("worker_id"),
+                    "active_jobs": active,
+                    "cpu_pct": cpu,
+                    "mem_pct": mem,
+                    "disk_pct": disk,
+                    "containers_running": containers,
+                    "heartbeat_age_s": round(age, 1),
+                }
+                poll_entry["workers"].append(entry)
+                print(
+                    f"  {w.get('worker_id','?')} | jobs={active} | "
+                    f"CPU={cpu}% Mem={mem}% Disk={disk}% | "
+                    f"containers={containers} | hb_age={age:.0f}s"
+                )
+
+                # Saturation checks
+                if age > 90:
+                    saturated = True
+                    wave_info["saturation_triggered"] = True
+                    results["saturation_point"] = concurrency
+                    results["saturation_reason"] = f"Heartbeat stale: {age:.0f}s"
+                    print(f"  !! SATURATION: heartbeat stale ({age:.0f}s)")
+                elif cpu >= CPU_SATURATION_PCT:
+                    if prev_high_cpu:
+                        saturated = True
+                        wave_info["saturation_triggered"] = True
+                        results["saturation_point"] = concurrency
+                        results["saturation_reason"] = f"CPU sustained >= {CPU_SATURATION_PCT}%: {cpu}%"
+                        print(f"  !! SATURATION: CPU {cpu}% (sustained)")
+                    prev_high_cpu = True
+                else:
+                    prev_high_cpu = False
+
+                if mem >= MEM_SATURATION_PCT:
+                    if prev_high_mem:
+                        saturated = True
+                        wave_info["saturation_triggered"] = True
+                        results["saturation_point"] = concurrency
+                        results["saturation_reason"] = f"Mem sustained >= {MEM_SATURATION_PCT}%: {mem}%"
+                        print(f"  !! SATURATION: Mem {mem}% (sustained)")
+                    prev_high_mem = True
+                else:
+                    prev_high_mem = False
+
+            wave_info["polls"].append(poll_entry)
+            if saturated:
+                break
+
+        wave_info["finished_at"] = ts()
+        results["waves"].append(wave_info)
+
+    results["finished_at"] = ts()
+    if not results["saturation_point"]:
+        results["saturation_point"] = "not reached"
+        results["saturation_reason"] = f"Completed all waves up to {max_jobs} jobs without saturation"
+
+    output.write_text(json.dumps(results, indent=2))
+    print(f"\n{'─' * 72}")
+    print(f"Saturation: {results['saturation_point']} jobs — {results['saturation_reason']}")
+    print(f"Results: {output}")
+
+
+def main():
+    p = argparse.ArgumentParser(description="Orbital worker stress test")
+    p.add_argument("--api", default="https://autonomous-enablements.whydevslovedynatrace.com",
+                   help="Orbital API base URL")
+    p.add_argument("--repo", default="dynatrace-wwse/dt-k8s-operator-enablement-new",
+                   help="GitHub repo to use as test workload (owner/name)")
+    p.add_argument("--arch", default="amd64", choices=["amd64", "arm64"],
+                   help="Worker arch to stress test (default: amd64)")
+    p.add_argument("--max-jobs", type=int, default=14,
+                   help="Max concurrent jobs to attempt (default: 14)")
+    p.add_argument("--step", type=int, default=2,
+                   help="Increment per wave (default: 2)")
+    p.add_argument("--wave-minutes", type=int, default=5,
+                   help="Minutes to observe each concurrency level (default: 5)")
+    p.add_argument("--cookie", default=None,
+                   help="_oauth2_proxy cookie value for authenticated API calls")
+    p.add_argument("--output", default=None,
+                   help="Output JSON file (default: stress-test-<ts>.json)")
+    args = p.parse_args()
+
+    out = Path(args.output) if args.output else Path(f"stress-test-{int(time.time())}.json")
+    run_stress_test(
+        api=args.api,
+        repo=args.repo,
+        arch=args.arch,
+        max_jobs=args.max_jobs,
+        step=args.step,
+        wave_minutes=args.wave_minutes,
+        cookie=args.cookie,
+        output=out,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ops-server/worker-agent/agent.py
+++ b/ops-server/worker-agent/agent.py
@@ -3,7 +3,9 @@
 import asyncio
 import json
 import logging
+import shutil
 import signal
+import subprocess
 import time
 from datetime import datetime, timezone
 
@@ -177,16 +179,66 @@ class WorkerAgent:
             port_pool_key, APP_PROXY_PORT_START, APP_PROXY_PORT_START + APP_PROXY_PORT_COUNT - 1,
         )
 
+    @staticmethod
+    def _collect_metrics() -> dict:
+        """Collect host CPU, memory, disk, and container metrics."""
+        metrics = {}
+        try:
+            import psutil as _ps
+            metrics["cpu_pct"] = str(round(_ps.cpu_percent(interval=None), 1))
+            vm = _ps.virtual_memory()
+            metrics["mem_pct"] = str(round(vm.percent, 1))
+            metrics["mem_used_gb"] = str(round(vm.used / 1024 ** 3, 2))
+            metrics["mem_total_gb"] = str(round(vm.total / 1024 ** 3, 2))
+        except ImportError:
+            # psutil not yet installed — read procfs directly
+            try:
+                with open("/proc/loadavg") as f:
+                    load1 = float(f.read().split()[0])
+                cpu_count = len([l for l in open("/proc/cpuinfo") if l.startswith("processor")])
+                metrics["cpu_pct"] = str(round(min(load1 / max(cpu_count, 1) * 100, 100), 1))
+            except Exception:
+                pass
+            try:
+                info = {}
+                with open("/proc/meminfo") as f:
+                    for line in f:
+                        k, v = line.split(":")
+                        info[k.strip()] = int(v.split()[0])
+                total = info.get("MemTotal", 0)
+                avail = info.get("MemAvailable", 0)
+                if total:
+                    metrics["mem_pct"] = str(round((total - avail) / total * 100, 1))
+                    metrics["mem_total_gb"] = str(round(total / 1024 ** 2, 2))
+                    metrics["mem_used_gb"] = str(round((total - avail) / 1024 ** 2, 2))
+            except Exception:
+                pass
+        try:
+            du = shutil.disk_usage("/")
+            metrics["disk_pct"] = str(round(du.used / du.total * 100, 1))
+        except Exception:
+            pass
+        try:
+            out = subprocess.check_output(
+                ["docker", "ps", "-q"], timeout=3, stderr=subprocess.DEVNULL
+            )
+            metrics["containers_running"] = str(len([l for l in out.splitlines() if l]))
+        except Exception:
+            pass
+        return metrics
+
     async def _heartbeat_loop(self):
         """Send periodic heartbeats to master."""
         worker_key = f"worker:{WORKER_ID}"
         port_pool_key = f"worker:{WORKER_ID}:app_ports_free"
         while self._running:
             try:
+                metrics = await asyncio.get_event_loop().run_in_executor(None, self._collect_metrics)
                 await self.pool.hset(worker_key, mapping={
                     "active_jobs": str(len(self.active_jobs)),
                     "last_heartbeat": datetime.now(timezone.utc).isoformat(),
                     "status": "ready" if len(self.active_jobs) < WORKER_CAPACITY else "busy",
+                    **metrics,
                 })
                 await self.pool.expire(worker_key, REGISTRATION_TTL)
                 await self.pool.expire(port_pool_key, REGISTRATION_TTL)

--- a/ops-server/worker-agent/executor.py
+++ b/ops-server/worker-agent/executor.py
@@ -382,7 +382,9 @@ async def execute_daemon(job: dict, redis_pool=None) -> dict:
     log.info("Cloning %s @ %s for daemon %s", head_repo, ref, job_id)
     await _git_clone(head_repo, ref, repo_dir)
     await _make_world_writable(repo_dir)
-    _write_env_file(repo_dir / ".devcontainer" / ".env")
+    # Per-session provisioned tokens override the worker-level static creds.
+    dt_env_overrides: dict[str, str] | None = job.get("dt_env") or None
+    _write_env_file(repo_dir / ".devcontainer" / ".env", overrides=dt_env_overrides)
 
     start_time = time.time()
     workspace = f"/workspaces/{repo_name}"
@@ -660,14 +662,21 @@ def _redact(token: str) -> str:
     return token[:14] + "***REDACTED***"
 
 
-def _write_env_file(env_path: Path):
-    """Mirror what the GHA workflow writes to .devcontainer/.env."""
+def _write_env_file(env_path: Path, overrides: dict[str, str] | None = None):
+    """Write .devcontainer/.env with DT credentials.
+
+    Uses per-session overrides (provisioned tokens) when provided, falls back
+    to the worker-level static env vars (used by integration tests).
+    """
     env_path.parent.mkdir(parents=True, exist_ok=True)
-    env_path.write_text(
-        f"DT_ENVIRONMENT={DT_ENVIRONMENT}\n"
-        f"DT_OPERATOR_TOKEN={DT_OPERATOR_TOKEN}\n"
-        f"DT_INGEST_TOKEN={DT_INGEST_TOKEN}\n"
-    )
+    resolved = {
+        "DT_ENVIRONMENT":   DT_ENVIRONMENT,
+        "DT_OPERATOR_TOKEN": DT_OPERATOR_TOKEN,
+        "DT_INGEST_TOKEN":  DT_INGEST_TOKEN,
+    }
+    if overrides:
+        resolved.update(overrides)
+    env_path.write_text("".join(f"{k}={v}\n" for k, v in resolved.items() if v))
 
 
 async def _make_world_writable(repo_dir: Path):

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -168,10 +168,59 @@ class WorkerManager:
         except Exception as e:
             log.warning("Failed to free master app proxy port %s: %s", port, e)
 
+    @staticmethod
+    def _collect_metrics() -> dict:
+        """Collect host CPU, memory, disk, and container metrics."""
+        import shutil as _shutil
+        metrics = {}
+        try:
+            import psutil as _ps
+            metrics["cpu_pct"] = str(round(_ps.cpu_percent(interval=None), 1))
+            vm = _ps.virtual_memory()
+            metrics["mem_pct"] = str(round(vm.percent, 1))
+            metrics["mem_used_gb"] = str(round(vm.used / 1024 ** 3, 2))
+            metrics["mem_total_gb"] = str(round(vm.total / 1024 ** 3, 2))
+        except ImportError:
+            try:
+                with open("/proc/loadavg") as f:
+                    load1 = float(f.read().split()[0])
+                cpu_count = len([l for l in open("/proc/cpuinfo") if l.startswith("processor")])
+                metrics["cpu_pct"] = str(round(min(load1 / max(cpu_count, 1) * 100, 100), 1))
+            except Exception:
+                pass
+            try:
+                info = {}
+                with open("/proc/meminfo") as f:
+                    for line in f:
+                        k, v = line.split(":")
+                        info[k.strip()] = int(v.split()[0])
+                total = info.get("MemTotal", 0)
+                avail = info.get("MemAvailable", 0)
+                if total:
+                    metrics["mem_pct"] = str(round((total - avail) / total * 100, 1))
+                    metrics["mem_total_gb"] = str(round(total / 1024 ** 2, 2))
+                    metrics["mem_used_gb"] = str(round((total - avail) / 1024 ** 2, 2))
+            except Exception:
+                pass
+        try:
+            du = _shutil.disk_usage("/")
+            metrics["disk_pct"] = str(round(du.used / du.total * 100, 1))
+        except Exception:
+            pass
+        try:
+            out = subprocess.check_output(
+                ["docker", "ps", "-q"], timeout=3, stderr=subprocess.DEVNULL
+            )
+            metrics["containers_running"] = str(len([l for l in out.splitlines() if l]))
+        except Exception:
+            pass
+        return metrics
+
     async def _master_heartbeat_loop(self):
         """Refresh the master's worker record every 15s so it never expires."""
         while not self._shutdown:
             try:
+                metrics = await asyncio.get_event_loop().run_in_executor(None, self._collect_metrics)
                 await self.pool.hset("worker:master-arm64", mapping={
                     "active_jobs": str(len(self.active_jobs)),
                     "last_heartbeat": datetime.now(timezone.utc).isoformat(),
@@ -179,6 +228,7 @@ class WorkerManager:
                         "ready" if len(self.active_jobs) < MAX_PARALLEL_WORKERS
                         else "busy"
                     ),
+                    **metrics,
                 })
                 await self.pool.expire("worker:master-arm64", 60)
                 await self.pool.expire("worker:master:app_ports_free", 60)


### PR DESCRIPTION
## Summary

Two commits bundled (independent but co-developed this session):

### Orbital dashboard + nightly improvements
- **Fix with AI**: always opens context modal — CI jobs no longer fire directly without user input
- **Nightly error summary**: failed jobs show top-12 common error patterns
- **Framework tests in nightly**: bats unit tests + k3d-basic + k3d-apps run alongside the fleet; `--include-framework` flag added to scheduler + systemd service
- **Worker metrics**: CPU/mem/disk/container counts via psutil in heartbeat loop, rendered as usage bars in dashboard worker cards
- **Stale branch fix**: hardcoded `feature/k3d-default-kind-cnfs` → `main`
- **Stress test tooling**: `ops-server/tools/stress_test.py` for measuring worker capacity (escalating wave test)
- **GitHub Actions**: `.github/workflows/framework-tests.yaml` — scheduled bats unit tests on push/PR/nightly

### Arena token provisioning
- `ops-server/provisioning/` — new package: `DTTokenProvisioner` + `TokenSpec` loader
- Tokens auto-created at session start: `enbl-{repo}-{user}-operator/ingest`, 4h expiry
- Supports both `api_token` (QA/bootstrap) and `oauth2` (app-installed) auth modes
- Per-repo token spec via `.devcontainer/yaml/dt-tokens.yaml`, falls back to framework default
- `ArenaProvisionRequest` accepts `tenantUrl`, `apiToken`, `oauthClientId/Secret`
- Tokens revoked immediately on session terminate
- `executor._write_env_file` accepts per-session overrides → DT operator deploys to correct tenant
- Exec timeout 30s → 120s

## Test plan
- [ ] Nightly run includes framework tests
- [ ] Worker cards show CPU/mem metrics in dashboard
- [ ] Arena provision with `tenantUrl` + `apiToken` creates tokens in DT tenant
- [ ] Session terminate revokes those tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)