### PR TITLE
feat: wildcard subdomain routing — fix astroshop image loading in Orbital

### DIFF
--- a/.devcontainer/post-create-astroshop-test.sh
+++ b/.devcontainer/post-create-astroshop-test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Minimal post-create for wildcard-subdomain testing.
+# Brings up only k3d + astroshop (no DT Operator, no OneAgent).
+# Verifies that images load correctly via the subdomain URL.
+# Usage: triggered automatically when the framework spins a daemon job
+#        pointing to this file as the post-create script.
+
+export SECONDS=0
+source .devcontainer/util/source_framework.sh
+
+setUpTerminal
+startK3dCluster
+
+printInfoSection "Deploying Astroshop (test — no DT components)"
+
+# Astroshop requires x86_64; skip gracefully on ARM
+if [[ "$ARCH" != "x86_64" ]]; then
+  printWarn "Astroshop only supports x86_64 — skipping"
+  finalizePostCreation
+  exit 0
+fi
+
+kubectl create ns astroshop 2>/dev/null || true
+kubectl apply -n astroshop -f "$FRAMEWORK_APPS_PATH/astroshop/yaml/astroshop-deployment.yaml"
+
+# Skip DT credentials — no operator/ingest token needed for this test
+kubectl -n astroshop create secret generic dt-credentials \
+  --from-literal="DT_API_TOKEN=dummy" \
+  --from-literal="DT_ENDPOINT=http://localhost:4318" 2>/dev/null || true
+
+waitForAllReadyPods "astroshop"
+registerAstroshopIngress "astroshop"
+
+printInfoSection "Astroshop test deployment complete"
+printInfo "App URL: $(getAppURL astroshop)"
+printInfo "Verify images: $(getAppURL astroshop)images/products/LensCleaningKit.jpg"
+
+finalizePostCreation

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
-#loading functions to script
+# TEST BRANCH: minimal post-create for wildcard-subdomain astroshop verification.
+# Brings up k3d + astroshop only (no DT Operator, no OneAgent).
+# This post-create is intentionally stripped down for the fix/wildcard-subdomain-app-routing branch.
 export SECONDS=0
 source .devcontainer/util/source_framework.sh
 
 setUpTerminal
-
-# Start Kubernetes cluster (K3s by default, or Kind if CLUSTER_ENGINE=kind)
-startCluster
-
+startK3dCluster
 installK9s
 
-# Dynatrace Operator is deployed automatically, secrets are read from the env.
-dynatraceDeployOperator
+if [[ "$ARCH" != "x86_64" ]]; then
+  printWarn "Astroshop only supports x86_64 — skipping deployment"
+  finalizePostCreation
+  exit 0
+fi
 
-# You can deploy CNFS (for CNFS use Kind) or AppOnly (use k3d)
-#deployCloudNative
-deployApplicationMonitoring
+printInfoSection "Deploying Astroshop (wildcard subdomain test — no DT components)"
 
-# The TODO App will be deployed as a sample
-deployTodoApp
+kubectl create ns astroshop 2>/dev/null || true
+kubectl apply -n astroshop -f "$FRAMEWORK_APPS_PATH/astroshop/yaml/astroshop-deployment.yaml"
+kubectl -n astroshop create secret generic dt-credentials \
+  --from-literal="DT_API_TOKEN=test-only" \
+  --from-literal="DT_ENDPOINT=http://localhost:4318" 2>/dev/null || true
 
-# If you want to deploy your own App, just create a function in the functions.sh file and call it here.
-# deployMyCustomApp
+waitForAllReadyPods "astroshop"
+registerAstroshopIngress "astroshop"
 
-# This step is needed, do not remove it
-# it'll verify if there are error in the logs and will show them in the greeting as well a monitoring 
 finalizePostCreation
-
-printInfoSection "Your dev container finished creating"
+printInfoSection "Astroshop ready — verify images at: $(getAppURL astroshop)images/products/LensCleaningKit.jpg"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
-# TEST BRANCH: minimal post-create for wildcard-subdomain astroshop verification.
-# Brings up k3d + astroshop only (no DT Operator, no OneAgent).
-# This post-create is intentionally stripped down for the fix/wildcard-subdomain-app-routing branch.
+#loading functions to script
 export SECONDS=0
 source .devcontainer/util/source_framework.sh
 
 setUpTerminal
-startK3dCluster
+
+# Start Kubernetes cluster (K3s by default, or Kind if CLUSTER_ENGINE=kind)
+startCluster
+
 installK9s
 
-if [[ "$ARCH" != "x86_64" ]]; then
-  printWarn "Astroshop only supports x86_64 — skipping deployment"
-  finalizePostCreation
-  exit 0
-fi
+# Dynatrace Operator is deployed automatically, secrets are read from the env.
+dynatraceDeployOperator
 
-printInfoSection "Deploying Astroshop (wildcard subdomain test — no DT components)"
+# You can deploy CNFS (for CNFS use Kind) or AppOnly (use k3d)
+#deployCloudNative
+deployApplicationMonitoring
 
-kubectl create ns astroshop 2>/dev/null || true
-kubectl apply -n astroshop -f "$FRAMEWORK_APPS_PATH/astroshop/yaml/astroshop-deployment.yaml"
-kubectl -n astroshop create secret generic dt-credentials \
-  --from-literal="DT_API_TOKEN=test-only" \
-  --from-literal="DT_ENDPOINT=http://localhost:4318" 2>/dev/null || true
+# The TODO App will be deployed as a sample
+deployTodoApp
 
-waitForAllReadyPods "astroshop"
-registerAstroshopIngress "astroshop"
+# If you want to deploy your own App, just create a function in the functions.sh file and call it here.
+# deployMyCustomApp
 
+# This step is needed, do not remove it
+# it'll verify if there are error in the logs and will show them in the greeting as well a monitoring 
 finalizePostCreation
-printInfoSection "Astroshop ready — verify images at: $(getAppURL astroshop)images/products/LensCleaningKit.jpg"
+
+printInfoSection "Your dev container finished creating"

--- a/.devcontainer/util/functions.sh
+++ b/.devcontainer/util/functions.sh
@@ -1810,6 +1810,25 @@ detectHostname() {
   fi
 }
 
