### PR TITLE
feat: add enablement-app-training-template to managed repos and docs

### DIFF
--- a/docs/template.md
+++ b/docs/template.md
@@ -1,6 +1,15 @@
+# Templates
 
+The framework ships two official templates. Choose the one that matches your delivery mode.
 
+| Template | Delivery mode | Best for |
+|---|---|---|
+| [Codespaces Template](#codespaces-template) | GitHub Codespaces | Labs, workshops, self-paced content delivered via browser Codespace |
+| [App Training Template](#app-training-template) | Orbital + Dynatrace app | Scored, interactive trainings rendered inside the Dynatrace product |
 
+---
+
+## Codespaces Template {#codespaces-template}
 
 !!! abstract "The [Enablement Codespaces Template](https://github.com/dynatrace-wwse/enablement-codespaces-template)"
     ![professors](img/dt_professors.png){ align=right ; width="150"}
@@ -9,7 +18,7 @@
 ---
 
 
-## 🚀 What is the Codespaces Template?
+### 🚀 What is the Codespaces Template?
 
 
 This template repository offers:
@@ -22,7 +31,7 @@ This template repository offers:
 
 ---
 
-## 📦 Repository Overview
+### 📦 Repository Overview
 
 **Main features:**
 
@@ -38,7 +47,7 @@ For a complete file and folder breakdown, see the [repository on GitHub](https:/
 ---
 
 
-## 📝 How to Use the Template
+### 📝 How to Use the Template
 
 
 1. **Create your own enablement repository**
@@ -57,7 +66,7 @@ For a complete file and folder breakdown, see the [repository on GitHub](https:/
 
 ---
 
-## 📝 TODOs in the Codebase
+### 📝 TODOs in the Codebase
 
 Throughout the template repository, you will find `TODO` comments in various files. These guide you step-by-step as you create your own enablements—reminding you where to add content, configure secrets, or customize scripts.
 
@@ -69,7 +78,7 @@ By following and resolving these TODOs, you can efficiently adapt the template t
 ---
 
 
-## 🧑‍🏫 Who is this for?
+### 🧑‍🏫 Who is this for?
 
 - Trainers and educators creating hands-on labs
 - Solution architects building demo environments
@@ -79,7 +88,7 @@ By following and resolving these TODOs, you can efficiently adapt the template t
 ---
 
 
-## 📚 Documentation & Resources
+### 📚 Documentation & Resources
 
 - [Template Repository](https://github.com/dynatrace-wwse/enablement-codespaces-template)
 - [How to use the Codespaces Template](https://dynatrace-wwse.github.io/enablement-codespaces-template/)
@@ -87,6 +96,80 @@ By following and resolving these TODOs, you can efficiently adapt the template t
 
 ---
 
+## App Training Template {#app-training-template}
+
+!!! abstract "The [Enablement App Training Template](https://github.com/dynatrace-wwse/enablement-app-training-template)"
+    The [Enablement App Training Template](https://github.com/dynatrace-wwse/enablement-app-training-template) is a trainer-authoring scaffold for building **interactive, scored trainings** that run on the **Orbital Operations server** and render inside the **Dynatrace app**. A trainer who follows the template in order can have a working interactive lesson — shell checks, kubectl, DQL validation, and a scored assessment — within approximately 30 minutes.
+
+---
+
+### 🚀 What is the App Training Template?
+
+This template is designed for content authors who want to deliver training **inside the Dynatrace product itself**, not through a separate browser tab. Learners interact with a live Kubernetes cluster and their Dynatrace tenant, get immediate feedback on every step, and receive a final scored assessment — all within the Dynatrace app.
+
+The template exposes every interactive block type as a live, runnable example:
+
+| Block type | What it does |
+|---|---|
+| `shell-verification` | Runs a shell command in the Orbital container and validates the output |
+| `kubectl` (interactive) | Terminal tab — learner types commands against the live cluster |
+| `kubectl` (non-interactive) | `shell-verification` with jsonpath/grep patterns |
+| `dql-verification` | Runs a DQL query against the learner's Dynatrace tenant |
+| `STEP_SETUP` | Runs framework functions before a page renders (credential loading, DynaKube generation) |
+| `multiple-choice` | Inline knowledge check (no separate file needed) |
+| `boundScenarioId` | Links a full scored assessment from `.assessment/*.json` |
+| Custom functions | `.devcontainer/util/my_functions.sh` — fault injection, scenario setup, validation helpers |
+| `hs-video` | Embedded video from the Orbital server |
+| `dt-app` deep links | In-lesson buttons that open Dynatrace apps (Kubernetes, Services, Notebooks, etc.) |
+
+---
+
+### 📦 Repository Overview
+
+- **.assessment/**: Scored assessment JSON files (MCQ + DQL questions, points, hints)
+- **.devcontainer/**: devcontainer config, `post-create.sh`, `my_functions.sh`
+- **docs/**: 5-lesson trainer guide + `AUTHORING.md` + `ORBITAL_AND_APP.md` + `REFERENCE_KUBERNETES_101.md`
+- **mkdocs.yaml**: Nav and site config
+- **README.md**: Trainer quickstart
+
+---
+
+### 📝 How to Use the Template
+
+1. **Create your training repository**
+	- Click "Use this template" on [the GitHub repo](https://github.com/dynatrace-wwse/enablement-app-training-template)
+	- Name your new repository `enablement-<topic>` in the `dynatrace-wwse` org
+2. **Open in Codespaces and follow the 5-lesson guide**
+	- `00 — Getting Started` → understand Orbital + Dynatrace app architecture
+	- `01 — Lesson Anatomy` → block types, lifecycle, nav registration
+	- `02 — Interactive Building Blocks` → click through every live example
+	- `03 — Example Lesson` → see a complete lesson end-to-end
+	- `04 — Publishing & Validation` → deploy to GitHub Pages, register with Orbital
+3. **Replace example content** with your training topic
+4. **Publish to GitHub Pages** with `deployGhdocs`
+5. **Register with Orbital** — contact the Orbital administrator with your repo URL
+
+---
+
+### 🧑‍🏫 Who is this for?
+
+- Solutions Engineers building scored interactive trainings inside the Dynatrace app
+- Content authors who want to use the reference training (`enablement-kubernetes-101`) as a pattern without reverse-engineering it
+- Trainers delivering Orbital-hosted labs with live cluster access and Dynatrace tenant integration
+
+---
+
+### 📚 Documentation & Resources
+
+- [Template Repository](https://github.com/dynatrace-wwse/enablement-app-training-template)
+- [Trainer Guide (GitHub Pages)](https://dynatrace-wwse.github.io/enablement-app-training-template/)
+- [Authoring Reference](https://dynatrace-wwse.github.io/enablement-app-training-template/AUTHORING/)
+- [Orbital & App Runtime](https://dynatrace-wwse.github.io/enablement-app-training-template/ORBITAL_AND_APP/)
+- [Reference Training (kubernetes-101)](https://github.com/dynatrace-wwse/enablement-kubernetes-101)
+- [Orbital Platform docs](ops-platform.md)
+
+---
+
 <div class="grid cards" markdown>
-- [Let's continue:octicons-arrow-right-24:](framework.md)
+- [Let's continue :octicons-arrow-right-24:](framework.md)
 </div>

--- a/repos.yaml
+++ b/repos.yaml
@@ -125,6 +125,17 @@ repos:
     is_template: true
     duration: "1h"
 
+  - name: enablement-app-training-template
+    repo: dynatrace-wwse/enablement-app-training-template
+    status: active
+    maintainer: "@shinojosa"
+    description: "Trainer-authoring scaffold for building interactive Dynatrace in-app enablement trainings on Orbital. Includes runnable examples for every interactive block type: shell verification, kubectl, DQL, assessments, and custom functions."
+    tags: [devops, orbital, dynatrace-app]
+    title: "App Training Template"
+    primary_tag: devops
+    is_template: true
+    duration: "30min"
+
   - name: enablement-kubernetes-opentelemetry-openpipeline
     repo: dynatrace-wwse/enablement-kubernetes-opentelemetry-openpipeline
     status: active


### PR DESCRIPTION
## Summary

- Registers `enablement-app-training-template` in `repos.yaml` as an active, sync-managed, template repo
- Updates `docs/template.md` to document both templates with a comparison table and full authoring guide
- Branch protection already applied via `sync protect-main --repo enablement-app-training-template`

## Changes

### `repos.yaml`
- New entry: `enablement-app-training-template`
- `status: active` | `is_template: true` | `sync_managed: true`
- Tags: `devops`, `orbital`, `dynatrace-app` | duration: `30min`
- Will now receive framework `push-update` syncs and appear in the repos registry

### `docs/template.md`
- Restructured with a comparison table (Codespaces Template vs App Training Template)
- Added full App Training Template section: block type table, repo structure, 5-step usage flow, links to AUTHORING.md / ORBITAL_AND_APP.md

## What's NOT in this PR
- `repos.json` update for The Hub — committed directly to `dynatrace-wwse.github.io` in a separate commit (see companion commit)

## Test plan
- [ ] `sync validate` passes with new repos.yaml entry
- [ ] `sync list` shows `enablement-app-training-template`
- [ ] docs/template.md renders correctly in MkDocs
- [ ] Branch protection is active on the new repo (already applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)