+computeOrbitalSubdomain() {
+  # Returns the wildcard subdomain label for an app running in Orbital.
+  # Format: {appname}--{job_slug}
+  # where job_slug is a sanitized, length-capped slice of ORBITAL_JOB_ID.
+  # The full label must fit in 63 chars (DNS label limit).
+  # Used by getAppURL and registerApp to build the canonical URL
+  # https://{appname}--{slug}.autonomous-enablements.whydevslovedynatrace.com
+  local app_name="$1"
+  local jid="${ORBITAL_JOB_ID:-}"
+  if [[ -z "$jid" ]]; then echo ""; return 0; fi
+  # Max label = 63; separator "--" = 2; leave remainder for job slug
+  local max_slug=$(( 61 - ${#app_name} ))
+  if [[ $max_slug -lt 4 ]]; then max_slug=4; fi
+  local slug="${jid:0:$max_slug}"
+  # Sanitize: only lowercase alphanum and hyphens; strip trailing hyphens
+  slug=$(echo "$slug" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9-' | sed 's/-*$//')
+  echo "${app_name}--${slug}"
+}
+
 installIngressController() {
   # Installs the nginx ingress controller in the Kind cluster.
   # Installs the nginx ingress controller.
@@ -1846,11 +1865,17 @@ installIngressController() {
 getAppURL() {
   # Returns the user-facing URL for an app based on environment type.
   # Usage: getAppURL <app-name>
+  # Orbital:    wildcard subdomain {appname}--{job_slug}.autonomous-enablements.*
   # Codespaces: port 80 is forwarded; catch-all ingress rule routes the request.
+  # Local/other: magic-DNS sslip.io URL
   local app_name="$1"
   local detected_ip
 
-  if [[ "$CODESPACES" == true ]]; then
+  if [[ "$(detectRunEnvironment)" == "orbital" ]] && [[ -n "${ORBITAL_JOB_ID:-}" ]]; then
+    local subdomain
+    subdomain=$(computeOrbitalSubdomain "$app_name")
+    echo "https://${subdomain}.autonomous-enablements.whydevslovedynatrace.com"
+  elif [[ "$CODESPACES" == true ]]; then
     echo "https://${CODESPACE_NAME}-80.app.github.dev"
   else
     detected_ip=$(detectIP)
@@ -1944,9 +1969,15 @@ INGRESSEOF
   # cs_port stays empty — Codespaces uses port 80 via the catch-all ingress rule
   local cs_port=""
 
-  # Write to app registry
+  # Compute the Orbital wildcard subdomain (empty when not in Orbital or no ORBITAL_JOB_ID)
+  local orbital_subdomain=""
+  if [[ "$(detectRunEnvironment)" == "orbital" ]] && [[ -n "${ORBITAL_JOB_ID:-}" ]]; then
+    orbital_subdomain=$(computeOrbitalSubdomain "$app_name")
+  fi
+
+  # Write to app registry — field 7 is the Orbital subdomain label (empty outside Orbital)
   mkdir -p "$(dirname "$APP_REGISTRY")"
-  echo "${app_name}|${namespace}|${service_name}|${service_port}|${ingress_host}|${cs_port}" >> "$APP_REGISTRY"
+  echo "${app_name}|${namespace}|${service_name}|${service_port}|${ingress_host}|${cs_port}|${orbital_subdomain}" >> "$APP_REGISTRY"
 
   local app_url
   app_url=$(getAppURL "$app_name" "$cs_port")
@@ -2028,11 +2059,18 @@ ASTROINGRESSEOF
 
   # cs_port stays empty — Codespaces uses port 80 via catch-all ingress rule
   local cs_port=""
+
+  # Compute the Orbital wildcard subdomain (empty when not in Orbital)
+  local orbital_subdomain=""
+  if [[ "$(detectRunEnvironment)" == "orbital" ]] && [[ -n "${ORBITAL_JOB_ID:-}" ]]; then
+    orbital_subdomain=$(computeOrbitalSubdomain "astroshop")
+  fi
+
   mkdir -p "$(dirname "$APP_REGISTRY")"
   # Remove old entry if exists
   grep -v "^astroshop|" "$APP_REGISTRY" > "${APP_REGISTRY}.tmp" 2>/dev/null || true
   mv "${APP_REGISTRY}.tmp" "$APP_REGISTRY" 2>/dev/null || true
-  echo "astroshop|${namespace}|frontend-proxy|8080|${ingress_host}|${cs_port}" >> "$APP_REGISTRY"
+  echo "astroshop|${namespace}|frontend-proxy|8080|${ingress_host}|${cs_port}|${orbital_subdomain}" >> "$APP_REGISTRY"
 
   local app_url
   app_url=$(getAppURL "astroshop" "$cs_port")

--- a/.devcontainer/util/functions.sh
+++ b/.devcontainer/util/functions.sh
@@ -2849,6 +2849,9 @@ verifyCodespaceCreation(){
     if [ -n "$containername" ]; then
       raw_errors=$(docker logs "$containername" 2>&1 | grep -i -E 'error|failed' || true)
     fi
+  elif [[ $INSTANTIATION_TYPE == "orbital" ]]; then
+    # Inside Orbital Sysbox; executor streams logs to Redis — no extra collection needed.
+    true
   else
     printWarn "Unknown instantiation type: $INSTANTIATION_TYPE"
   fi

--- a/.devcontainer/util/functions.sh
+++ b/.devcontainer/util/functions.sh
@@ -1813,17 +1813,28 @@ detectHostname() {
 computeOrbitalSubdomain() {
   # Returns the wildcard subdomain label for an app running in Orbital.
   # Format: {appname}--{job_slug}
-  # where job_slug is a sanitized, length-capped slice of ORBITAL_JOB_ID.
+  # where job_slug replaces the verbose worker prefix with a short ID:
+  #   worker-x86_64-34ea2d-repo-ts-hex  →  34ea2d-repo-ts-hex
+  #   master-repo-ts-hex                →  master-repo-ts-hex
   # The full label must fit in 63 chars (DNS label limit).
   # Used by getAppURL and registerApp to build the canonical URL
   # https://{appname}--{slug}.autonomous-enablements.whydevslovedynatrace.com
   local app_name="$1"
   local jid="${ORBITAL_JOB_ID:-}"
   if [[ -z "$jid" ]]; then echo ""; return 0; fi
+
+  # Shorten: strip "worker-{arch}-" prefix, keeping only the 6-char hex + rest
+  local slug_base
+  if [[ "$jid" =~ ^worker-[^-]+-([a-f0-9]{6})-(.+)$ ]]; then
+    slug_base="${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
+  else
+    slug_base="$jid"
+  fi
+
   # Max label = 63; separator "--" = 2; leave remainder for job slug
   local max_slug=$(( 61 - ${#app_name} ))
   if [[ $max_slug -lt 4 ]]; then max_slug=4; fi
-  local slug="${jid:0:$max_slug}"
+  local slug="${slug_base:0:$max_slug}"
   # Sanitize: only lowercase alphanum and hyphens; strip trailing hyphens
   slug=$(echo "$slug" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9-' | sed 's/-*$//')
   echo "${app_name}--${slug}"

--- a/.devcontainer/util/variables.sh
+++ b/.devcontainer/util/variables.sh
@@ -69,13 +69,15 @@ if [ -z "$GITHUB_REPOSITORY" ]; then
 fi
 
 # Calculating instantiation type
-if [[ $CODESPACES == true ]]; then
+if [[ "${ORBITAL_ENVIRONMENT:-}" == "true" ]]; then
+  INSTANTIATION_TYPE="orbital"
+elif [[ $CODESPACES == true ]]; then
   INSTANTIATION_TYPE="github-codespaces"
 elif [[ $REMOTE_CONTAINERS == true ]]; then
   INSTANTIATION_TYPE="remote-container"
 elif [[ -n $GITHUB_WORKFLOW ]] || [[ -n $GITHUB_STEP_SUMMARY ]]; then
   INSTANTIATION_TYPE="github-workflow"
-else 
+else
   INSTANTIATION_TYPE="local-docker-container"
 fi
 export INSTANTIATION_TYPE=$INSTANTIATION_TYPE

--- a/docs/instantiation-types.md
+++ b/docs/instantiation-types.md
@@ -153,33 +153,45 @@ Every app gets a dedicated HTTPS URL derived from the job ID:
 https://{appname}--{job_slug}.autonomous-enablements.whydevslovedynatrace.com
 ```
 
-`job_slug` is the first 52 characters of the job ID, lower-cased, with non-`[a-z0-9-]`
-characters removed (e.g. `_` in `x86_64` is stripped). The total subdomain label stays
-within the 63-character DNS limit.
+`job_slug` is derived from the job ID with the verbose worker prefix shortened:
 
-**Example:**
+- Worker jobs: `worker-x86_64-34ea2d-...` → `34ea2d-...` (6-char hex replaces `worker-{arch}-`)
+- Master jobs: `master-...` stays as-is
+
+The result is then lower-cased, non-`[a-z0-9-]` characters stripped, and truncated so the
+full DNS label (`{appname}--{slug}`) stays within the 63-character limit.
+
+**Examples:**
 
 ```
-https://astroshop--worker-x8664-a99883-codespaces-framework-1779883231.autonomous-enablements.whydevslovedynatrace.com
+# AMD worker job
+https://astroshop--34ea2d-codespaces-framework-1779883231-abc123.autonomous-enablements.whydevslovedynatrace.com
+
+# Master job
+https://astroshop--master-codespaces-framework-1779883231-abc123.autonomous-enablements.whydevslovedynatrace.com
 ```
 
 #### How routing works
+
+Works with both `k3d` and `kind` cluster engines — the outer proxy layer is
+engine-agnostic; only the inner nginx ingress provider differs (`cloud` for k3d,
+`kind` for kind).
 
 ```
 Browser → nginx (wildcard TLS block)
          → FastAPI /proxy-subdomain/{path}
          → _find_job_by_subdomain() [Redis lookup via normalized prefix scan]
          → http://{worker_ip}:{app_proxy_port}/{path}
-              Host: {app}.{worker_ip}.sslip.io   ← k3d nginx-ingress routes on this
-         → k3d nginx-ingress → Envoy / service
+              Host: {app}.{worker_ip}.sslip.io   ← nginx ingress routes on this
+         → nginx ingress → Envoy / service
 ```
 
 Key points:
 
 - **No HTML/CSS rewriting.** Every app is served at root `/` so Next.js, SPAs, and
   static asset resolvers all work without `basePath` hacks.
-- The k3d ingress always uses the sslip.io host internally. The public wildcard URL
-  is a separate nginx front-end that sets the `Host` header for k3d.
+- The nginx ingress always uses the sslip.io host internally. The public wildcard URL
+  is a separate nginx front-end that sets the `Host` header for the ingress.
 - `app_proxy_port` is a fixed host port (32000–32005) published by the Sysbox
   container and stored in Redis on job start.
 

--- a/docs/instantiation-types.md
+++ b/docs/instantiation-types.md
@@ -138,6 +138,71 @@ The nginx ingress has a **catch-all rule** (no Host restriction) that routes all
 - Apps are accessible at `http://<app>.<your-ip>.sslip.io` — the host's port 80 routes to the nginx ingress inside the container.
 
 
+### 4. 🛰️ Orbital (Sysbox / Training delivery)
+
+Orbital is the Dynatrace WWSE self-service training platform. Each job runs inside a
+[Sysbox](https://github.com/nestybox/sysbox) container (Docker-in-Docker without
+`--privileged`) on an EC2 worker. Orbital is the only instantiation type that uses
+**wildcard subdomains** instead of port forwarding.
+
+#### How apps are exposed in Orbital
+
+Every app gets a dedicated HTTPS URL derived from the job ID:
+
+```
+https://{appname}--{job_slug}.autonomous-enablements.whydevslovedynatrace.com
+```
+
+`job_slug` is the first 52 characters of the job ID, lower-cased, with non-`[a-z0-9-]`
+characters removed (e.g. `_` in `x86_64` is stripped). The total subdomain label stays
+within the 63-character DNS limit.
+
+**Example:**
+
+```
+https://astroshop--worker-x8664-a99883-codespaces-framework-1779883231.autonomous-enablements.whydevslovedynatrace.com
+```
+
+#### How routing works
+
+```
+Browser → nginx (wildcard TLS block)
+         → FastAPI /proxy-subdomain/{path}
+         → _find_job_by_subdomain() [Redis lookup via normalized prefix scan]
+         → http://{worker_ip}:{app_proxy_port}/{path}
+              Host: {app}.{worker_ip}.sslip.io   ← k3d nginx-ingress routes on this
+         → k3d nginx-ingress → Envoy / service
+```
+
+Key points:
+
+- **No HTML/CSS rewriting.** Every app is served at root `/` so Next.js, SPAs, and
+  static asset resolvers all work without `basePath` hacks.
+- The k3d ingress always uses the sslip.io host internally. The public wildcard URL
+  is a separate nginx front-end that sets the `Host` header for k3d.
+- `app_proxy_port` is a fixed host port (32000–32005) published by the Sysbox
+  container and stored in Redis on job start.
+
+#### Environment signals
+
+| Variable | Value | Set by |
+|---|---|---|
+| `ORBITAL_ENVIRONMENT` | `true` | executor.py (injected into all Orbital container jobs) |
+| `ORBITAL_JOB_ID` | `<job_id>` | executor.py (daemon/integration-test; used to compute subdomain slug) |
+| `INSTANTIATION_TYPE` | `orbital` | `variables.sh` (reads `ORBITAL_ENVIRONMENT`) |
+
+`detectRunEnvironment()` returns `"orbital"` when `ORBITAL_ENVIRONMENT=true`, which
+`getAppURL()` and `registerApp()` use to build the wildcard subdomain URL instead of
+the sslip.io or Codespaces URL.
+
+!!! info "DNS & TLS requirements"
+    The wildcard subdomain requires:
+
+    - DNS: `*.autonomous-enablements.whydevslovedynatrace.com A 18.134.158.252` (Google Cloud DNS)
+    - TLS: a Let's Encrypt wildcard cert for `*.autonomous-enablements.whydevslovedynatrace.com`
+      issued via DNS-01 challenge (manual renewal every 90 days)
+    - nginx: `server_names_hash_bucket_size 128` in `/etc/nginx/nginx.conf`
+
 
 ## ⚡ Quick Comparison
 
@@ -146,6 +211,7 @@ The nginx ingress has a **catch-all rule** (no Host restriction) that routes all
 | ☁️ Codespaces         | GitHub Cloud         | ❌             | ✅         | ❌           | Auto-injected   | Auto            | Quick onboarding, demos   |
 | 🖥️ VS Code DevContainer | Provided Infrastructure | ✅             | ✅         | ✅           | Auto/manual     | Auto            | Full-featured local dev   |
 | 🐳 Local Container    | Provided Infrastructure | ❌             | ✅         | ✅           | Manual/`.env`   | Manual/Makefile | Reproducible local dev    |
+| 🛰️ Orbital            | EC2 Sysbox Workers   | ❌             | ✅         | ❌           | Auto-injected   | Wildcard subdomain | Training delivery      |
 
 
 ## 🔐 Secrets & Environment

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -2199,12 +2199,20 @@ async def _find_job_by_subdomain(subdomain: str) -> tuple[str, dict, dict]:
         if app_info:
             return job_prefix, meta, app_info
 
-    # Prefix scan for truncated long job IDs
+    # Prefix scan for truncated long job IDs.
+    # The slug normalises the job_id (lowercases, strips non-[a-z0-9-] chars like _,
+    # then truncates), so we must apply the same transform before comparing.
+    import re as _re
+    def _slug_normalize(s: str) -> str:
+        return _re.sub(r'[^a-z0-9-]', '', s.lower())
+
+    norm_prefix = _slug_normalize(job_prefix)
     keys = await pool.keys("job:running:*")
     for raw_key in keys:
         key = raw_key.decode() if isinstance(raw_key, bytes) else raw_key
         job_id = key.removeprefix("job:running:")
-        if not job_id.startswith(job_prefix):
+        norm_id = _slug_normalize(job_id)
+        if not norm_id.startswith(norm_prefix):
             continue
         meta = await pool.hgetall(key)
         if not meta:

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -2172,10 +2172,49 @@ async def _read_app_registry(job_id: str, meta: dict) -> list[dict]:
                 "service": parts[2],
                 "port": parts[3],
                 "ingress_host": parts[4],
+                # field 7: orbital subdomain label e.g. "astroshop--enablement-674b15115240"
+                "orbital_subdomain": parts[6].strip() if len(parts) >= 7 else "",
             })
 
     await pool.set(cache_key, json.dumps(apps), ex=60)
     return apps
+
+
+async def _find_job_by_subdomain(subdomain: str) -> tuple[str, dict, dict]:
+    """Find a running job and app info from a wildcard subdomain label.
+
+    subdomain format: {appname}--{job_id_prefix}
+    Returns (job_id, job_meta, app_info) or ("", {}, {}) if not found.
+    """
+    if "--" not in subdomain:
+        return "", {}, {}
+
+    appname, job_prefix = subdomain.split("--", 1)
+
+    # Direct lookup first (covers arena job IDs which fit untruncated)
+    meta = await pool.hgetall(f"job:running:{job_prefix}")
+    if meta:
+        apps = await _read_app_registry(job_prefix, meta)
+        app_info = next((a for a in apps if a["name"] == appname), None)
+        if app_info:
+            return job_prefix, meta, app_info
+
+    # Prefix scan for truncated long job IDs
+    keys = await pool.keys("job:running:*")
+    for raw_key in keys:
+        key = raw_key.decode() if isinstance(raw_key, bytes) else raw_key
+        job_id = key.removeprefix("job:running:")
+        if not job_id.startswith(job_prefix):
+            continue
+        meta = await pool.hgetall(key)
+        if not meta:
+            continue
+        apps = await _read_app_registry(job_id, meta)
+        app_info = next((a for a in apps if a["name"] == appname), None)
+        if app_info:
+            return job_id, meta, app_info
+
+    return "", {}, {}
 
 
 @app.get("/api/jobs/{job_id}/apps")
@@ -2186,12 +2225,16 @@ async def api_job_apps(job_id: str):
         raise HTTPException(status_code=404, detail="job not running")
 
     apps = await _read_app_registry(job_id, meta)
-    return {
-        "apps": [
-            {**a, "proxy_url": f"/apps/{job_id}/{a['name']}/"}
-            for a in apps
-        ]
-    }
+    result = []
+    for a in apps:
+        entry = {**a, "proxy_url": f"/apps/{job_id}/{a['name']}/"}
+        if a.get("orbital_subdomain"):
+            entry["subdomain_url"] = (
+                f"https://{a['orbital_subdomain']}"
+                ".autonomous-enablements.whydevslovedynatrace.com/"
+            )
+        result.append(entry)
+    return {"apps": result}
 
 
 def _rewrite_proxy_body(content: bytes, base_path: str, content_type: str) -> bytes:
@@ -2461,6 +2504,109 @@ async def proxy_job_app(job_id: str, app_name: str, request: Request, path: str 
         status_code=upstream.status_code,
         headers=resp_headers,
         media_type=content_type or None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wildcard-subdomain app proxy
+# ---------------------------------------------------------------------------
+# Handles requests routed via nginx from wildcard subdomains:
+#   {appname}--{job_slug}.autonomous-enablements.whydevslovedynatrace.com
+#
+# nginx rewrites the path to /proxy-subdomain/<original-path> and sets
+# the X-App-Subdomain header to the subdomain label before forwarding here.
+# Unlike /apps/{job_id}/{app_name}/ there is NO HTML rewriting — the app
+# runs at root so all asset paths resolve correctly without patching.
+# ---------------------------------------------------------------------------
+
+@app.api_route(
+    "/proxy-subdomain/{path:path}",
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"],
+)
+async def proxy_subdomain_app(request: Request, path: str):
+    """Reverse-proxy to an app via its wildcard subdomain URL.
+
+    No HTML/CSS rewriting — the app is served at root (/), so all relative
+    asset paths resolve naturally without a basePath shim.
+    """
+    from fastapi.responses import Response as PlainResponse
+
+    subdomain = request.headers.get("x-app-subdomain", "")
+    if not subdomain or "--" not in subdomain:
+        raise HTTPException(status_code=400, detail="missing or invalid X-App-Subdomain header")
+
+    job_id, meta, app_info = await _find_job_by_subdomain(subdomain)
+    if not job_id:
+        raise HTTPException(status_code=404, detail=f"no running job found for subdomain '{subdomain}'")
+
+    app_proxy_port = meta.get("app_proxy_port")
+    if not app_proxy_port:
+        return HTMLResponse(
+            "<html><body style='font-family:sans-serif;padding:32px;background:#050810;color:#d0d7de'>"
+            "<h3 style='color:#f0b429'>App proxy not available</h3>"
+            "<p>This job was started before app port forwarding was added.</p>"
+            "<p>Terminate and start a new session to enable app preview.</p>"
+            "</body></html>",
+            status_code=503,
+        )
+
+    worker_id = meta.get("worker_id", "")
+    if worker_id.startswith("worker-"):
+        worker_hash = await pool.hgetall(f"worker:{worker_id}")
+        target_ip = worker_hash.get("host", "127.0.0.1")
+    else:
+        target_ip = "127.0.0.1"
+
+    target_url = f"http://{target_ip}:{app_proxy_port}/{path}"
+    if request.url.query:
+        target_url += f"?{request.url.query}"
+
+    forward_headers = {
+        "Host": app_info["ingress_host"],
+    }
+    for h in ("accept", "accept-language", "cookie",
+               "content-type", "cache-control", "x-requested-with",
+               "accept-encoding"):
+        if h in request.headers:
+            forward_headers[h] = request.headers[h]
+
+    body = await request.body()
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
+            upstream = await client.request(
+                method=request.method,
+                url=target_url,
+                headers=forward_headers,
+                content=body,
+            )
+    except httpx.ConnectError:
+        raise HTTPException(status_code=502, detail="could not connect to app")
+    except httpx.TimeoutException:
+        raise HTTPException(status_code=504, detail="upstream app timed out")
+
+    skip = {"transfer-encoding", "connection", "keep-alive", "upgrade",
+            "proxy-authenticate", "proxy-authorization", "te", "trailers",
+            "x-frame-options", "content-security-policy",
+            "content-security-policy-report-only"}
+    resp_headers = {
+        k: v for k, v in upstream.headers.items()
+        if k.lower() not in skip
+    }
+
+    # Rewrite Location redirects to stay on the same subdomain (no path prefix needed)
+    location = resp_headers.get("location", "")
+    if location:
+        if location.startswith("http://") or location.startswith("https://"):
+            # Absolute redirect — preserve as-is (app is at root, no prefix to fix)
+            pass
+        # Root-relative redirects are correct because basePath is /
+
+    return PlainResponse(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        headers=resp_headers,
+        media_type=upstream.headers.get("content-type") or None,
     )
 
 
@@ -3299,15 +3445,20 @@ async function pollApps() {{
 
 class ArenaExecRequest(BaseModel):
     command: str
+    # When True, run inside an interactive zsh (-i) so .zshrc / my_functions.sh are sourced.
+    # Use for STEP_SETUP commands that call shell functions. Default False (faster, no profile).
+    interactive: bool = False
 
 
 @app.post("/api/arena/sessions/{job_id}/exec")
 async def api_arena_session_exec(job_id: str, body: ArenaExecRequest):
-    """Run a non-interactive command inside the training container.
+    """Run a command inside the training container.
 
-    Uses the same SSH→docker-exec chain as the PTY bridge but without a TTY,
-    so the output can be captured and returned as JSON for shell-validation
-    question types.
+    Uses the same SSH→docker-exec chain as the PTY bridge but without a TTY.
+    Set interactive=True to load .zshrc (required for shell functions defined
+    in my_functions.sh, e.g. dynatraceEvalReadSaveCredentials, generateDynakube).
+
+    All executions are appended to job:exec-log:{job_id} in Redis for auditing.
 
     Returns: { stdout, stderr, exitCode }
     """
@@ -3322,15 +3473,14 @@ async def api_arena_session_exec(job_id: str, body: ArenaExecRequest):
 
     worker_id = meta.get("worker_id", "")
     repo = meta.get("repo", "")
-    # repo is stored as "org/repo-name"; workspace only uses the repo-name part
     repo_name = repo.split("/")[-1] if "/" in repo else repo
     container = meta.get("sb_name") or f"sb-{job_id[-32:]}"
 
-    # Match PTY bridge pattern: no outer shell wrapper — Sysbox container has docker but not bash.
-    # PTY: docker exec sb-{id} docker exec -it -w /workspaces/{repo} dt zsh
+    # interactive=True: zsh -i loads .zshrc so my_functions.sh functions are available
+    zsh_flag = "-ic" if body.interactive else "-c"
     cmd_args = ["docker", "exec", container,
                 "docker", "exec", "-w", f"/workspaces/{repo_name}", "dt",
-                "zsh", "-c", body.command]
+                "zsh", zsh_flag, body.command]
 
     worker_rec = await pool.hgetall(f"worker:{worker_id}") if worker_id.startswith("worker-") else {}
     ssh_host = worker_rec.get("ssh_host", "")
@@ -3340,6 +3490,7 @@ async def api_arena_session_exec(job_id: str, body: ArenaExecRequest):
     else:
         full_cmd = cmd_args
 
+    ts = datetime.utcnow().isoformat(timespec="seconds") + "Z"
     try:
         proc = await _asyncio.create_subprocess_exec(
             *full_cmd,
@@ -3347,15 +3498,75 @@ async def api_arena_session_exec(job_id: str, body: ArenaExecRequest):
             stderr=_asyncio.subprocess.PIPE,
         )
         stdout_b, stderr_b = await _asyncio.wait_for(proc.communicate(), timeout=120)
-        return {
+        result = {
             "stdout": stdout_b.decode("utf-8", errors="replace"),
             "stderr": stderr_b.decode("utf-8", errors="replace"),
             "exitCode": proc.returncode,
         }
     except _asyncio.TimeoutError:
-        return {"stdout": "", "stderr": "Command timed out after 120 seconds", "exitCode": -1}
+        result = {"stdout": "", "stderr": "Command timed out after 120 seconds", "exitCode": -1}
     except Exception as exc:
-        return {"stdout": "", "stderr": str(exc), "exitCode": -1}
+        result = {"stdout": "", "stderr": str(exc), "exitCode": -1}
+
+    # Append to per-job exec audit log (capped at 500 entries, 24h TTL)
+    log_key = f"job:exec-log:{job_id}"
+    entry = json.dumps({
+        "ts": ts,
+        "command": body.command,
+        "interactive": body.interactive,
+        "exitCode": result["exitCode"],
+        "stdout": result["stdout"][:2000],
+        "stderr": result["stderr"][:500],
+    })
+    try:
+        await pool.rpush(log_key, entry)
+        await pool.ltrim(log_key, -500, -1)
+        await pool.expire(log_key, 86400)
+    except Exception as log_err:
+        log.warning("Could not write exec-log for %s: %s", job_id, log_err)
+
+    return result
+
+
+@app.post("/api/arena/sessions/{job_id}/terminate")
+async def api_arena_terminate(job_id: str):
+    """Terminate a training session from the Arena app (no oauth2-proxy auth required).
+
+    Publishes on ``ops:terminate`` — the worker kills the Sysbox container and
+    cleans up Redis state. Mirrors /api/jobs/{job_id}/terminate but skips the
+    writer-role check so the Dynatrace app function can call it with just the
+    ORBITAL_TOKEN Bearer header.
+
+    Returns 404 if the job is not currently running.
+    """
+    if not await pool.exists(f"job:running:{job_id}"):
+        in_completed = await pool.exists(f"job:log:{job_id}")
+        detail = (
+            f"Job {job_id} has already completed."
+            if in_completed else
+            f"Job {job_id} is not running."
+        )
+        raise HTTPException(404, detail)
+
+    # Best-effort: revoke provisioned DT tokens
+    meta = await pool.hgetall(f"job:running:{job_id}")
+    if meta.get("dt_token_ids") and meta.get("dt_tenant_url"):
+        from provisioning import DTTokenProvisioner
+        try:
+            token_ids = json.loads(meta["dt_token_ids"])
+            provisioner = DTTokenProvisioner(
+                tenant_url=meta["dt_tenant_url"],
+                api_token=meta.get("dt_auth_token", ""),
+                oauth_client_id=meta.get("dt_oauth_client_id", ""),
+                oauth_client_secret=meta.get("dt_oauth_client_secret", ""),
+            )
+            asyncio.create_task(provisioner.revoke_tokens(token_ids))
+        except Exception as exc:
+            log.warning("Could not initiate token revocation for %s: %s", job_id, exc)
+
+    await pool.publish("ops:terminate", job_id)
+    log.info("Arena termination requested for %s", job_id)
+    return {"status": "termination_requested", "job_id": job_id}
 
 
 # ── Framework test suites ─────────────────────────────────────────────────────

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -2585,10 +2585,11 @@ async def proxy_subdomain_app(request: Request, path: str):
         "Host": app_info["ingress_host"],
     }
     for h in ("accept", "accept-language", "cookie",
-               "content-type", "cache-control", "x-requested-with",
-               "accept-encoding"):
+               "content-type", "cache-control", "x-requested-with"):
         if h in request.headers:
             forward_headers[h] = request.headers[h]
+    # accept-encoding intentionally not forwarded — we need plain bytes to
+    # rewrite localhost URLs in HTML without re-compressing the body.
 
     body = await request.body()
 
@@ -2608,25 +2609,31 @@ async def proxy_subdomain_app(request: Request, path: str):
     skip = {"transfer-encoding", "connection", "keep-alive", "upgrade",
             "proxy-authenticate", "proxy-authorization", "te", "trailers",
             "x-frame-options", "content-security-policy",
-            "content-security-policy-report-only"}
+            "content-security-policy-report-only",
+            "content-encoding", "content-length"}
     resp_headers = {
         k: v for k, v in upstream.headers.items()
         if k.lower() not in skip
     }
 
-    # Rewrite Location redirects to stay on the same subdomain (no path prefix needed)
-    location = resp_headers.get("location", "")
-    if location:
-        if location.startswith("http://") or location.startswith("https://"):
-            # Absolute redirect — preserve as-is (app is at root, no prefix to fix)
-            pass
-        # Root-relative redirects are correct because basePath is /
+    content = upstream.content
+    content_type = upstream.headers.get("content-type", "")
+
+    # Rewrite hardcoded localhost:8080 in HTML bodies.
+    # Next.js imageLoader uses NEXT_PUBLIC_FRONTEND_ADDR which is baked to
+    # http://localhost:8080 at image build time; browsers can't reach that.
+    if "text/html" in content_type and b"localhost:8080" in content:
+        public_host = request.headers.get("host", "")
+        if public_host:
+            pub = f"https://{public_host}".encode()
+            content = content.replace(b"http://localhost:8080", pub)
+            content = content.replace(b"https://localhost:8080", pub)
 
     return PlainResponse(
-        content=upstream.content,
+        content=content,
         status_code=upstream.status_code,
         headers=resp_headers,
-        media_type=upstream.headers.get("content-type") or None,
+        media_type=content_type or None,
     )
 
 

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -2199,20 +2199,32 @@ async def _find_job_by_subdomain(subdomain: str) -> tuple[str, dict, dict]:
         if app_info:
             return job_prefix, meta, app_info
 
-    # Prefix scan for truncated long job IDs.
-    # The slug normalises the job_id (lowercases, strips non-[a-z0-9-] chars like _,
-    # then truncates), so we must apply the same transform before comparing.
+    # Prefix scan for truncated/shortened job IDs.
+    # computeOrbitalSubdomain in functions.sh:
+    #   1. strips "worker-{arch}-" prefix, keeping "{hex6}-{rest}"  (or keeps "master-{rest}")
+    #   2. lowercases + strips non-[a-z0-9-] chars (e.g. _ in x86_64)
+    #   3. truncates to DNS label budget
+    # We must apply the same transform to each job_id before comparing.
     import re as _re
     def _slug_normalize(s: str) -> str:
         return _re.sub(r'[^a-z0-9-]', '', s.lower())
+
+    def _slug_short(s: str) -> str:
+        """Mirror computeOrbitalSubdomain: strip worker-{arch}- prefix."""
+        m = _re.match(r'^worker-[^-]+-([a-f0-9]{6})-(.+)$', s)
+        if m:
+            return f"{m.group(1)}-{m.group(2)}"
+        return s
 
     norm_prefix = _slug_normalize(job_prefix)
     keys = await pool.keys("job:running:*")
     for raw_key in keys:
         key = raw_key.decode() if isinstance(raw_key, bytes) else raw_key
         job_id = key.removeprefix("job:running:")
-        norm_id = _slug_normalize(job_id)
-        if not norm_id.startswith(norm_prefix):
+        # Try full normalized ID first, then shortened form (worker-arch- stripped)
+        norm_short = _slug_normalize(_slug_short(job_id))
+        norm_full  = _slug_normalize(job_id)
+        if not (norm_short.startswith(norm_prefix) or norm_full.startswith(norm_prefix)):
             continue
         meta = await pool.hgetall(key)
         if not meta:

--- a/ops-server/nginx/ops-server.conf
+++ b/ops-server/nginx/ops-server.conf
@@ -314,3 +314,50 @@ server {
     server_name autonomous-enablements.whydevslovedynatrace.com;
     return 301 https://$host$request_uri;
 }
+
+# ── Wildcard subdomain — direct app access at root path ────────────────────
+#
+# Serves apps at https://{appname}--{job_slug}.autonomous-enablements.whydevslovedynatrace.com/
+# The app runs at root (/) so Next.js and other SPAs resolve asset paths correctly
+# without any HTML/CSS rewriting — fixes the image-loading issue with Astroshop.
+#
+# Prerequisites (one-time setup):
+#   1. DNS: add A record  *.autonomous-enablements.whydevslovedynatrace.com → <server-IP>
+#              in Google Cloud DNS console (whydevslovedynatrace.com zone)
+#   2. TLS:  certbot certonly --manual --preferred-challenges dns \
+#              -d "*.autonomous-enablements.whydevslovedynatrace.com" \
+#              -d "autonomous-enablements.whydevslovedynatrace.com"
+#            (adds wildcard SAN to the existing cert; requires adding a DNS TXT record)
+#
+server {
+    listen 443 ssl;
+    # Regex captures the subdomain label (everything before the first dot)
+    server_name ~^(?<app_subdomain>[^.]+)\.autonomous-enablements\.whydevslovedynatrace\.com$;
+
+    ssl_certificate     /etc/letsencrypt/live/autonomous-enablements.whydevslovedynatrace.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/autonomous-enablements.whydevslovedynatrace.com/privkey.pem;
+
+    # Allow embedding in the dashboard iframe
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options nosniff always;
+
+    location / {
+        # Rewrite to the FastAPI subdomain proxy handler, preserving the full path
+        rewrite ^/(.*)$ /proxy-subdomain/$1 break;
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-App-Subdomain   $app_subdomain;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_buffering    off;
+        proxy_read_timeout 60;
+    }
+}
+
+# HTTP → HTTPS redirect for wildcard subdomains
+server {
+    listen 80;
+    server_name ~^[^.]+\.autonomous-enablements\.whydevslovedynatrace\.com$;
+    return 301 https://$host$request_uri;
+}

--- a/ops-server/worker-agent/agent.py
+++ b/ops-server/worker-agent/agent.py
@@ -221,6 +221,10 @@ class SysboxPool:
         # Wipe inner docker state without touching the outer Sysbox or its image cache.
         for cmd in [
             ["docker", "exec", slot.sb_name, "docker", "rm", "-fv", "dt"],
+            # Remove all remaining containers (k3d nodes, etc.) left from the previous job.
+            # Must run after dt removal so the rm -fv dt succeeds by name first.
+            ["docker", "exec", slot.sb_name, "sh", "-c",
+             "docker ps -aq | xargs -r docker rm -f 2>/dev/null; true"],
             ["docker", "exec", slot.sb_name, "docker", "volume", "prune", "-f"],
             ["docker", "exec", slot.sb_name, "docker", "network", "prune", "-f"],
         ]:

--- a/ops-server/worker-agent/agent.py
+++ b/ops-server/worker-agent/agent.py
@@ -595,10 +595,14 @@ class WorkerAgent:
                 healthy = False
             finally:
                 self._job_slots.pop(job_id, None)
-                # Release slot back to pool (re-init if unhealthy).
-                await self.sysbox_pool.release(slot, healthy=healthy)
+                # Terminated daemon jobs have their Sysbox force-removed externally.
+                # docker wait returns normally (no exception), so healthy stays True.
+                # We must release as unhealthy so _init_slot gets a fresh container;
+                # otherwise the dead slot re-enters the pool and the next git clone fails.
+                was_terminated = job_id in self._terminated_jobs
+                await self.sysbox_pool.release(slot, healthy=healthy and not was_terminated)
 
-                if job_id in self._terminated_jobs:
+                if was_terminated:
                     job["status"] = "terminated"
                     job["result"] = job.get("result") or {}
                     job["result"]["terminated"] = True

--- a/ops-server/worker-agent/executor.py
+++ b/ops-server/worker-agent/executor.py
@@ -413,7 +413,11 @@ async def execute_daemon(
     await _git_clone(head_repo, ref, repo_dir)
     await _make_world_writable(repo_dir)
     dt_env_overrides: dict[str, str] | None = job.get("dt_env") or None
-    _write_env_file(repo_dir / ".devcontainer" / ".env", overrides=dt_env_overrides)
+    _write_env_file(
+        repo_dir / ".devcontainer" / ".env",
+        overrides=dt_env_overrides,
+        orbital_job_id=job_id,
+    )
 
     start_time = time.time()
     workspace = f"/workspaces/{repo_name}"
@@ -712,7 +716,11 @@ def _redact(token: str) -> str:
     return token[:14] + "***REDACTED***"
 
 
-def _write_env_file(env_path: Path, overrides: dict[str, str] | None = None):
+def _write_env_file(
+    env_path: Path,
+    overrides: dict[str, str] | None = None,
+    orbital_job_id: str = "",
+):
     """Write .devcontainer/.env with DT credentials."""
     env_path.parent.mkdir(parents=True, exist_ok=True)
     resolved = {
@@ -720,6 +728,8 @@ def _write_env_file(env_path: Path, overrides: dict[str, str] | None = None):
         "DT_OPERATOR_TOKEN": DT_OPERATOR_TOKEN,
         "DT_INGEST_TOKEN":   DT_INGEST_TOKEN,
     }
+    if orbital_job_id:
+        resolved["ORBITAL_JOB_ID"] = orbital_job_id
     if overrides:
         resolved.update(overrides)
     env_path.write_text("".join(f"{k}={v}\n" for k, v in resolved.items() if v))

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -875,7 +875,7 @@ class WorkerManager:
         log.info("Cloning %s @ %s for job %s", head_repo, ref, job_id)
         await self._git_clone(head_repo, ref, repo_dir)
         await self._make_world_writable(repo_dir)
-        self._write_env_file(repo_dir / ".devcontainer" / ".env", arch="arm64")
+        self._write_env_file(repo_dir / ".devcontainer" / ".env", arch="arm64", job_id=job_id)
 
         # Sysbox-isolated nested containers (see executor.py for the same
         # architecture): outer Sysbox container runs docker:25-dind; inner
@@ -1096,7 +1096,7 @@ class WorkerManager:
         log.info("Cloning %s @ %s for daemon %s", head_repo, ref, job_id)
         await self._git_clone(head_repo, ref, repo_dir)
         await self._make_world_writable(repo_dir)
-        self._write_env_file(repo_dir / ".devcontainer" / ".env", arch="arm64")
+        self._write_env_file(repo_dir / ".devcontainer" / ".env", arch="arm64", job_id=job_id)
 
         workspace  = f"/workspaces/{repo_name}"
         env_file_inside = f"{workspace}/.devcontainer/.env"
@@ -1379,7 +1379,7 @@ class WorkerManager:
         log.info("Cloning %s @ %s for framework-sysbox %s (%s)", repo, ref, suite, job_id)
         await self._git_clone(repo, ref, repo_dir)
         await self._make_world_writable(repo_dir)
-        self._write_env_file(repo_dir / ".devcontainer" / ".env", arch="arm64")
+        self._write_env_file(repo_dir / ".devcontainer" / ".env", arch="arm64", job_id=job_id)
 
         workspace  = f"/workspaces/{repo_name}"
         env_file_inside = f"{workspace}/.devcontainer/.env"
@@ -1729,7 +1729,7 @@ class WorkerManager:
         )
         return content
 
-    def _write_env_file(self, env_path: Path, arch: str):
+    def _write_env_file(self, env_path: Path, arch: str, job_id: str = ""):
         """Mirror the GHA workflow's .env writing.
 
         Adds K3D_* port overrides so the in-container k3d cluster doesn't
@@ -1739,6 +1739,9 @@ class WorkerManager:
         registerApp's hostname-based ingress route is stable across parallel
         workers (otherwise each worker's dt container would use its own
         random container hostname).
+
+        ORBITAL_JOB_ID is passed so the framework can compute the wildcard
+        subdomain URL for each app (e.g. astroshop--<slug>.autonomous-enablements.*).
         """
         import socket
         external_hostname = os.environ.get("EXTERNAL_HOSTNAME") or socket.gethostname()
@@ -1754,6 +1757,7 @@ class WorkerManager:
             f"K3D_API_PORT=6444\n"
             f"EXTERNAL_HOSTNAME={external_hostname}\n"
             f"ORBITAL_ENVIRONMENT=true\n"
+            f"ORBITAL_JOB_ID={job_id}\n"
         )
 
     async def _git_clone(self, repo: str, ref: str, dest: Path):

--- a/validation-reports/demo-agentic-ai-with-nvidia/2026-05-26.md
+++ b/validation-reports/demo-agentic-ai-with-nvidia/2026-05-26.md
@@ -1,0 +1,463 @@
+# Validation Report — demo-agentic-ai-with-nvidia
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-26 |
+| Training ID | `agentic-ai-nvidia` |
+| Job ID | `enablement-c080f04f48a9` |
+| Pages crawled | 10 |
+| Steps executed | 53 |
+| Pass | 4 |
+| Fail | **3** |
+| Expected-fail | 0 |
+| Skip | 46 |
+| Duration | 198s |
+
+## Summary
+
+**3 step(s) failed.** See details below.
+
+## Step Findings
+
+### 1. [⏭️ SKIP] `ui` step
+
+```
+streamlit open-source app framework
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 2. [⏭️ SKIP] `ui` step
+
+```
+Enter Secrets for Dynatrace, Tavily, and NVIDIA
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 3. [⏭️ SKIP] `ui` step
+
+```
+Wait for App to start It will take a minute or so for Codespaces to start, the installation to take place, and the App to open.  It should like as follows when it is done.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 4. [⏭️ SKIP] `ui` step
+
+```
+It will take a minute or so for Codespaces to start, the installation to take place, and the App to open.  It should like as follows when it is done.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 5. [⏭️ SKIP] `ui` step
+
+```
+Open App Once the browser opens, it will take a few seconds before the application is initialized so a blank page is OK at first then the prompt will appear.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 6. [⏭️ SKIP] `ui` step
+
+```
+Submit a prompt Enter prompt and choose with or without guardrails. Below is example prompt and response.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 7. [⏭️ SKIP] `ui` step
+
+```
+Enter prompt and choose with or without guardrails. Below is example prompt and response.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 8. [⏭️ SKIP] `verify` step
+
+```
+Validate Distributed Tracing in Dynatrace Go back to the Distributed Tracing App in Dynatrace
+* Can you find your request with Guardrails?
+* How many guardrail checks were activated? What is the total
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 9. [⏭️ SKIP] `verify` step
+
+```
+Validate Distributed Tracing in Dynatrace
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 10. [⏭️ SKIP] `ui` step
+
+```
+Explore the AI Observability App in Dynatrace Open the Dynatrace Tenant and go to the AI Observability App * Explore the various LLM metrics in the Overview Tab
+* Guardrails, Agent Topology, Model Ver
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 11. [⏭️ SKIP] `ui` step
+
+```
+Open the Dynatrace Tenant and go to the AI Observability App * Explore the various LLM metrics in the Overview Tab
+* Guardrails, Agent Topology, Model Versioning, and more!
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 12. [⏭️ SKIP] `ui` step
+
+```
+Create Environment Variables file
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 13. [✅ PASS] `shell` step
+
+```
+cp app/.env-app-template .env
+```
+
+### 14. [⏭️ SKIP] `ui` step
+
+```
+Create a Tavily API KEY API Key on tavily.com
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 15. [✅ PASS] `shell` step
+
+```
+curl --request GET \
+    --url https://api.tavily.com/usage  \
+    --header "Authorization: Bearer $TAVILY_API_KEY" | jq .
+```
+
+### 16. [⏭️ SKIP] `ui` step
+
+```
+Set NVIDIA API Key
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 17. [⏭️ SKIP] `ui` step
+
+```
+Create a NVIDIA API Key on build.nvidia.com
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 18. [⏭️ SKIP] `ui` step
+
+```
+Create Dynatrace API Key
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 19. [⏭️ SKIP] `ui` step
+
+```
+Create virtual environment
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 20. [✅ PASS] `shell` step
+
+```
+uv venv --python 3.13 .venv
+source .venv/bin/activate
+```
+
+### 21. [❌ FAIL] `shell` step
+
+```
+uv pip install -r app/requirements.txt
+```
+
+**Error:** zsh:1: command not found: uv
+
+
+### 22. [❌ FAIL] `shell` step
+
+```
+source .env
+python app/update_config.py build
+```
+
+**Error:** zsh:2: command not found: python
+
+
+### 23. [⏭️ SKIP] `verify` step
+
+```
+Verify Start codespace This will take a few minutes to complete and will perform the following:
+* Retrieve and save required environment settings
+* Start an OpenTelemetry collector
+* Create Python vir
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 24. [⏭️ SKIP] `verify` step
+
+```
+Verify Start codespace
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 25. [⏭️ SKIP] `ui` step
+
+```
+This will take a few minutes to complete and will perform the following:
+* Retrieve and save required environment settings
+* Start an OpenTelemetry collector
+* Create Python virtual environment and in
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 26. [⏭️ SKIP] `verify` step
+
+```
+Once codespace is completed the startup, you should see this:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 27. [❌ FAIL] `shell` step
+
+```
+cd /workspaces/demo-agentic-ai-with-nvidia
+source .venv/bin/activate
+streamlit run app/app.py
+```
+
+**Error:** HTTP 504: <html>
+<head><title>504 Gateway Time-out</title></head>
+<body>
+<center><h1>504 Gateway Time-out</h1></center>
+<hr><center>nginx/1.24.0 (Ubuntu)</center>
+</body>
+</html>
+
+
+### 28. [⏭️ SKIP] `verify` step
+
+```
+Self-check prompts for input/output validation
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 29. [⏭️ SKIP] `ui` step
+
+```
+Dynatrace Tenant. For a Trial, visit Dynatrace signup page
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 30. [⏭️ SKIP] `ui` step
+
+```
+TODO: Add the sizing & secrets needed.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 31. [⏭️ SKIP] `ui` step
+
+```
+Branch select the main branch
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 32. [⏭️ SKIP] `ui` step
+
+```
+select the main branch
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 33. [⏭️ SKIP] `ui` step
+
+```
+Machine sizing As a machine type select 2-core
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 34. [⏭️ SKIP] `ui` step
+
+```
+As a machine type select 2-core
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 35. [⏭️ SKIP] `ui` step
+
+```
+Secrets (enter your credentials within the following variables) DT_ENVIRONMENT DT_OPERATOR_TOKEN DT_INGEST_TOKEN
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 36. [⏭️ SKIP] `ui` step
+
+```
+2. While the Codespace is set-up for you, learn powerful usecases with Dynatrace #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 37. [⏭️ SKIP] `ui` step
+
+```
+Showing open ports in the container #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 38. [⏭️ SKIP] `ui` step
+
+```
+There is a helper function loaded in the shell to see the open ports in the dev.container.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 39. [✅ PASS] `shell` step
+
+```
+showOpenPorts(){
+  sudo netstat -tulnp
+}
+```
+
+### 40. [⏭️ SKIP] `ui` step
+
+```
+In here you put your enablement content after Codespaces has been started and everything is ready and set-up.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 41. [⏭️ SKIP] `ui` step
+
+```
+All the MD files are under the docs folder. In the main README.md file you want to give an intro on what the tutorial is about, being very short and to the point. If you add images there you reference
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 42. [⏭️ SKIP] `ui` step
+
+```
+Visit this page for the reference on using MKDocs markdown:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 43. [⏭️ SKIP] `ui` step
+
+```
+The code for this repository is hosted on GitHub. Click the "View Code on GitHub" link above.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 44. [⏭️ SKIP] `ui` step
+
+```
+2.- you dont want your users to go to the local copy of the labguide but to the one in the internet so we can monitor all user interactions with your lab guide.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 45. [⏭️ SKIP] `ui` step
+
+```
+To watch the local mkdocs just go to the terminal and see the process exposed in port 8000.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 46. [⏭️ SKIP] `verify` step
+
+```
+Make sure that there is no warning in there, if there is a warning is because most likely you are referencing a page or an image that is missing or wrong.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 47. [⏭️ SKIP] `verify` step
+
+```
+Make sure to install the plugin Todo Tree. This is a great plugin for tracking TODOs in repositories. I've added a couple of TODOs that you'll need to take care before going live.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 48. [⏭️ SKIP] `ui` step
+
+```
+For enhancing the documentation just create a Fork of this repo and add a PR.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 49. [⏭️ SKIP] `ui` step
+
+```
+Another way to do this is by going to https://github.com/codespaces and delete the codespace.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 50. [⏭️ SKIP] `ui` step
+
+```
+You may also want to deactivate or delete the API token needed for this lab.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 51. [⏭️ SKIP] `ui` step
+
+```
+Create a Free Trial in Dynatrace
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 52. [⏭️ SKIP] `ui` step
+
+```
+Or open an issue to share suggestions, topics you'd like us to cover, or examples you'd find helpful.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 53. [⏭️ SKIP] `ui` step
+
+```
+Thank you for helping us create better enablement resources for everyone ❤️
+```
+
+**Error:** UI/verify steps skipped (--no-ui)

--- a/validation-reports/demo-astroshop-problems/2026-05-26.md
+++ b/validation-reports/demo-astroshop-problems/2026-05-26.md
@@ -1,0 +1,446 @@
+# Validation Report — demo-astroshop-problems
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-26 |
+| Training ID | `astroshop-problems` |
+| Job ID | `enablement-ed9905a6c67f` |
+| Pages crawled | 13 |
+| Steps executed | 46 |
+| Pass | 2 |
+| Fail | **4** |
+| Expected-fail | 0 |
+| Skip | 40 |
+| Duration | 158s |
+
+## Summary
+
+**4 step(s) failed.** See details below.
+
+## Step Findings
+
+### 1. [⏭️ SKIP] `ui` step
+
+```
+Paste the five values into Codespaces' "Set secret" dialog when you
+create the Codespace. Codespaces stores them encrypted and injects
+them as env vars in the container.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 2. [⏭️ SKIP] `ui` step
+
+```
+After post-create — what's live #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 3. [⏭️ SKIP] `ui` step
+
+```
+Some Dynatrace settings need a click in the UI because the API requires
+human consent:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 4. [⏭️ SKIP] `ui` step
+
+```
+Each is a one-click setup. After that, every workshop run is fully
+automated from secrets only.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 5. [❌ FAIL] `shell` step
+
+```
+cd .devcontainer
+cp .env.example .env    # if needed
+$EDITOR .env
+make start
+```
+
+**Error:** cp: cannot stat '.env.example': No such file or directory
+zsh:3: command not found: .env
+bash: line 1: cached_makefile.sh: No such file or directory
+bash: line 1: start: command not found
+make: *** [M
+
+### 6. [✅ PASS] `shell` step
+
+```
+# tokens + URL are in .devcontainer/.env (gitignored, 0600)
+set -a; source .devcontainer/.env; set +a
+source .devcontainer/util/source_framework.sh
+seedWorkshopReleases
+# → 4 CUSTOM_DEPLOYMENT + 4 pip
+```
+
+### 7. [⏭️ SKIP] `verify` step
+
+```
+This repo wires the prevention loop : the same pipeline that delivers
+the change asks the platform if the change is safe, and the platform
+answers based on real telemetry from a real load test — not f
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 8. [⏭️ SKIP] `ui` step
+
+```
+Open the Services app (Ctrl+K → services ).
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 9. [⏭️ SKIP] `ui` step
+
+```
+Add the column Last seen .
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 10. [⏭️ SKIP] `ui` step
+
+```
+Open the Live Debugger (Ctrl+K → debug ).
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 11. [⏭️ SKIP] `ui` step
+
+```
+Set a non-breaking breakpoint on the responsible line; collect
+   variable values without changing the code.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 12. [⏭️ SKIP] `ui` step
+
+```
+Open Profiling & Optimization.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 13. [⏭️ SKIP] `ui` step
+
+```
+On the high-suspension PG, open Technologies & Processes.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 14. [⏭️ SKIP] `ui` step
+
+```
+Open questions Q&A
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 15. [⏭️ SKIP] `verify` step
+
+```
+This page is the recipe. The Astroshop demo is one instance of a
+pattern that drops into any application + any CI system. Seven steps;
+expect a half-day of work for a single service, a sprint for an
+o
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 16. [⏭️ SKIP] `ui` step
+
+```
+Pick 5–15 user journeys that matter. For an e-commerce shop:
+   homepage, browse products, add to cart, checkout. For an API:
+   the top-N endpoints by traffic + the top-N by business value.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 17. [⏭️ SKIP] `verify` step
+
+```
+Make sure it propagates W3C trace-context + baggage. Most of them
+   support this with a one-line config now.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 18. [⏭️ SKIP] `ui` step
+
+```
+Step 4 — Create the SRG with monaco #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 19. [❌ FAIL] `shell` step
+
+```
+# .gitlab-ci.yml or any CI script:
+source .devcontainer/util/my_functions.sh
+
+# 1) the release marker — for Davis correlation + dashboards
+sendDeploymentEvent $VERSION staging $PROBLEM
+
+# 2) pipeline-
+```
+
+**Error:** sendDeploymentEvent:5: command not found: printWarn
+_dtSdlcPost:3: command not found: printError
+_dtSdlcPost:3: command not found: printError
+
+
+### 20. [⏭️ SKIP] `ui` step
+
+```
+Set the env vars in your CI's secrets/variables:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 21. [⏭️ SKIP] `ui` step
+
+```
+Add a job at the end of every environment-touching stage that
+   calls the helpers.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 22. [⏭️ SKIP] `ui` step
+
+```
+The 11 open questions and their answers
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 23. [⏭️ SKIP] `verify` step
+
+```
+The single highest-leverage thing you can do for the on-call experience
+is to make sure the Davis problem card answers "which change caused
+this?" right at the top.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 24. [⏭️ SKIP] `ui` step
+
+```
+What you add with this repo's helpers #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 25. [⏭️ SKIP] `ui` step
+
+```
+The 11 open questions and their answers #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 26. [⏭️ SKIP] `ui` step
+
+```
+Short answer: Centralize the implementation, distribute via a
+reusable include — developers add one line.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 27. [❌ FAIL] `shell` step
+
+```
+validate:
+  needs: deploy-staging
+  outputs:
+    verdict: ${{ steps.guardian.outputs.verdict }}
+  steps:
+    - id: guardian
+      run: |
+        # same dtctl trigger + poll pattern
+        echo "verdi
+```
+
+**Error:** zsh:1: command not found: validate:
+zsh:2: command not found: needs:
+zsh:3: command not found: outputs:
+zsh:4: bad substitution
+
+
+### 28. [⏭️ SKIP] `ui` step
+
+```
+For GitHub : yes — for the Workflow → GitHub direction. It removes
+the need for custom Lambda / Azure Function relays when a Dynatrace
+Workflow needs to act on a repo (open an issue, dispatch a workfl
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 29. [⏭️ SKIP] `ui` step
+
+```
+You want Davis problems to auto-open GitHub issues with reproducer
+  context.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 30. [❌ FAIL] `shell` step
+
+```
+# tokens + URL are in .devcontainer/.env (gitignored, 0600)
+set -a; source .devcontainer/.env; set +a
+applyMonacoConfig            # bash helper from my_functions.sh
+# or directly:
+cd .devcontainer/mi
+```
+
+**Error:** zsh:3: command not found: applyMonacoConfig
+zsh:6: command not found: monaco
+
+
+### 31. [⏭️ SKIP] `ui` step
+
+```
+Optional (set them when the in-cluster GitLab is reachable from the
+target tenant — otherwise placeholders go in, and these resources just
+record the connector shape without being functional):
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 32. [⏭️ SKIP] `ui` step
+
+```
+TODO: Add the sizing & secrets needed.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 33. [⏭️ SKIP] `ui` step
+
+```
+Branch select the main branch
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 34. [⏭️ SKIP] `ui` step
+
+```
+select the main branch
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 35. [⏭️ SKIP] `ui` step
+
+```
+Machine sizing As a machine type select 2-core
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 36. [⏭️ SKIP] `ui` step
+
+```
+As a machine type select 2-core
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 37. [⏭️ SKIP] `ui` step
+
+```
+Secrets (enter your credentials within the following variables) DT_ENVIRONMENT DT_OPERATOR_TOKEN DT_INGEST_TOKEN
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 38. [⏭️ SKIP] `ui` step
+
+```
+2. While the Codespace is set-up for you, learn powerful usecases with Dynatrace #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 39. [⏭️ SKIP] `ui` step
+
+```
+Showing open ports in the container #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 40. [⏭️ SKIP] `ui` step
+
+```
+There is a helper function loaded in the shell to see the open ports in the dev.container.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 41. [✅ PASS] `shell` step
+
+```
+showOpenPorts(){
+  sudo netstat -tulnp
+}
+```
+
+### 42. [⏭️ SKIP] `ui` step
+
+```
+Another way to do this is by going to https://github.com/codespaces and delete the codespace.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 43. [⏭️ SKIP] `ui` step
+
+```
+You may also want to deactivate or delete the API token needed for this lab.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 44. [⏭️ SKIP] `ui` step
+
+```
+Create a Free Trial in Dynatrace
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 45. [⏭️ SKIP] `ui` step
+
+```
+Or open an issue to share suggestions, topics you'd like us to cover, or examples you'd find helpful.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 46. [⏭️ SKIP] `ui` step
+
+```
+Thank you for helping us create better enablement resources for everyone ❤️
+```
+
+**Error:** UI/verify steps skipped (--no-ui)

--- a/validation-reports/enablement-dynatrace-ai-mcp/2026-05-26.md
+++ b/validation-reports/enablement-dynatrace-ai-mcp/2026-05-26.md
@@ -1,0 +1,933 @@
+# Validation Report — enablement-dynatrace-ai-mcp
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-26 |
+| Training ID | `ai-mcp` |
+| Job ID | `enablement-ed02fc093787` |
+| Pages crawled | 7 |
+| Steps executed | 111 |
+| Pass | 2 |
+| Fail | **6** |
+| Expected-fail | 0 |
+| Skip | 103 |
+| Duration | 118s |
+
+## Summary
+
+**6 step(s) failed.** See details below.
+
+## Step Findings
+
+### 1. [⏭️ SKIP] `verify` step
+
+```
+Check the Resources page for documentation links
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 2. [⏭️ SKIP] `ui` step
+
+```
+In this lab, you'll set up your workshop environment using GitHub Codespaces and configure the necessary credentials.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 3. [⏭️ SKIP] `verify` step
+
+```
+Before starting, ensure you have:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 4. [⏭️ SKIP] `ui` step
+
+```
+Click the button below to launch your personal workshop environment:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 5. [❌ FAIL] `shell` step
+
+```
+bash .devcontainer/fetch-secrets.sh
+```
+
+**Stdout:**
+```
+🔐 Workshop Credentials Setup
+
+✅ Attendee ID: attendee-y6vt
+
+❌ No token provided. Exiting.
+
+```
+
+### 6. [⏭️ SKIP] `ui` step
+
+```
+2.2 Enter Your Credentials #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 7. [✅ PASS] `shell` step
+
+```
+source ~/.bashrc
+```
+
+### 8. [⏭️ SKIP] `ui` step
+
+```
+3.1 Open the Environment File #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 9. [⏭️ SKIP] `ui` step
+
+```
+3.2 Add Dynatrace Credentials #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 10. [⏭️ SKIP] `verify` step
+
+```
+3.3 Verify Configuration #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 11. [✅ PASS] `shell` step
+
+```
+echo "Attendee: $ATTENDEE_ID"
+echo "Azure OpenAI: ${AZURE_OPENAI_ENDPOINT:+configured}"
+```
+
+### 12. [⏭️ SKIP] `verify` step
+
+```
+Step 4: Verify the Sample Application #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 13. [❌ FAIL] `shell` step
+
+```
+python app/main.py
+```
+
+**Error:** zsh:1: command not found: python
+
+
+### 14. [⏭️ SKIP] `ui` step
+
+```
+When the application starts, VS Code shows a popup about port 8000 — click "Open in Browser"
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 15. [⏭️ SKIP] `verify` step
+
+```
+You should see the AI Chat Interface
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 16. [⏭️ SKIP] `ui` step
+
+```
+If you miss the popup, click the Ports tab in VS Code, find port 8000, and click the globe icon.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 17. [⏭️ SKIP] `verify` step
+
+```
+Before proceeding to Lab 1, verify:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 18. [⏭️ SKIP] `ui` step
+
+```
+You've set your Attendee ID (remember it — you'll use it throughout)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 19. [❌ FAIL] `shell` step
+
+```
+bash .devcontainer/fetch-secrets.sh
+```
+
+**Stdout:**
+```
+🔐 Workshop Credentials Setup
+
+✅ Attendee ID: attendee-epiy
+
+❌ No token provided. Exiting.
+
+```
+
+### 20. [⏭️ SKIP] `ui` step
+
+```
+Enter the workshop token from your instructor.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 21. [⏭️ SKIP] `verify` step
+
+```
+"Invalid workshop token" — Double-check for extra spaces. Ask your instructor.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 22. [⏭️ SKIP] `verify` step
+
+```
+"Connection refused" on port 8000 — Check the Ports tab in VS Code.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 23. [⏭️ SKIP] `ui` step
+
+```
+In this lab, you'll add OpenLLMetry instrumentation to the sample RAG application to send traces to Dynatrace.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 24. [⏭️ SKIP] `ui` step
+
+```
+Add Traceloop instrumentation to a Python AI application
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 25. [⏭️ SKIP] `verify` step
+
+```
+Verify traces are being sent to Dynatrace
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 26. [❌ FAIL] `shell` step
+
+```
+pip install traceloop-sdk opentelemetry-exporter-otlp opentelemetry-instrumentation-fastapi
+```
+
+**Error:** error: externally-managed-environment
+
+× This environment is externally managed
+╰─> To install Python packages system-wide, try apt install
+    python3-xyz, where xyz is the package you are trying to
+
+
+### 27. [⏭️ SKIP] `ui` step
+
+```
+Step 2: Add Dynatrace Instrumentation #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 28. [⏭️ SKIP] `ui` step
+
+```
+2.1 Open the Main Application File #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 29. [⏭️ SKIP] `ui` step
+
+```
+2.3 Add the Instrumentation Code #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 30. [⏭️ SKIP] `ui` step
+
+```
+Dynatrace expects metrics with Delta temporality , not Cumulative. This environment variable must be set before initializing Traceloop.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 31. [❌ FAIL] `shell` step
+
+```
+python app/main.py
+```
+
+**Error:** zsh:1: command not found: python
+
+
+### 32. [⏭️ SKIP] `verify` step
+
+```
+You should see:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 33. [⏭️ SKIP] `ui` step
+
+```
+5.1 Open the Chat UI #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 34. [⏭️ SKIP] `ui` step
+
+```
+When you start the app, Codespaces detects port 8000 and shows a popup — click "Open in Browser" .
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 35. [⏭️ SKIP] `ui` step
+
+```
+5.3 Toggle RAG Mode #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 36. [❌ FAIL] `shell` step
+
+```
+pip install traceloop-sdk opentelemetry-exporter-otlp
+```
+
+**Error:** error: externally-managed-environment
+
+× This environment is externally managed
+╰─> To install Python packages system-wide, try apt install
+    python3-xyz, where xyz is the package you are trying to
+
+
+### 37. [⏭️ SKIP] `ui` step
+
+```
+Navigate to distributed traces in Dynatrace
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 38. [⏭️ SKIP] `ui` step
+
+```
+Create basic queries for AI observability
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 39. [⏭️ SKIP] `ui` step
+
+```
+Open the Dynatrace environment URL provided by your instructor:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 40. [⏭️ SKIP] `ui` step
+
+```
+2.1 Navigate to the AI Observability App #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 41. [⏭️ SKIP] `ui` step
+
+```
+In the left navigation menu, click Search
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 42. [⏭️ SKIP] `ui` step
+
+```
+Search for AI Observability and select the app
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 43. [⏭️ SKIP] `ui` step
+
+```
+Click Service Health on the top
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 44. [⏭️ SKIP] `ui` step
+
+```
+Click Explorer on the top
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 45. [⏭️ SKIP] `ui` step
+
+```
+Select View traces on the top right.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 46. [⏭️ SKIP] `ui` step
+
+```
+3.3 Select a Trace #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 47. [⏭️ SKIP] `ui` step
+
+```
+Click any trace to view the details.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 48. [⏭️ SKIP] `ui` step
+
+```
+Choose Your Persona #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 49. [⏭️ SKIP] `ui` step
+
+```
+7.1 Create a New Notebook #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 50. [⏭️ SKIP] `ui` step
+
+```
+Navigate to Notebooks in the left-hand menu
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 51. [⏭️ SKIP] `ui` step
+
+```
+Click + Notebook on the top
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 52. [⏭️ SKIP] `ui` step
+
+```
+For each DQL query, create a new DQL tile
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 53. [⏭️ SKIP] `ui` step
+
+```
+8.1 Create a New Notebook #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 54. [⏭️ SKIP] `ui` step
+
+```
+Navigate to Notebooks in the left-hand menu
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 55. [⏭️ SKIP] `ui` step
+
+```
+Click Options > Visualization and select "Pie" for a better view.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 56. [⏭️ SKIP] `verify` step
+
+```
+Azure OpenAI caches prompts > 1024 tokens. Check your cache hit rate:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 57. [⏭️ SKIP] `verify` step
+
+```
+"Missing LLM attributes" — Ensure you're using the traceloop-sdk. Check span details for available attributes.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 58. [⏭️ SKIP] `ui` step
+
+```
+Model Context Protocol (MCP) is an open standard that allows AI assistants to interact with external tools and data sources. With Dynatrace MCP, you can:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 59. [⏭️ SKIP] `ui` step
+
+```
+1.1 Open the MCP Configuration File #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 60. [⏭️ SKIP] `verify` step
+
+```
+Step 2: Verify MCP Connection #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 61. [⏭️ SKIP] `ui` step
+
+```
+2.1 Open GitHub Copilot Chat #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 62. [⏭️ SKIP] `ui` step
+
+```
+Click on the Copilot icon on the top bar
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 63. [⏭️ SKIP] `ui` step
+
+```
+Choose Your Persona #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 64. [⏭️ SKIP] `ui` step
+
+```
+Go to your AI Chat Service UI (http://localhost:8000)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 65. [⏭️ SKIP] `ui` step
+
+```
+Enable the 🐛 Simulate Errors toggle
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 66. [⏭️ SKIP] `verify` step
+
+```
+5.2 Check for Anomalies #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 67. [⏭️ SKIP] `ui` step
+
+```
+Go to your AI Chat Service UI (http://localhost:8000)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 68. [⏭️ SKIP] `ui` step
+
+```
+Enable the 🐛 Simulate Errors toggle
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 69. [⏭️ SKIP] `ui` step
+
+```
+Create Incident Communication #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 70. [⏭️ SKIP] `ui` step
+
+```
+Open a Dynatrace Notebook
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 71. [⏭️ SKIP] `ui` step
+
+```
+Add a ✨ Prompt tile
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 72. [⏭️ SKIP] `verify` step
+
+```
+Verify JSON syntax is valid
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 73. [⏭️ SKIP] `verify` step
+
+```
+Check your service is sending data to Dynatrace
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 74. [⏭️ SKIP] `ui` step
+
+```
+In this lab, you'll create automated workflows that transform you from someone who monitors AI costs to someone who controls them. This is your "hero moment" — building automation you can take back to
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 75. [⏭️ SKIP] `ui` step
+
+```
+Create a Dynatrace Workflow for AI observability
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 76. [⏭️ SKIP] `ui` step
+
+```
+Set up automated token usage monitoring
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 77. [⏭️ SKIP] `ui` step
+
+```
+Step 1: Navigate to Workflows #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 78. [⏭️ SKIP] `ui` step
+
+```
+In Dynatrace, click on the Workflows app in the left navigation (or search for it).
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 79. [⏭️ SKIP] `ui` step
+
+```
+Choose Your Persona #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 80. [⏭️ SKIP] `ui` step
+
+```
+Goal: Create workflows that alert you before users complain. Sleep better knowing automation has your back.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 81. [⏭️ SKIP] `ui` step
+
+```
+Step 2: Create a Token Usage Alert Workflow #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 82. [⏭️ SKIP] `ui` step
+
+```
+2.1 Create a New Workflow #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 83. [⏭️ SKIP] `ui` step
+
+```
+Click + Workflow
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 84. [⏭️ SKIP] `ui` step
+
+```
+2.2 Set the Trigger #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 85. [⏭️ SKIP] `ui` step
+
+```
+Click on the trigger block
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 86. [⏭️ SKIP] `ui` step
+
+```
+Select Time Interval trigger : run every 15 minutes for testing
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 87. [⏭️ SKIP] `ui` step
+
+```
+2.3 Add a DQL Query Action #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 88. [⏭️ SKIP] `ui` step
+
+```
+Click + Add task
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 89. [⏭️ SKIP] `ui` step
+
+```
+Select Execute DQL query
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 90. [⏭️ SKIP] `ui` step
+
+```
+Enter this query:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 91. [⏭️ SKIP] `ui` step
+
+```
+2.4 Add a Notification Action #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 92. [⏭️ SKIP] `ui` step
+
+```
+Add an Email → Send email task. Configure your message:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 93. [⏭️ SKIP] `ui` step
+
+```
+2.5 Add a Condition #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 94. [⏭️ SKIP] `ui` step
+
+```
+Select Condition and set:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 95. [⏭️ SKIP] `ui` step
+
+```
+Click Create/Save draft
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 96. [⏭️ SKIP] `ui` step
+
+```
+3.1 Create a New Workflow #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 97. [⏭️ SKIP] `ui` step
+
+```
+Click + Workflow
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 98. [⏭️ SKIP] `ui` step
+
+```
+3.2 Set Schedule Trigger #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 99. [⏭️ SKIP] `ui` step
+
+```
+Select Fix Time trigger
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 100. [⏭️ SKIP] `ui` step
+
+```
+3.3 Add Comprehensive DQL Query #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 101. [⏭️ SKIP] `ui` step
+
+```
+3.4 Add Summary Query #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 102. [⏭️ SKIP] `ui` step
+
+```
+Add an Email → Send email task. Configure your message:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 103. [⏭️ SKIP] `ui` step
+
+```
+Click Create/Save draft
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 104. [⏭️ SKIP] `ui` step
+
+```
+Set up notification
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 105. [⏭️ SKIP] `ui` step
+
+```
+Know how to add conditions and notifications
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 106. [⏭️ SKIP] `verify` step
+
+```
+"Workflow not triggering" — Verify the workflow is Enabled . Use Run to test manually.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 107. [⏭️ SKIP] `verify` step
+
+```
+"DQL query returns no data" — Verify your service name matches exactly. Ensure your app has processed requests recently.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 108. [⏭️ SKIP] `verify` step
+
+```
+"Notification not received" — Verify the notification channel configuration.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 109. [⏭️ SKIP] `ui` step
+
+```
+Create scheduled workflows that run DQL queries
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 110. [⏭️ SKIP] `ui` step
+
+```
+Set up token usage alerts with thresholds
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 111. [⏭️ SKIP] `ui` step
+
+```
+Add conditions to avoid alert noise
+```
+
+**Error:** UI/verify steps skipped (--no-ui)

--- a/validation-reports/enablement-dynatrace-log-ingest-101/2026-05-26.md
+++ b/validation-reports/enablement-dynatrace-log-ingest-101/2026-05-26.md
@@ -1,0 +1,442 @@
+# Validation Report — enablement-dynatrace-log-ingest-101
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-26 |
+| Training ID | `log-ingest-101` |
+| Job ID | `enablement-922a429ceba1` |
+| Pages crawled | 7 |
+| Steps executed | 54 |
+| Pass | 8 |
+| Fail | **1** |
+| Expected-fail | 1 |
+| Skip | 44 |
+| Duration | 333s |
+
+## Summary
+
+**1 step(s) failed.** See details below.
+
+## Step Findings
+
+### 1. [⏭️ SKIP] `verify` step
+
+```
+Configure and validate Kubernetes log ingest into Dynatrace
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 2. [⏭️ SKIP] `verify` step
+
+```
+Configure and validate Kubernetes log ingest into Dynatrace
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 3. [⏭️ SKIP] `ui` step
+
+```
+Enable OpenTelemetry OneAgent Features
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 4. [⏭️ SKIP] `ui` step
+
+```
+Enable Log Enrichment OneAgent Features
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 5. [⏭️ SKIP] `ui` step
+
+```
+Enable OpenTelemetry OneAgent Features #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 6. [⏭️ SKIP] `ui` step
+
+```
+Enable Log Enrichment OneAgent Features #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 7. [⏭️ SKIP] `ui` step
+
+```
+Technically you only need to enable Log Enrichment for Node.js for this lab.  However, we recommend enabling this capability for all technologies to get the most value out of your log data.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 8. [⏭️ SKIP] `ui` step
+
+```
+Create Codespace #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 9. [⏭️ SKIP] `ui` step
+
+```
+Click to open Codespaces for this lab repository:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 10. [⏭️ SKIP] `ui` step
+
+```
+Branch select the main branch
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 11. [⏭️ SKIP] `ui` step
+
+```
+select the main branch
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 12. [⏭️ SKIP] `ui` step
+
+```
+Dev container configuration select Enablement on codespaces template
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 13. [⏭️ SKIP] `ui` step
+
+```
+select Enablement on codespaces template
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 14. [⏭️ SKIP] `ui` step
+
+```
+Machine type select 4-core
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 15. [⏭️ SKIP] `ui` step
+
+```
+select 4-core
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 16. [⏭️ SKIP] `ui` step
+
+```
+Region select any region, preferably one closest to your Dynatrace tenant
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 17. [⏭️ SKIP] `ui` step
+
+```
+select any region, preferably one closest to your Dynatrace tenant
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 18. [⏭️ SKIP] `ui` step
+
+```
+The AstroShop app is being exposed in the devcontainer to your localhost. If you want to make the endpoints publicly accesible, just go to the ports section, right click on them and change the visibil
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 19. [✅ PASS] `shell` step
+
+```
+kubectl delete pods --all -n astroshop
+```
+
+### 20. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n astroshop
+```
+
+### 21. [✅ PASS] `shell` step
+
+```
+kubectl get events -n astroshop
+```
+
+### 22. [✅ PASS] `shell` step
+
+```
+kubectl get events -n kube-system
+kubectl get events -n default
+```
+
+### 23. [❌ FAIL] `shell` step
+
+```
+kubectl get svc astroshop-frontendproxy -n astroshop
+```
+
+**Error:** Error from server (NotFound): services "astroshop-frontendproxy" not found
+
+
+### 24. [⏭️ SKIP] `ui` step
+
+```
+Dynatrace provides a flexible approach to Kubernetes observability where you can pick and choose the level of observability you need for your Kubernetes clusters. The Dynatrace Operator manages all th
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 25. [⏭️ SKIP] `ui` step
+
+```
+Enable data enrichment for Kubernetes environments.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 26. [⏭️ SKIP] `ui` step
+
+```
+1. Select distribution
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 27. [⏭️ SKIP] `ui` step
+
+```
+2. Select observability options
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 28. [✅ PASS] `shell` step
+
+```
+helm install dynatrace-operator oci://public.ecr.aws/dynatrace/dynatrace-operator \
+--create-namespace \
+--namespace dynatrace \
+--atomic
+```
+
+### 29. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 30. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f dynakube.yaml
+```
+
+**Error:** Student-created file 'dynakube.yaml' not present — expected in automated context
+
+### 31. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 32. [⏭️ SKIP] `verify` step
+
+```
+In case you encounter an ImagePullBackOff error (using sprint or dev tenants), check public.ecr.aws to make sure the container image with that tag exists.  If not, change the value to use an existing 
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 33. [✅ PASS] `shell` step
+
+```
+kubectl delete pods -n astroshop --field-selector="status.phase=Running"
+```
+
+### 34. [⏭️ SKIP] `verify` step
+
+```
+Validate Log Ingest #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 35. [⏭️ SKIP] `verify` step
+
+```
+Validate log data after running the query.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 36. [⏭️ SKIP] `ui` step
+
+```
+Here you will find the log ingest rules set at the environment-level.  Rules configured here will be inherited by every host group, Kubernetes cluster, and host in the environment.  However, these set
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 37. [⏭️ SKIP] `ui` step
+
+```
+An enhancement to the log module for Kubernetes introduces a feature that enables Dynatrace to capture all container logs, even those that do not meet the autodiscovery requirements.  The logs from th
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 38. [⏭️ SKIP] `ui` step
+
+```
+Dynatrace includes built-in sensitive data masking rules for email address, credit cards, URL queries, IBAN, and API-Tokens at the Environment-level.  If these settings are enabled, that may have alre
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 39. [⏭️ SKIP] `ui` step
+
+```
+The advantage of using the SHA-256 masking type is that every unique value (email address) will produce a unique hash value.  This may enable you to see if the log contains the same email address or d
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 40. [⏭️ SKIP] `ui` step
+
+```
+We will add a configuration that ensures multi‑line application logs are ingested as a single log entry instead of one entry per line.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 41. [⏭️ SKIP] `ui` step
+
+```
+The log is not pure JSON (it has prefixes and trailers), so do NOT enable “Detect JSON format” — that would break parsing.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 42. [⏭️ SKIP] `ui` step
+
+```
+The log already merges correctly using timestamp detection alone. We enable Skip indented lines as a defensive setting to prevent accidental splits, and explicitly disable JSON detection because the l
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 43. [⏭️ SKIP] `ui` step
+
+```
+This allows the Log Module to discover the Dynatrace component logs.  However, we need to add an ingest rule to ship them to Dynatrace.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 44. [⏭️ SKIP] `ui` step
+
+```
+Dynatrace OpenPipeline can reshape incoming data for better understanding, processing, and analysis. OpenPipeline processing is based on rules that you create and offers a flexible way of extracting v
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 45. [⏭️ SKIP] `ui` step
+
+```
+This processor rule will create a new field containing the MD5 hash value of the credit card number.  This is an example of masking sensitive data at ingest using OpenPipeline.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 46. [⏭️ SKIP] `ui` step
+
+```
+Click on Dimensions and add the following:
+Dimensions:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 47. [⏭️ SKIP] `ui` step
+
+```
+This metric extraction rule will create a counter metric to count the number of payment service failures caused by the feature flag being enabled.  Using DQL, one could count the number of log message
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 48. [⏭️ SKIP] `ui` step
+
+```
+OpenPipeline can also be used to set the security context of the log data to manage permissions to specific logs.  Additionally, you can use storage processor rules to store specific log data in a buc
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 49. [⏭️ SKIP] `ui` step
+
+```
+A pipeline will not have any effect unless logs are configured to be routed to the pipeline. With dynamic routing, data is routed based on a matching condition. The matching condition is a DQL query t
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 50. [⏭️ SKIP] `ui` step
+
+```
+Enable Astroshop Problem Patterns #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 51. [⏭️ SKIP] `ui` step
+
+```
+Or open an issue to share suggestions, topics you'd like us to cover, or examples you'd find helpful.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 52. [⏭️ SKIP] `ui` step
+
+```
+Thank you for helping us create better enablement resources for everyone ❤️
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 53. [⏭️ SKIP] `ui` step
+
+```
+Another way to do this is by going to https://github.com/codespaces and delete the codespace.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 54. [⏭️ SKIP] `ui` step
+
+```
+You may also want to deactivate or delete the API token needed for this lab.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)

--- a/validation-reports/enablement-kubernetes-101/2026-05-26.md
+++ b/validation-reports/enablement-kubernetes-101/2026-05-26.md
@@ -1,0 +1,257 @@
+# Validation Report — enablement-kubernetes-101
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-26 |
+| Training ID | `kubernetes-101` |
+| Job ID | `enablement-47128fdb4aa8` |
+| Pages crawled | 6 |
+| Steps executed | 26 |
+| Pass | 8 |
+| Fail | **3** |
+| Expected-fail | 1 |
+| Skip | 14 |
+| Duration | 244s |
+
+## Summary
+
+**3 step(s) failed.** See details below.
+
+## Step Findings
+
+### 1. [⏭️ SKIP] `verify` step
+
+```
+Each step has an automated shell check built into the documentation — you must pass the check before you can continue.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 2. [⏭️ SKIP] `ui` step
+
+```
+Open the Terminal tab above at any time to run kubectl commands directly against your cluster.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 3. [⏭️ SKIP] `verify` step
+
+```
+Click Start Environment in the status bar above to provision your live environment. The shell check buttons on each step will not be active until the environment is ready.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 4. [⏭️ SKIP] `verify` step
+
+```
+Before deploying the Dynatrace Operator, confirm that your Kubernetes cluster is ready and the demo application is running. Use the checks below — both must pass before you continue.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 5. [✅ PASS] `shell` step
+
+```
+kubectl get nodes
+```
+
+### 6. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n todoapp
+```
+
+### 7. [❌ FAIL] `shell` step
+
+```
+kubectl apply DynaKube CR
+       │
+       ▼
+Dynatrace Operator (watches CRDs)
+       │
+       ├─► OneAgent DaemonSet  → runs on every node, instruments processes (CloudNativeFullStack only)
+       └─►
+```
+
+**Error:** error: Unexpected args: [DynaKube CR]
+See 'kubectl apply -h' for help and examples
+zsh:2: command not found: \M-b\M-^T\M-^B
+zsh:3: command not found: \M-b\M-^V\M-<
+zsh:4: number expected
+zsh:5: comman
+
+### 8. [⏭️ SKIP] `ui` step
+
+```
+Step 1 — Create the dynatrace namespace #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 9. [✅ PASS] `shell` step
+
+```
+kubectl create namespace dynatrace
+```
+
+### 10. [⏭️ SKIP] `ui` step
+
+```
+Step 2 — Add the Dynatrace Helm repository #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 11. [✅ PASS] `shell` step
+
+```
+helm repo add dynatrace \
+  https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/main/config/helm/repos/stable
+helm repo update
+```
+
+### 12. [✅ PASS] `shell` step
+
+```
+helm install dynatrace-operator dynatrace/dynatrace-operator \
+  -n dynatrace
+```
+
+### 13. [⏭️ SKIP] `verify` step
+
+```
+Verify the install
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 14. [⏭️ SKIP] `ui` step
+
+```
+Step 1 — Open the Dynatrace UI #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 15. [⏭️ SKIP] `ui` step
+
+```
+Normally you would navigate to:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 16. [⏭️ SKIP] `ui` step
+
+```
+Click Connect cluster and follow the wizard. Dynatrace will generate two manifests:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 17. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f /workspaces/enablement-kubernetes-101/.devcontainer/yaml/gen/dynakube.yaml
+```
+
+**Error:** Student-created file '/workspaces/enablement-kubernetes-101/.devcontainer/yaml/gen/dynakube.yaml' not present — expected in automated context
+
+### 18. [❌ FAIL] `shell` step
+
+```
+kubectl get pods -n dynatrace --watch
+```
+
+**Error:** HTTP 504: <html>
+<head><title>504 Gateway Time-out</title></head>
+<body>
+<center><h1>504 Gateway Time-out</h1></center>
+<hr><center>nginx/1.24.0 (Ubuntu)</center>
+</body>
+</html>
+
+
+### 19. [✅ PASS] `shell` step
+
+```
+kubectl rollout restart deployment -n todoapp
+```
+
+### 20. [✅ PASS] `shell` step
+
+```
+kubectl rollout status deployment -n todoapp --timeout=120s
+```
+
+### 21. [⏭️ SKIP] `verify` step
+
+```
+Step 3 — Verify in Dynatrace #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 22. [⏭️ SKIP] `verify` step
+
+```
+Verify logs in Dynatrace #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 23. [⏭️ SKIP] `verify` step
+
+```
+Once OneAgent is injected and the services are running, Dynatrace will start collecting logs automatically. Trigger a log entry by creating a TODO item in the application, then verify it appears in Dy
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 24. [⏭️ SKIP] `verify` step
+
+```
+Knowledge check #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 25. [❌ FAIL] `shell` step
+
+```
+# Cluster and node status
+kubectl get nodes
+kubectl cluster-info
+
+# Namespace management
+kubectl create namespace dynatrace
+kubectl get namespaces
+
+# Pod monitoring
+kubectl get pods -n dynatrace --wat
+```
+
+**Error:** HTTP 504: <html>
+<head><title>504 Gateway Time-out</title></head>
+<body>
+<center><h1>504 Gateway Time-out</h1></center>
+<hr><center>nginx/1.24.0 (Ubuntu)</center>
+</body>
+</html>
+
+
+### 26. [✅ PASS] `shell` step
+
+```
+# Add repo
+helm repo add dynatrace \
+  https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/main/config/helm/repos/stable
+
+# Check installed release
+helm list -n dynatrace
+
+# Uninstall
+helm 
+```

--- a/validation-reports/enablement-kubernetes-opentelemetry-openpipeline/2026-05-26.md
+++ b/validation-reports/enablement-kubernetes-opentelemetry-openpipeline/2026-05-26.md
@@ -1,0 +1,331 @@
+# Validation Report — enablement-kubernetes-opentelemetry-openpipeline
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-26 |
+| Training ID | `kubernetes-otel-openpipeline` |
+| Job ID | `enablement-9f455b28edc1` |
+| Pages crawled | 6 |
+| Steps executed | 39 |
+| Pass | 1 |
+| Fail | **1** |
+| Expected-fail | 0 |
+| Skip | 37 |
+| Duration | 268s |
+
+## Summary
+
+**1 step(s) failed.** See details below.
+
+## Step Findings
+
+### 1. [⏭️ SKIP] `ui` step
+
+```
+Create custom Buckets for Grail storage management
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 2. [⏭️ SKIP] `ui` step
+
+```
+Add Bucket Storage Management Permissions
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 3. [⏭️ SKIP] `ui` step
+
+```
+Add Storage Management Permissions #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 4. [⏭️ SKIP] `verify` step
+
+```
+The Grail data model consists of buckets, tables, and views.  Records are stored in buckets.  Buckets are assigned to tables, including logs, metrics, events, security events, and bizevents tables. Fe
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 5. [⏭️ SKIP] `ui` step
+
+```
+storage:bucket-definitions:delete
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 6. [⏭️ SKIP] `ui` step
+
+```
+After creating the policy, be sure to add/bind it to a group that you belong to.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 7. [⏭️ SKIP] `ui` step
+
+```
+Create Codespace #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 8. [⏭️ SKIP] `ui` step
+
+```
+Click to open Codespaces for this lab repository:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 9. [⏭️ SKIP] `ui` step
+
+```
+Branch select the main branch
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 10. [⏭️ SKIP] `ui` step
+
+```
+select the main branch
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 11. [⏭️ SKIP] `ui` step
+
+```
+Dev container configuration select Enablement on codespaces template
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 12. [⏭️ SKIP] `ui` step
+
+```
+select Enablement on codespaces template
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 13. [⏭️ SKIP] `ui` step
+
+```
+Machine type select 4-core
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 14. [⏭️ SKIP] `ui` step
+
+```
+select 4-core
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 15. [⏭️ SKIP] `ui` step
+
+```
+Region select any region, preferably one closest to your Dynatrace tenant
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 16. [⏭️ SKIP] `ui` step
+
+```
+select any region, preferably one closest to your Dynatrace tenant
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 17. [⏭️ SKIP] `ui` step
+
+```
+The apps MKdocs and Astronomy Shop are being exposed in the devcontainer to your localhost. If you want to make the endpoints public accesible, just go to the ports section in VsCode, right click on t
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 18. [✅ PASS] `shell` step
+
+```
+kubectl delete pods -n astronomy-shop --field-selector="status.phase=Running"
+```
+
+### 19. [⏭️ SKIP] `ui` step
+
+```
+What is a Capstone ? A hands-on, culminating learning experience where participants apply the knowledge and skills they've gained throughout a course or program to solve a real-world problem, create a
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 20. [❌ FAIL] `shell` step
+
+```
+cd $BASE_DIR/lab-modules/opentelemetry-capstone
+```
+
+**Error:** zsh:cd:1: no such file or directory: /lab-modules/opentelemetry-capstone
+
+
+### 21. [⏭️ SKIP] `verify` step
+
+```
+Validate the OpenTelemetry data using the Astronomy Shop Dashboard.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 22. [⏭️ SKIP] `ui` step
+
+```
+In this module we'll create Grail storage Buckets to manage log data.  By default, all logs are stored in a default logs bucket in Grail - that retains log data for 35 days.  We can create custom buck
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 23. [⏭️ SKIP] `ui` step
+
+```
+You can create a bucket tailored to your needs. Grail buckets behave like folders in a file system and are designed for records that should be handled together. For example, you might need to store to
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 24. [⏭️ SKIP] `ui` step
+
+```
+Create new custom buckets for log data
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 25. [⏭️ SKIP] `ui` step
+
+```
+Create Buckets #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 26. [⏭️ SKIP] `ui` step
+
+```
+If your DPS subscription includes both logs license models (Usage based and Retain with Included Queries) you will have the option to configure which license model will be used by logs queried from th
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 27. [⏭️ SKIP] `ui` step
+
+```
+Add OpenTelemetry service name and namespace
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 28. [⏭️ SKIP] `verify` step
+
+```
+This modifies the log attributes at query time and helps us identify the processing rules for Dynatrace OpenPipeline.  We'll validate the results after OpenPipeline, later.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 29. [⏭️ SKIP] `verify` step
+
+```
+This modifies the log attributes at query time and helps us identify the processing rules for Dynatrace OpenPipeline.  We'll validate the results after OpenPipeline, later.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 30. [⏭️ SKIP] `verify` step
+
+```
+These are the logs that will be modified using the Java technology processor bundle within OpenPipeline.  We'll validate the results after OpenPipeline, later.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 31. [⏭️ SKIP] `verify` step
+
+```
+This modifies the log attributes at query time and helps us identify the processing rules for Dynatrace OpenPipeline.  We'll validate the results after OpenPipeline, next .
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 32. [⏭️ SKIP] `ui` step
+
+```
+If the images are too small and the text is difficult to read, right-click and open the image in a new tab.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 33. [⏭️ SKIP] `ui` step
+
+```
+A pipeline will not have any effect unless logs are configured to be routed to the pipeline.  With dynamic routing, data is routed based on a matching condition. The matching condition is a DQL query 
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 34. [⏭️ SKIP] `ui` step
+
+```
+Extracting business data from logs has many benefits.  By generating a bizevent with OpenPipeline, the business data becomes immediately accessible for analysis, forensics, trending, and alerting - bu
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 35. [⏭️ SKIP] `ui` step
+
+```
+By completing this module, you've successfully set up Dynatrace OpenPipeline pipelines to process the Astronomy Shop logs at ingest.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 36. [⏭️ SKIP] `ui` step
+
+```
+Astronomy Shop logs Add OpenTelemetry service name and namespace fields to unify telemetry signals and enable out-of-the-box analysis Enrich SDK logs with additional Kubernetes metadata to unify telem
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 37. [⏭️ SKIP] `ui` step
+
+```
+Add OpenTelemetry service name and namespace fields to unify telemetry signals and enable out-of-the-box analysis
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 38. [⏭️ SKIP] `ui` step
+
+```
+Another way to do this is by going to https://github.com/codespaces and delete the codespace.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 39. [⏭️ SKIP] `ui` step
+
+```
+You may also want to deactivate or delete the API token needed for this lab.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)

--- a/validation-reports/enablement-kubernetes-opentelemetry/2026-05-26.md
+++ b/validation-reports/enablement-kubernetes-opentelemetry/2026-05-26.md
@@ -1,0 +1,974 @@
+# Validation Report — enablement-kubernetes-opentelemetry
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-26 |
+| Training ID | `kubernetes-opentelemetry` |
+| Job ID | `enablement-25aa2f8a97de` |
+| Pages crawled | 8 |
+| Steps executed | 125 |
+| Pass | 32 |
+| Fail | **9** |
+| Expected-fail | 27 |
+| Skip | 57 |
+| Duration | 285s |
+
+## Summary
+
+**9 step(s) failed.** See details below.
+
+## Step Findings
+
+### 1. [⏭️ SKIP] `verify` step
+
+```
+OpenTelemetry Capstone Deploy 2 OpenTelemetry Collectors (DaemonSet + Deployment) Configure OpenTelemetry Collector service pipeline for data enrichment Analyze metrics, traces, and logs in Dynatrace 
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 2. [⏭️ SKIP] `verify` step
+
+```
+Observe OpenTelemetry Collector health in Dynatrace
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 3. [⏭️ SKIP] `ui` step
+
+```
+Create Codespace #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 4. [⏭️ SKIP] `ui` step
+
+```
+Click to open Codespaces for this lab repository:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 5. [⏭️ SKIP] `ui` step
+
+```
+Branch select the main branch
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 6. [⏭️ SKIP] `ui` step
+
+```
+select the main branch
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 7. [⏭️ SKIP] `ui` step
+
+```
+Dev container configuration select Dynatrace Enablement Container
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 8. [⏭️ SKIP] `ui` step
+
+```
+select Dynatrace Enablement Container
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 9. [⏭️ SKIP] `ui` step
+
+```
+Machine type select 4-core
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 10. [⏭️ SKIP] `ui` step
+
+```
+select 4-core
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 11. [⏭️ SKIP] `ui` step
+
+```
+Region select any region, preferably one closest to your Dynatrace tenant
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 12. [⏭️ SKIP] `ui` step
+
+```
+select any region, preferably one closest to your Dynatrace tenant
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 13. [⏭️ SKIP] `verify` step
+
+```
+Validate Astronomy Shop #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 14. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n astronomy-shop
+```
+
+### 15. [✅ PASS] `shell` step
+
+```
+kubectl delete pods --all -n astronomy-shop
+```
+
+### 16. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n astronomy-shop
+```
+
+### 17. [✅ PASS] `shell` step
+
+```
+kubectl get events -n astronomy-shop
+```
+
+### 18. [✅ PASS] `shell` step
+
+```
+kubectl get events -n kube-system
+kubectl get events -n default
+```
+
+### 19. [✅ PASS] `shell` step
+
+```
+kubectl get svc astronomy-shop-frontendproxy -n astronomy-shop
+```
+
+### 20. [⏭️ SKIP] `ui` step
+
+```
+The Astronomy Shop demo application provides several feature flags that you can use to simulate different scenarios. These flags are managed by flagd, a simple feature flag service that supports OpenF
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 21. [⏭️ SKIP] `ui` step
+
+```
+In your Github Codespaces Terminal set the environment variables:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 22. [✅ PASS] `shell` step
+
+```
+cd $REPO_PATH
+pwd
+```
+
+### 23. [⏭️ SKIP] `ui` step
+
+```
+You should find yourself at the base directory of the repository. If not, then navigate to it.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 24. [✅ PASS] `shell` step
+
+```
+kubectl create namespace dynatrace
+```
+
+### 25. [✅ PASS] `shell` step
+
+```
+kubectl create secret generic dynatrace-otelcol-dt-api-credentials --from-literal=DT_ENDPOINT=$DT_ENDPOINT --from-literal=DT_API_TOKEN=$DT_API_TOKEN -n dynatrace
+```
+
+### 26. [✅ PASS] `shell` step
+
+```
+kubectl apply -f cluster-manifests/cert-manager.yaml
+```
+
+### 27. [❌ FAIL] `shell` step
+
+```
+kubectl apply -f cluster-manifests/opentelemetry-operator.yaml
+```
+
+**Error:** Error from server (InternalError): error when creating "cluster-manifests/opentelemetry-operator.yaml": Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhoo
+
+**Stdout:**
+```
+namespace/opentelemetry-operator-system created
+customresourcedefinition.apiextensions.k8s.io/instrumentations.opentelemetry.io created
+customresourcedefinition.apiextensions.k8s.io/opampbridges.opentelemetry.io created
+customresourcedefinition.apiextensions.k8s.io/opentelemetrycollectors.openteleme
+```
+
+### 28. [⏭️ SKIP] `verify` step
+
+```
+Validate that the OpenTelemetry Operator components are running.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 29. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n opentelemetry-operator-system
+```
+
+### 30. [⏭️ SKIP] `ui` step
+
+```
+In your Github Codespaces Terminal set the environment variables:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 31. [❌ FAIL] `shell` step
+
+```
+cd $REPO_PATH/lab-modules/opentelemetry-logs
+```
+
+**Error:** zsh:cd:1: no such file or directory: /lab-modules/opentelemetry-logs
+
+
+### 32. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/collector/logs/otel-collector-logs-crd-01.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/collector/logs/otel-collector-logs-crd-01.yaml' not present — expected in automated context
+
+### 33. [⏭️ SKIP] `verify` step
+
+```
+Validate running pod(s)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 34. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 35. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/rbac/otel-collector-k8s-clusterrole-logs.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/rbac/otel-collector-k8s-clusterrole-logs.yaml' not present — expected in automated context
+
+### 36. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/rbac/otel-collector-k8s-clusterrole-logs-crb.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/rbac/otel-collector-k8s-clusterrole-logs-crb.yaml' not present — expected in automated context
+
+### 37. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/collector/logs/otel-collector-logs-crd-02.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/collector/logs/otel-collector-logs-crd-02.yaml' not present — expected in automated context
+
+### 38. [⏭️ SKIP] `verify` step
+
+```
+Validate running pod(s)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 39. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 40. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/collector/logs/otel-collector-logs-crd-03.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/collector/logs/otel-collector-logs-crd-03.yaml' not present — expected in automated context
+
+### 41. [⏭️ SKIP] `verify` step
+
+```
+Validate running pod(s)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 42. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 43. [⏭️ SKIP] `ui` step
+
+```
+This could also be set using OpenPipeline, but this puts control of this attribute's value at the app/infra layer (optionally)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 44. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/collector/logs/otel-collector-logs-crd-04.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/collector/logs/otel-collector-logs-crd-04.yaml' not present — expected in automated context
+
+### 45. [⏭️ SKIP] `verify` step
+
+```
+Validate running pod(s)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 46. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 47. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/collector/logs/otel-collector-logs-crd-05.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/collector/logs/otel-collector-logs-crd-05.yaml' not present — expected in automated context
+
+### 48. [⏭️ SKIP] `verify` step
+
+```
+Validate running pod(s)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 49. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 50. [❌ FAIL] `shell` step
+
+```
+helm upgrade astronomy-shop open-telemetry/opentelemetry-demo --values astronomy-shop/sed/collector-values.yaml --namespace astronomy-shop --version "0.31.0"
+```
+
+**Error:** Error: open astronomy-shop/sed/collector-values.yaml: no such file or directory
+
+
+### 51. [⏭️ SKIP] `verify` step
+
+```
+Since the processor uses the Kubernetes API, it needs the correct permission to work correctly. Since service accounts are the only authentication option you must give the service account the proper a
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 52. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/rbac/otel-collector-k8s-clusterrole-events.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/rbac/otel-collector-k8s-clusterrole-events.yaml' not present — expected in automated context
+
+### 53. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/rbac/otel-collector-k8s-clusterrole-events-crb.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/rbac/otel-collector-k8s-clusterrole-events-crb.yaml' not present — expected in automated context
+
+### 54. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/collector/events/otel-collector-events-crd-01.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/collector/events/otel-collector-events-crd-01.yaml' not present — expected in automated context
+
+### 55. [⏭️ SKIP] `verify` step
+
+```
+Validate running pod(s)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 56. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 57. [✅ PASS] `shell` step
+
+```
+kubectl scale deployment astronomy-shop-imageprovider -n astronomy-shop --replicas=2
+```
+
+### 58. [✅ PASS] `shell` step
+
+```
+kubectl scale deployment astronomy-shop-imageprovider -n astronomy-shop --replicas=1
+```
+
+### 59. [⏭️ SKIP] `ui` step
+
+```
+In your Github Codespaces Terminal set the environment variables:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 60. [❌ FAIL] `shell` step
+
+```
+cd $REPO_PATH/lab-modules/opentelemetry-traces
+```
+
+**Error:** zsh:cd:1: no such file or directory: /lab-modules/opentelemetry-traces
+
+
+### 61. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/collector/traces/otel-collector-traces-crd-01.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/collector/traces/otel-collector-traces-crd-01.yaml' not present — expected in automated context
+
+### 62. [⏭️ SKIP] `verify` step
+
+```
+Validate running pod(s)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 63. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 64. [❌ FAIL] `shell` step
+
+```
+helm upgrade astronomy-shop open-telemetry/opentelemetry-demo --values astronomy-shop/sed/collector-values.yaml --namespace astronomy-shop --version "0.31.0"
+```
+
+**Error:** Error: open astronomy-shop/sed/collector-values.yaml: no such file or directory
+
+
+### 65. [⏭️ SKIP] `ui` step
+
+```
+Open the opentelemetry-traces_dt_notebook Notebook.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 66. [⏭️ SKIP] `ui` step
+
+```
+These attributes are good, but we can add more to provide better Kubernetes context to these transactions.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 67. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/rbac/otel-collector-k8s-clusterrole-traces.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/rbac/otel-collector-k8s-clusterrole-traces.yaml' not present — expected in automated context
+
+### 68. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/rbac/otel-collector-k8s-clusterrole-traces-crb.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/rbac/otel-collector-k8s-clusterrole-traces-crb.yaml' not present — expected in automated context
+
+### 69. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/collector/traces/otel-collector-traces-crd-02.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/collector/traces/otel-collector-traces-crd-02.yaml' not present — expected in automated context
+
+### 70. [⏭️ SKIP] `verify` step
+
+```
+Validate running pod(s)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 71. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 72. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/collector/traces/otel-collector-traces-crd-03.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/collector/traces/otel-collector-traces-crd-03.yaml' not present — expected in automated context
+
+### 73. [⏭️ SKIP] `verify` step
+
+```
+Validate running pod(s)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 74. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 75. [⏭️ SKIP] `ui` step
+
+```
+This could also be set using OpenPipeline, but this puts control of this attribute's value at the app/infra layer (optionally)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 76. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/collector/traces/otel-collector-traces-crd-04.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/collector/traces/otel-collector-traces-crd-04.yaml' not present — expected in automated context
+
+### 77. [⏭️ SKIP] `verify` step
+
+```
+Validate running pod(s)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 78. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 79. [⏭️ SKIP] `verify` step
+
+```
+Once you've applied your filters, the trace list updates in real time. From there, you can select a trace to view its waterfall visualization, which shows the sequence and timing of spans across servi
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 80. [⏭️ SKIP] `ui` step
+
+```
+In your Github Codespaces Terminal set the environment variables:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 81. [❌ FAIL] `shell` step
+
+```
+cd $REPO_PATH/lab-modules/opentelemetry-metrics
+```
+
+**Error:** zsh:cd:1: no such file or directory: /lab-modules/opentelemetry-metrics
+
+
+### 82. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/collector/metrics/otel-collector-metrics-node-crd-01.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/collector/metrics/otel-collector-metrics-node-crd-01.yaml' not present — expected in automated context
+
+### 83. [⏭️ SKIP] `verify` step
+
+```
+Validate running pod(s)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 84. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 85. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/rbac/otel-collector-k8s-clusterrole-metrics.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/rbac/otel-collector-k8s-clusterrole-metrics.yaml' not present — expected in automated context
+
+### 86. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/rbac/otel-collector-k8s-clusterrole-metrics-crb.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/rbac/otel-collector-k8s-clusterrole-metrics-crb.yaml' not present — expected in automated context
+
+### 87. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/collector/metrics/otel-collector-metrics-node-crd-02.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/collector/metrics/otel-collector-metrics-node-crd-02.yaml' not present — expected in automated context
+
+### 88. [⏭️ SKIP] `verify` step
+
+```
+Validate running pod(s)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 89. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 90. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/collector/metrics/otel-collector-metrics-cluster-crd-01.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/collector/metrics/otel-collector-metrics-cluster-crd-01.yaml' not present — expected in automated context
+
+### 91. [⏭️ SKIP] `verify` step
+
+```
+Validate running pod(s)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 92. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 93. [❌ FAIL] `shell` step
+
+```
+helm upgrade astronomy-shop open-telemetry/opentelemetry-demo --values astronomy-shop/sed/collector-values.yaml --namespace astronomy-shop --version "0.31.0"
+```
+
+**Error:** Error: open astronomy-shop/sed/collector-values.yaml: no such file or directory
+
+
+### 94. [⏭️ SKIP] `ui` step
+
+```
+What is a Capstone ? A hands-on, culminating learning experience where participants apply the knowledge and skills they've gained throughout a course or program to solve a real-world problem, create a
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 95. [⏭️ SKIP] `verify` step
+
+```
+Observe OpenTelemetry Collector health in Dynatrace
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 96. [⏭️ SKIP] `ui` step
+
+```
+Add OpenTelemetry Dashboards from Hub
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 97. [⏭️ SKIP] `ui` step
+
+```
+Define workshop user variables In your Github Codespaces Terminal set the environment variables:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 98. [❌ FAIL] `shell` step
+
+```
+cd $REPO_PATH/lab-modules/opentelemetry-capstone
+```
+
+**Error:** zsh:cd:1: no such file or directory: /lab-modules/opentelemetry-capstone
+
+
+### 99. [✅ PASS] `shell` step
+
+```
+kubectl delete ns dynatrace
+```
+
+### 100. [✅ PASS] `shell` step
+
+```
+kubectl create namespace dynatrace
+```
+
+### 101. [✅ PASS] `shell` step
+
+```
+kubectl create secret generic dynatrace-otelcol-dt-api-credentials --from-literal=DT_ENDPOINT=$DT_ENDPOINT --from-literal=DT_API_TOKEN=$DT_API_TOKEN -n dynatrace
+```
+
+### 102. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/cert-manager.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/cert-manager.yaml' not present — expected in automated context
+
+### 103. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/opentelemetry-operator.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/opentelemetry-operator.yaml' not present — expected in automated context
+
+### 104. [⏭️ SKIP] `verify` step
+
+```
+Validate that the OpenTelemetry Operator components are running.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 105. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n opentelemetry-operator-system
+```
+
+### 106. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/rbac/otel-collector-k8s-clusterrole.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/rbac/otel-collector-k8s-clusterrole.yaml' not present — expected in automated context
+
+### 107. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/rbac/otel-collector-k8s-clusterrole-crb.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/rbac/otel-collector-k8s-clusterrole-crb.yaml' not present — expected in automated context
+
+### 108. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/collector/dynatrace/otel-collector-dynatrace-deployment-crd.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/collector/dynatrace/otel-collector-dynatrace-deployment-crd.yaml' not present — expected in automated context
+
+### 109. [⏭️ SKIP] `verify` step
+
+```
+Validate running pod(s)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 110. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 111. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f opentelemetry/collector/dynatrace/otel-collector-dynatrace-daemonset-crd.yaml
+```
+
+**Error:** Student-created file 'opentelemetry/collector/dynatrace/otel-collector-dynatrace-daemonset-crd.yaml' not present — expected in automated context
+
+### 112. [⏭️ SKIP] `verify` step
+
+```
+Validate running pod(s)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 113. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 114. [❌ FAIL] `shell` step
+
+```
+helm upgrade astronomy-shop open-telemetry/opentelemetry-demo --values astronomy-shop/sed/collector-values.yaml --namespace astronomy-shop --version "0.31.0"
+```
+
+**Error:** Error: open astronomy-shop/sed/collector-values.yaml: no such file or directory
+
+
+### 115. [⏭️ SKIP] `verify` step
+
+```
+Validate and Analyze Data in Dynatrace #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 116. [⏭️ SKIP] `verify` step
+
+```
+Observe OpenTelemetry Collector health in Dynatrace #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 117. [⏭️ SKIP] `ui` step
+
+```
+Enable OpenTelemetry Collector self-monitoring telemetry
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 118. [⏭️ SKIP] `ui` step
+
+```
+Enable OpenTelemetry Collector self-monitoring telemetry
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 119. [⏭️ SKIP] `ui` step
+
+```
+Or open an issue to share suggestions, topics you'd like us to cover, or examples you'd find helpful.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 120. [⏭️ SKIP] `ui` step
+
+```
+Thank you for helping us create better enablement resources for everyone ❤️
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 121. [⏭️ SKIP] `ui` step
+
+```
+Visualization and Analysis: By exporting telemetry data to Dynatrace, you can visualize and analyze the health of your Kubernetes cluster. For example, you can use DQL to create dashboards that displa
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 122. [⏭️ SKIP] `ui` step
+
+```
+Alerting: With the collected data, you can set up alerts to notify you of any issues in your Kubernetes cluster. For instance, you can configure alerts for high error rates or resource exhaustion.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 123. [⏭️ SKIP] `ui` step
+
+```
+Delete Codespaces Instance #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 124. [⏭️ SKIP] `ui` step
+
+```
+Another way to do this is by going to https://github.com/codespaces and delete the codespace.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 125. [⏭️ SKIP] `ui` step
+
+```
+You may also want to deactivate or delete the API token needed for this lab.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)

--- a/validation-reports/workshop-destination-automation/2026-05-26.md
+++ b/validation-reports/workshop-destination-automation/2026-05-26.md
@@ -1,0 +1,1061 @@
+# Validation Report — workshop-destination-automation
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-26 |
+| Training ID | `destination-automation` |
+| Job ID | `enablement-02acf69457d3` |
+| Pages crawled | 10 |
+| Steps executed | 129 |
+| Pass | 5 |
+| Fail | **5** |
+| Expected-fail | 0 |
+| Skip | 119 |
+| Duration | 121s |
+
+## Summary
+
+**5 step(s) failed.** See details below.
+
+## Step Findings
+
+### 1. [⏭️ SKIP] `verify` step
+
+```
+This lab demonstrates how Dynatrace and Red Hat Ansible Automation Platform (AAP) work together to deploy, observe, automate, and remediate a containerized AI application.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 2. [⏭️ SKIP] `verify` step
+
+```
+Observe prompt-to-response behavior in AI workloads.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 3. [⏭️ SKIP] `ui` step
+
+```
+Using full admin permissions to the Dynatrace account and tenant, create the following tokens/credentials for this workshop.  Store them in a secure location, as you will need to input them into the A
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 4. [⏭️ SKIP] `ui` step
+
+```
+Provisioning Red Hat Ansible Automation Platform will take some time (next step).  It is recommended to create these tokens while AAP is installing.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 5. [⏭️ SKIP] `ui` step
+
+```
+Use this token for Monaco configuration-as-code deployment.  This token is also used by Ansible roles that create Dynatrace configuration objects not handled by Monaco.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 6. [⏭️ SKIP] `verify` step
+
+```
+[ ] Verify connectivity to required registries and APIs
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 7. [⏭️ SKIP] `verify` step
+
+```
+[ ] Confirm workshop host has available CPU, memory, and disk for containers
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 8. [⏭️ SKIP] `verify` step
+
+```
+[ ] Validate that port access policies allow workshop traffic
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 9. [⏭️ SKIP] `verify` step
+
+```
+[ ] Confirm you are able to create all tokens/credentials
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 10. [⏭️ SKIP] `verify` step
+
+```
+Validate the platform is ready for deployment workflows.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 11. [❌ FAIL] `shell` step
+
+```
+sudo dnf update -y
+sudo dnf install -y ansible-core
+sudo dnf install -y wget git-core rsync vim nano git
+sudo dnf install -y podman
+sudo dnf install -y python3-pip
+```
+
+**Error:** sudo: dnf: command not found
+sudo: dnf: command not found
+sudo: dnf: command not found
+sudo: dnf: command not found
+sudo: dnf: command not found
+
+
+### 12. [❌ FAIL] `shell` step
+
+```
+sudo reboot
+```
+
+**Error:** sudo: reboot: command not found
+
+
+### 13. [✅ PASS] `shell` step
+
+```
+cd ~
+git clone https://github.com/dynatrace-wwse/workshop-destination-automation.git
+```
+
+### 14. [✅ PASS] `shell` step
+
+```
+cd ~/workshop-destination-automation/ansible
+```
+
+### 15. [⏭️ SKIP] `ui` step
+
+```
+Create AAP target installation directory
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 16. [✅ PASS] `shell` step
+
+```
+export CURRENT_USER=$(whoami)
+sudo mkdir /opt/ansible
+sudo chown $CURRENT_USER:$CURRENT_USER /opt/ansible
+```
+
+### 17. [❌ FAIL] `shell` step
+
+```
+mkdir -p ~/.ansible/collections
+ansible-galaxy collection install -r requirements.yml
+```
+
+**Error:** zsh:2: command not found: ansible-galaxy
+
+
+### 18. [⏭️ SKIP] `ui` step
+
+```
+Set your required variables and run the install playbook.  You may review additional installation variables in the documentation here: AAP Containerized Quickstart
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 19. [⏭️ SKIP] `ui` step
+
+```
+Provisioning Red Hat Ansible Automation Platform will take some time.  It is recommended to create the Dynatrace Tokens and Credentials while AAP is installing.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 20. [⏭️ SKIP] `verify` step
+
+```
+After installation completes, you can validate AAP status with the included healthcheck script.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 21. [✅ PASS] `shell` step
+
+```
+cd ~/workshop-destination-automation/ansible && ./aap_status.sh
+```
+
+### 22. [⏭️ SKIP] `verify` step
+
+```
+Step 4: Apply Subscription and Validate Access ¶
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 23. [⏭️ SKIP] `verify` step
+
+```
+Open the AAP web console https://{AAP-PUBLIC-HOSTNAME}:443/ You can expect a TLS certificate warning
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 24. [⏭️ SKIP] `verify` step
+
+```
+You can expect a TLS certificate warning
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 25. [⏭️ SKIP] `verify` step
+
+```
+Confirm Controller and Automation Hub are reachable
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 26. [⏭️ SKIP] `ui` step
+
+```
+If you choose to build locally, the default configurations may fail.  You will need to troubleshoot this on your own, requiring Ansible and ansible-builder expertise.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 27. [⏭️ SKIP] `ui` step
+
+```
+Step 1: Create AAP Service Account User ¶
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 28. [❌ FAIL] `shell` step
+
+```
+cd ~/workshop-destination-automation/ansible
+ansible-playbook deploy/playbooks/configure_aap.yml
+```
+
+**Error:** zsh:2: command not found: ansible-playbook
+
+
+### 29. [⏭️ SKIP] `ui` step
+
+```
+Create Job Template Domains (optional, recommended)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 30. [⏭️ SKIP] `ui` step
+
+```
+OpenPipeline routing tables are comprehensive for the environment.  If existing rules exist in the routing table, applying a new configuration with Monaco will delete/overwrite the existing rules.  To
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 31. [⏭️ SKIP] `ui` step
+
+```
+Enable Workflows Authorization:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 32. [⏭️ SKIP] `ui` step
+
+```
+Open the Workflows app.  In the top right corner, click on the gear icon, then Authorization Settings.  Enable all Primary Permissions.  Enable all Secondary Permissions.  Click Save.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 33. [⏭️ SKIP] `verify` step
+
+```
+Verify health endpoints and access
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 34. [⏭️ SKIP] `verify` step
+
+```
+Continue to Observe and Automate .
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 35. [⏭️ SKIP] `verify` step
+
+```
+In this phase, you drive the application with prompts, observe behavior in Dynatrace AI observability views, and automate controlled runtime changes through deployment workflows.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 36. [⏭️ SKIP] `verify` step
+
+```
+Observe workload behavior and AI response characteristics
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 37. [⏭️ SKIP] `ui` step
+
+```
+Choose office destinations closest to your geography (continent).
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 38. [⏭️ SKIP] `ui` step
+
+```
+Open the AI Travel Advisor application
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 39. [⏭️ SKIP] `ui` step
+
+```
+Set the approach to Direct LLM
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 40. [⏭️ SKIP] `ui` step
+
+```
+Ask for travel advice for the same location set used in Direct LLM
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 41. [⏭️ SKIP] `verify` step
+
+```
+Step 2: Observe in Dynatrace ¶
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 42. [⏭️ SKIP] `ui` step
+
+```
+Log in to your Dynatrace tenant
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 43. [⏭️ SKIP] `ui` step
+
+```
+In the Dynatrace web UI, search for AI Observability or navigate via the Apps menu
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 44. [⏭️ SKIP] `ui` step
+
+```
+Open the AI Observability app
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 45. [⏭️ SKIP] `ui` step
+
+```
+In the service list, select the ai-travel-advisor service.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 46. [⏭️ SKIP] `ui` step
+
+```
+OpenLLMetry is an open observability approach for LLM applications that captures prompt, response, model, token, latency, and retrieval metadata using OpenTelemetry-aligned telemetry. This turns AI be
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 47. [⏭️ SKIP] `ui` step
+
+```
+Select one of your recent prompts (ideally from the baseline traffic you generated in Step 1).
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 48. [⏭️ SKIP] `ui` step
+
+```
+Click Open Distributed Trace to view the full call flow.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 49. [⏭️ SKIP] `verify` step
+
+```
+Did you observe any parallel processing, or was everything sequential?
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 50. [⏭️ SKIP] `ui` step
+
+```
+What metrics would you add to this trace if you were responsible for cost control?
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 51. [⏭️ SKIP] `verify` step
+
+```
+How observability and automation work together to validate changes
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 52. [⏭️ SKIP] `ui` step
+
+```
+Open the Red Hat AAP web interface in your browser
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 53. [⏭️ SKIP] `ui` step
+
+```
+Log in using your instructor credentials
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 54. [⏭️ SKIP] `ui` step
+
+```
+Open the Red Hat AAP web interface in your browser
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 55. [⏭️ SKIP] `ui` step
+
+```
+Log in using your participant credentials (provided by your instructor)
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 56. [⏭️ SKIP] `ui` step
+
+```
+In the AAP web UI, navigate to Automation Execution → Templates
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 57. [⏭️ SKIP] `verify` step
+
+```
+Stage 1: Validate — Pre-flight checks ensure target infrastructure is ready
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 58. [⏭️ SKIP] `verify` step
+
+```
+Stage 4: Verify — Health checks confirm the new deployment is responsive and operational
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 59. [⏭️ SKIP] `ui` step
+
+```
+Click Next → Launch .
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 60. [⏭️ SKIP] `verify` step
+
+```
+Inspect Job Outputs and Validate Deployment
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 61. [⏭️ SKIP] `verify` step
+
+```
+While the workflow executes, observe:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 62. [⏭️ SKIP] `ui` step
+
+```
+Open the AI Observability app in Dynatrace
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 63. [⏭️ SKIP] `ui` step
+
+```
+Navigate to the Explorer tab
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 64. [⏭️ SKIP] `ui` step
+
+```
+Select the ai-travel-advisor service
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 65. [⏭️ SKIP] `ui` step
+
+```
+Open the prompt details and review: Prompt text Response text Model metadata Temperature and runtime settings Token usage User feedback
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 66. [⏭️ SKIP] `ui` step
+
+```
+From the selected prompt, open the distributed trace .
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 67. [⏭️ SKIP] `ui` step
+
+```
+In Dynatrace, open the Dashboards app.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 68. [⏭️ SKIP] `ui` step
+
+```
+Open the AI Model Versioning and A/B Testing dashboard.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 69. [⏭️ SKIP] `ui` step
+
+```
+At the top of the dashboard, set the comparison variables for: Provider A + Model A Provider B + Model B
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 70. [⏭️ SKIP] `ui` step
+
+```
+Choose the same or very similar prompts across both model versions and compare:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 71. [⏭️ SKIP] `ui` step
+
+```
+If you were choosing a production default, which runtime would you select and why?
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 72. [⏭️ SKIP] `verify` step
+
+```
+Dynatrace makes it possible to compare AI runtime inputs, outputs, performance, functionality, cost, and user feedback across the full delivery lifecycle. That means you can move from guesswork to evi
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 73. [⏭️ SKIP] `ui` step
+
+```
+Enable a feature flag that changes the AI embedding model.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 74. [⏭️ SKIP] `verify` step
+
+```
+Observe impact without taking down the application.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 75. [⏭️ SKIP] `verify` step
+
+```
+Validate Dynatrace detection of model drift and resulting problem state.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 76. [⏭️ SKIP] `ui` step
+
+```
+OpenFeature is an open standard and CNCF sandbox project that provides a vendor-neutral API and SDK model for feature flagging, so application code can evaluate flags consistently without being tightl
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 77. [⏭️ SKIP] `ui` step
+
+```
+In this step, you will introduce a controlled embedding-model change, via an OpenFeature feature flag, to create observable drift conditions.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 78. [⏭️ SKIP] `ui` step
+
+```
+For the new embedding model value, select the same model the application is currently using
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 79. [⏭️ SKIP] `verify` step
+
+```
+Execute the job and confirm the application remains available
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 80. [⏭️ SKIP] `verify` step
+
+```
+Step 2: Observe Drift Behavior ¶
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 81. [⏭️ SKIP] `ui` step
+
+```
+Continue sending prompts for several minutes to create sustained telemetry
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 82. [⏭️ SKIP] `verify` step
+
+```
+Keep submitting prompts and feedback. After some time, you should observe that RAG responses begin returning to expected quality.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 83. [⏭️ SKIP] `verify` step
+
+```
+Which signals would you expect to see in telemetry during the failure period vs the recovery period?
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 84. [⏭️ SKIP] `ui` step
+
+```
+In the AAP web interface, navigate to Automation Decisions -> Rule Audit
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 85. [⏭️ SKIP] `ui` step
+
+```
+Open the event details from the Rule Audit record
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 86. [⏭️ SKIP] `verify` step
+
+```
+Confirm the event source is Dynatrace and review the payload metadata describing the AI Travel Advisor problem
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 87. [⏭️ SKIP] `verify` step
+
+```
+You should see that a remediation job template was executed. The specific job is selected because the incoming event payload matched a rulebook condition that points to the desired remediation action.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 88. [⏭️ SKIP] `ui` step
+
+```
+Open the related job execution output in AAP.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 89. [⏭️ SKIP] `verify` step
+
+```
+Verify the job changed the OpenFeature embedding-model flag back to the correct original model used to build the Weaviate collection.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 90. [⏭️ SKIP] `ui` step
+
+```
+Open the Dynatrace environment and navigate to the AI Observability app
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 91. [⏭️ SKIP] `ui` step
+
+```
+Click on the service to open the detail view
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 92. [⏭️ SKIP] `ui` step
+
+```
+Navigate to the Problems tab to see automatically detected issues
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 93. [⏭️ SKIP] `verify` step
+
+```
+You should see a problem card titled AI Travel Advisor: Embedding Model Drift Detected . This problem was automatically created when Dynatrace Intelligence detected the anomaly during your traffic gen
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 94. [⏭️ SKIP] `ui` step
+
+```
+Dynatrace correlates high vector distances with low user satisfaction signals to create a clear problem statement: "Embedding Model Drift Detected."
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 95. [⏭️ SKIP] `ui` step
+
+```
+Open the workflow execution that was triggered by this problem detection
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 96. [⏭️ SKIP] `verify` step
+
+```
+Dynatrace's out-of-the-box integrations with ServiceNow, JIRA, Slack, PagerDuty, and many others, ensure that teams across operations, development, and business stakeholders are informed of AI service
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 97. [⏭️ SKIP] `ui` step
+
+```
+Set up a local development environment with the workshop repository
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 98. [⏭️ SKIP] `ui` step
+
+```
+Log in to AAP Gateway as your assigned user (instructor or participant). Click your username in the top-right corner and select User Settings . Navigate to the Tokens tab and click Create token .
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 99. [⏭️ SKIP] `verify` step
+
+```
+Read for participants who will observe job executions and query automation status
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 100. [✅ PASS] `shell` step
+
+```
+git clone https://github.com/dynatrace-wwse/workshop-destination-automation.git
+cd workshop-destination-automation
+```
+
+### 101. [❌ FAIL] `shell` step
+
+```
+cp dynatrace/skills/references/ai-observability.md .github/skills/dtctl/references/ai-observability.md
+```
+
+**Error:** cp: cannot create regular file '.github/skills/dtctl/references/ai-observability.md': No such file or directory
+
+
+### 102. [⏭️ SKIP] `verify` step
+
+```
+Validate the integration by asking Copilot a simple question, for example:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 103. [⏭️ SKIP] `ui` step
+
+```
+The Model Context Protocol (MCP) is an open standard enabling AI agents to securely connect to external systems. MCP Servers bridge AI agents and APIs, translating natural-language requests into authe
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 104. [⏭️ SKIP] `ui` step
+
+```
+Log in to AAP as your assigned user (instructor or participant).  From your user profile, manually generate a Platform API Token with the appropriate scope:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 105. [⏭️ SKIP] `verify` step
+
+```
+read for participants who will primarily observe
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 106. [⏭️ SKIP] `verify` step
+
+```
+Validate the integration by asking Copilot:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 107. [⏭️ SKIP] `ui` step
+
+```
+How many UI screens and filters would you typically navigate to find failed jobs across multiple templates, correlate them with EDA rule activations, and summarize root causes from job logs? What does
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 108. [⏭️ SKIP] `verify` step
+
+```
+Observe how Copilot proposes tool calls to the Ansible MCP Server. Review the proposed actions before approving:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 109. [⏭️ SKIP] `verify` step
+
+```
+Verify the job template name matches your request
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 110. [⏭️ SKIP] `verify` step
+
+```
+Wait for Copilot to report the job execution status. Confirm it returns:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 111. [⏭️ SKIP] `verify` step
+
+```
+Validate the Change
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 112. [⏭️ SKIP] `ui` step
+
+```
+Open the AI Travel Advisor web interface in your browser
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 113. [⏭️ SKIP] `verify` step
+
+```
+Return to the Copilot chat and verify the runtime change via observability signals:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 114. [⏭️ SKIP] `verify` step
+
+```
+How many steps would it take to manually launch this job template through the AAP UI, supply the correct variables, monitor execution, and then validate the outcome through a separate Dynatrace query?
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 115. [⏭️ SKIP] `verify` step
+
+```
+Observe how the agent:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 116. [⏭️ SKIP] `verify` step
+
+```
+Observe, decide, and act collapse from minutes or hours into seconds. The agent handles the mechanical translation between systems while a human stays in control of the decision.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 117. [⏭️ SKIP] `verify` step
+
+```
+Every tool call—DQL query, AAP job launch, health check—is visible in the chat transcript. Delegated actions remain traceable, reviewable, and reversible through the same AAP and Dynatrace surfaces yo
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 118. [⏭️ SKIP] `verify` step
+
+```
+[ ] End-to-end delegated workflow completed: analyze models -> select best -> apply via AAP -> verify
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 119. [⏭️ SKIP] `ui` step
+
+```
+If you used a GitHub Codespace for this workshop, delete it immediately after completing the Delegate phase to avoid unwanted consumption charges.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 120. [⏭️ SKIP] `ui` step
+
+```
+Navigate to https://github.com/codespaces
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 121. [⏭️ SKIP] `verify` step
+
+```
+Confirm deletion
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 122. [⏭️ SKIP] `verify` step
+
+```
+How to validate model and retrieval configuration changes with telemetry-backed evidence.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 123. [⏭️ SKIP] `ui` step
+
+```
+Add policy-driven approvals for high-impact automation paths.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 124. [⏭️ SKIP] `verify` step
+
+```
+Confirm no unexpected services or credentials remain active.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 125. [⏭️ SKIP] `ui` step
+
+```
+Disable or remove temporary credentials and service accounts used for the workshop.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 126. [⏭️ SKIP] `ui` step
+
+```
+Archive or delete workshop-specific projects and job templates if this was a disposable environment.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 127. [⏭️ SKIP] `verify` step
+
+```
+Verify expected ports are closed.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 128. [⏭️ SKIP] `verify` step
+
+```
+Confirm no workshop containers are still running.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 129. [⏭️ SKIP] `verify` step
+
+```
+Confirm disk and memory utilization has returned to expected idle levels.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)

--- a/validation-reports/workshop-dynatrace-log-analytics/2026-05-26.md
+++ b/validation-reports/workshop-dynatrace-log-analytics/2026-05-26.md
@@ -1,0 +1,543 @@
+# Validation Report — workshop-dynatrace-log-analytics
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-26 |
+| Training ID | `log-analytics` |
+| Job ID | `enablement-dd2261328a08` |
+| Pages crawled | 11 |
+| Steps executed | 67 |
+| Pass | 11 |
+| Fail | **2** |
+| Expected-fail | 1 |
+| Skip | 53 |
+| Duration | 397s |
+
+## Summary
+
+**2 step(s) failed.** See details below.
+
+## Step Findings
+
+### 1. [⏭️ SKIP] `verify` step
+
+```
+Deploy Dynatrace Deploy Dynatrace on Kubernetes for full-stack observability with logs in context Validate observability signals, including logs
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 2. [⏭️ SKIP] `verify` step
+
+```
+Validate observability signals, including logs
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 3. [⏭️ SKIP] `ui` step
+
+```
+Use Dynatrace Account Management to create a Platform Token.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 4. [⏭️ SKIP] `ui` step
+
+```
+Create Codespace #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 5. [⏭️ SKIP] `ui` step
+
+```
+Click to open Codespaces for this workshop repository:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 6. [⏭️ SKIP] `ui` step
+
+```
+Branch select the main branch
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 7. [⏭️ SKIP] `ui` step
+
+```
+select the main branch
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 8. [⏭️ SKIP] `ui` step
+
+```
+Dev container configuration select Dynatrace Enablement Container
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 9. [⏭️ SKIP] `ui` step
+
+```
+select Dynatrace Enablement Container
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 10. [⏭️ SKIP] `ui` step
+
+```
+Machine type select 4-core
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 11. [⏭️ SKIP] `ui` step
+
+```
+select 4-core
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 12. [⏭️ SKIP] `ui` step
+
+```
+Region select any region, preferably one closest to your Dynatrace tenant
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 13. [⏭️ SKIP] `ui` step
+
+```
+select any region, preferably one closest to your Dynatrace tenant
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 14. [⏭️ SKIP] `verify` step
+
+```
+Make sure your container has sufficient resources (4 CPU Core & 16 GB Memory minimum).
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 15. [⏭️ SKIP] `ui` step
+
+```
+EasyTrade is not required to complete the workshop.  It is available should you choose to add additional environment complexity and use cases.  The hands-on exercises do not reference EasyTrade, howev
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 16. [⏭️ SKIP] `verify` step
+
+```
+Deploying additional demo applications will consume significant resources.  In order to deploy EasyTrade, make sure you have 8 CPU and 32GB Memory allocated to your Codespaces container.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 17. [⏭️ SKIP] `ui` step
+
+```
+HipsterShop is not required to complete the workshop.  It is available should you choose to add additional environment complexity and use cases.  The hands-on exercises do not reference HipsterShop, h
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 18. [⏭️ SKIP] `verify` step
+
+```
+Deploying additional demo applications will consume significant resources.  In order to deploy HipsterShop, make sure you have 8 CPU and 32GB Memory allocated to your Codespaces container.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 19. [✅ PASS] `shell` step
+
+```
+kubectl delete pods --all -n astroshop
+```
+
+### 20. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n astroshop
+```
+
+### 21. [✅ PASS] `shell` step
+
+```
+kubectl get events -n astroshop
+```
+
+### 22. [✅ PASS] `shell` step
+
+```
+kubectl get events -n kube-system
+kubectl get events -n default
+```
+
+### 23. [❌ FAIL] `shell` step
+
+```
+kubectl get svc astroshop-frontendproxy -n astroshop
+```
+
+**Error:** Error from server (NotFound): services "astroshop-frontendproxy" not found
+
+
+### 24. [⏭️ SKIP] `verify` step
+
+```
+Review the Monaco logs output in the console and check for any error messages.  If the configurations were deployed successfully, you should see Successfully deployed Dynatrace Configurations with Mon
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 25. [⏭️ SKIP] `ui` step
+
+```
+Dynatrace provides a flexible approach to Kubernetes observability where you can pick and choose the level of observability you need for your Kubernetes clusters. The Dynatrace Operator manages all th
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 26. [⏭️ SKIP] `ui` step
+
+```
+Enable data enrichment for Kubernetes environments.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 27. [⏭️ SKIP] `ui` step
+
+```
+Set Environment Variables #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 28. [❌ FAIL] `shell` step
+
+```
+export DT_ENVIRONMENT=https://abc123.apps.dynatrace.com
+export DT_OPERATOR_TOKEN=dt0c01.<YOUR-DYNATRACE-OPERATOR-TOKEN>
+export DT_INGEST_TOKEN=dt0c01.<YOUR-DATA-INGEST-TOKEN>
+```
+
+**Error:** zsh:3: parse error near `\n'
+
+
+### 29. [⏭️ SKIP] `verify` step
+
+```
+Validate that the Dynatrace Operator was deployed successfully.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 30. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 31. [⏭️ SKIP] `verify` step
+
+```
+Validate that the Dynatrace Dynakube was deployed successfully.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 32. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 33. [✅ PASS] `shell` step
+
+```
+kubectl delete pods -n astroshop --field-selector="status.phase=Running"
+```
+
+### 34. [⏭️ SKIP] `verify` step
+
+```
+Validate Log Ingest #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 35. [⏭️ SKIP] `verify` step
+
+```
+Validate log data after running the query.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 36. [⏭️ SKIP] `ui` step
+
+```
+1. Select distribution
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 37. [⏭️ SKIP] `ui` step
+
+```
+2. Select observability options
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 38. [✅ PASS] `shell` step
+
+```
+helm install dynatrace-operator oci://public.ecr.aws/dynatrace/dynatrace-operator \
+--create-namespace \
+--namespace dynatrace \
+--atomic
+```
+
+### 39. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 40. [⚠️ EXPECTED-FAIL] `shell` step
+
+```
+kubectl apply -f dynakube.yaml
+```
+
+**Error:** Student-created file 'dynakube.yaml' not present — expected in automated context
+
+### 41. [✅ PASS] `shell` step
+
+```
+kubectl get pods -n dynatrace
+```
+
+### 42. [⏭️ SKIP] `verify` step
+
+```
+In case you encounter an ImagePullBackOff error, check public.ecr.aws to make sure the container image with that tag exists.  If not, change the value to use an existing one.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 43. [✅ PASS] `shell` step
+
+```
+kubectl delete pods -n astroshop --field-selector="status.phase=Running"
+```
+
+### 44. [⏭️ SKIP] `verify` step
+
+```
+Validate Log Ingest #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 45. [⏭️ SKIP] `verify` step
+
+```
+Validate log data after running the query.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 46. [⏭️ SKIP] `ui` step
+
+```
+Navigate from a log entry to the affected Kubernetes workload.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 47. [⏭️ SKIP] `ui` step
+
+```
+Create custom pipelines to extract relevant log fields.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 48. [⏭️ SKIP] `ui` step
+
+```
+Enable Reusable, Scalable Filtering
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 49. [⏭️ SKIP] `ui` step
+
+```
+Users can select one or more values at runtime, making the segment reusable across dashboards, notebooks, and workflows.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 50. [⏭️ SKIP] `verify` step
+
+```
+Ensure compliance with internal and external data governance policies.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 51. [⏭️ SKIP] `ui` step
+
+```
+Record level control is done via fields or dt.security.context which must be set on the records themselves and
+defined within the policy.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 52. [⏭️ SKIP] `ui` step
+
+```
+Create Metrics from Logs
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 53. [⏭️ SKIP] `ui` step
+
+```
+Dynatrace, with OpenPipeline, can create metrics and aggregate metric data points from log data at ingest.  By leveraging metrics based on your log data you'll get:
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 54. [⏭️ SKIP] `ui` step
+
+```
+Create Events from Logs
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 55. [⏭️ SKIP] `ui` step
+
+```
+Extract a Business Event to enable business observablity and report on business outcomes.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 56. [⏭️ SKIP] `ui` step
+
+```
+Use logs when low frequency refresh is required, involve a complex DQL, join different data types, analyzing short timeframes. Use metrics when high frequency refresh is required, trending over long t
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 57. [⏭️ SKIP] `ui` step
+
+```
+Use metrics when high frequency refresh is required, trending over long timeframes, need to optimize query costs, to create SLOs/alerts.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 58. [⏭️ SKIP] `ui` step
+
+```
+Now that logs are flowing into Dynatrace from our Kubernetes environment, it's time to unlock their full potential. Enter Dynatrace Query Language (DQL) - a powerful, intuitive language purpose-built 
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 59. [⏭️ SKIP] `ui` step
+
+```
+Or open an issue to share suggestions, topics you'd like us to cover, or examples you'd find helpful.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 60. [⏭️ SKIP] `ui` step
+
+```
+Thank you for helping us create better enablement resources for everyone ❤️
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 61. [⏭️ SKIP] `ui` step
+
+```
+Delete Dynatrace Configurations with Monaco #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 62. [⏭️ SKIP] `ui` step
+
+```
+You can choose to keep the Dynatrace configurations, including the Notebooks and Dashboards, but if you want to delete them automatically you can leverage the helper function.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 63. [⏭️ SKIP] `ui` step
+
+```
+Delete the Dynatrace configurations with Monaco using the provided helper function.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 64. [⏭️ SKIP] `ui` step
+
+```
+Delete Codespace #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 65. [⏭️ SKIP] `ui` step
+
+```
+Another way to do this is by going to https://github.com/codespaces and delete the codespace.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 66. [⏭️ SKIP] `ui` step
+
+```
+Delete Dynatrace Tokens #
+```
+
+**Error:** UI/verify steps skipped (--no-ui)
+
+### 67. [⏭️ SKIP] `ui` step
+
+```
+You may also want to deactivate or delete the API and Platform token(s) needed for this lab.
+```
+
+**Error:** UI/verify steps skipped (--no-ui)


### PR DESCRIPTION
## Summary

- **Root cause:** Astroshop (Next.js) was served at `/apps/{job_id}/astroshop/` via the Orbital proxy. Next.js dynamic asset references escape the HTML rewriter and 404. The underlying k3d ingress + Envoy routing was correct all along.
- **Fix:** Apps now get a canonical URL at `{appname}--{job_slug}.autonomous-enablements.whydevslovedynatrace.com`, served at root `/`. No HTML/CSS rewriting — Next.js resolves assets correctly.
- **Proxy endpoint verified:** `GET /proxy-subdomain/{path}` returns 200 for both the astroshop page and image URLs.

## Changes

- **`functions.sh`** — `computeOrbitalSubdomain()`, updated `getAppURL` / `registerApp` / `registerAstroshopIngress` to emit wildcard subdomain URLs when `ORBITAL_JOB_ID` is set; APP_REGISTRY field 7 = orbital_subdomain
- **`executor.py`** — `_write_env_file()` now writes `ORBITAL_JOB_ID` into the daemon job `.env` so `functions.sh` can compute the subdomain
- **`agent.py`** — slot cleanup now removes all inner containers (k3d nodes) between jobs, fixing a naming-conflict bug where old k3d-enablement-server-0 blocked fresh cluster creation
- **`manager.py`** — injects `ORBITAL_JOB_ID` into Sysbox `.env` for manager-spawned containers
- **`app.py`** — `_find_job_by_subdomain()`, `/proxy-subdomain/{path}` route, `subdomain_url` in job apps API
- **`ops-server.conf`** — wildcard `server_name` block for `*.autonomous-enablements.whydevslovedynatrace.com`
- **`post-create.sh`** (branch only) — stripped to k3d + astroshop only for fast verification

## Test plan

- [x] Astroshop deployed in 3:35 on daemon job `worker-x86_64-8f6d29-codespaces-framework-1779882065194-f5457d`
- [x] `GET /proxy-subdomain/` → 200
- [x] `GET /proxy-subdomain/images/products/LensCleaningKit.jpg` → 200
- [x] **DNS:** Add `*.autonomous-enablements.whydevslovedynatrace.com A 18.134.158.252` to Google Cloud DNS
- [x] **TLS:** `certbot certonly --manual --preferred-challenges dns -d "*.autonomous-enablements.whydevslovedynatrace.com" -d "autonomous-enablements.whydevslovedynatrace.com"`
- [x] `/etc/nginx/nginx.conf`: ensure `server_names_hash_bucket_size 128;` (already done on server)
- [ ] Full end-to-end: open `https://astroshop--{job_slug}.autonomous-enablements.whydevslovedynatrace.com` in browser and verify images load

## Test container

Daemon job running: `worker-x86_64-8f6d29-codespaces-framework-1779882065194-f5457d` (amd64, worker-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)