### PR TITLE
feat(test): AI Travel Advisor K3d integration test + DT_LLM_TOKEN support

### DIFF
--- a/.devcontainer/test/integration_k3d_aitraveladvisor.sh
+++ b/.devcontainer/test/integration_k3d_aitraveladvisor.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Integration test: AI Travel Advisor app on K3d
+#
+# Validates that the AI Travel Advisor stack (Ollama, Weaviate, app) deploys
+# successfully on K3d and is reachable through the nginx ingress.
+#
+# Requires DT_LLM_TOKEN — skips gracefully when absent so CI stays green on
+# workers that don't carry this credential.
+#
+# Architecture: AMD64 only — Ollama image is not published for ARM64.
+#
+# Run: bash .devcontainer/test/integration_k3d_aitraveladvisor.sh
+source .devcontainer/util/source_framework.sh
+
+if [[ "$ARCH" != "x86_64" ]]; then
+  printWarn "Skipping AI Travel Advisor test — AMD64 only (arch: $ARCH)"
+  exit 0
+fi
+
+if [[ -z "$DT_LLM_TOKEN" ]]; then
+  printWarn "Skipping AI Travel Advisor test — DT_LLM_TOKEN not set"
+  exit 0
+fi
+
+printInfoSection "=== AI Travel Advisor K3d integration test | arch: $ARCH ==="
+
+_run_env=$(detectRunEnvironment)
+printInfo "Environment: $_run_env | Arch: $ARCH"
+
+# Pre-test cleanup
+printInfo "Pre-test cleanup: removing any existing K3d clusters..."
+k3d cluster list -o json 2>/dev/null \
+  | python3 -c "import sys,json; [print(c['name']) for c in json.load(sys.stdin)]" 2>/dev/null \
+  | xargs -r k3d cluster delete 2>/dev/null || true
+
+# 1. Start K3d cluster
+printInfoSection "1/4  Starting K3d cluster"
+export CLUSTER_ENGINE=k3d
+startK3dCluster
+
+# 2. Deploy AI Travel Advisor (Ollama → Weaviate → app)
+printInfoSection "2/4  Deploying AI Travel Advisor stack"
+deployAITravelAdvisorApp
+
+# 3. Assertions
+printInfoSection "3/4  Assertions"
+
+assertRunningPod ai-travel-advisor ollama
+assertRunningPod ai-travel-advisor weaviate
+assertRunningPod ai-travel-advisor ai-travel-advisor
+assertRunningApp ai-travel-advisor
+
+# Verify weaviate PVC uses local-path (the fix this test guards)
+printInfoSection "Verifying weaviate PVC storageClassName: local-path"
+SC=$(kubectl get pvc weaviate-pvc -n ai-travel-advisor -o jsonpath='{.spec.storageClassName}' 2>/dev/null)
+if [[ "$SC" == "local-path" ]]; then
+  printInfo "✅ weaviate PVC storageClassName = local-path"
+else
+  printError "❌ weaviate PVC storageClassName = '${SC}' (expected local-path)"
+  deleteK3dCluster
+  exit 1
+fi
+
+# 4. Cleanup
+printInfoSection "4/4  Cleanup: deleting K3d cluster"
+deleteK3dCluster
+
+printInfoSection "✅ AI Travel Advisor K3d test PASSED (arch: $ARCH)"

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -3604,6 +3604,7 @@ FRAMEWORK_SUITES = [
     {"id": "k3d-apps",  "name": "K3d App Exposure",          "description": "All demo apps deployed + exposed via ingress",  "arch": "amd64", "needs_creds": False, "test_script": "bash .devcontainer/test/integration_k3d_apps.sh"},
     {"id": "dt-apponly","name": "DT Application Monitoring", "description": "Operator + ActiveGate + CSI code injection + todo-app (K3d, AMD64+ARM64)",          "arch": "both", "needs_creds": True,  "test_script": "bash .devcontainer/test/integration_appmon_k3d_todoapp.sh"},
     {"id": "dt-cnfs",   "name": "DT CloudNative FullStack",  "description": "CNFS dynakube + K3d — OneAgent crash expected on container nodes (AMD64+ARM64)", "arch": "both", "needs_creds": True,  "requires_native": True, "test_script": "bash .devcontainer/test/integration_cnfs_k3d_todoapp.sh"},
+    {"id": "k3d-aitraveladvisor", "name": "AI Travel Advisor", "description": "Ollama + Weaviate + app on K3d — verifies local-path PVC and ingress (AMD64, needs DT_LLM_TOKEN)", "arch": "amd64", "needs_creds": True, "test_script": "bash .devcontainer/test/integration_k3d_aitraveladvisor.sh"},
 ]
 
 @app.get("/api/framework/suites")

--- a/ops-server/nightly/scheduler.py
+++ b/ops-server/nightly/scheduler.py
@@ -166,10 +166,11 @@ async def run_nightly(
         # Sysbox suites — run on BOTH arm64 (master Sysbox) and amd64 (AMD workers)
         # dt-apponly / dt-cnfs: uses COE tenant creds; validates DT modules per arch
         for suite_id, script in [
-            ("engines",    "bash .devcontainer/test/integration_engines.sh"),
-            ("k3d-apps",   "bash .devcontainer/test/integration_k3d_apps.sh"),
-            ("dt-apponly", "bash .devcontainer/test/integration_appmon_k3d_todoapp.sh"),
-            ("dt-cnfs",    "bash .devcontainer/test/integration_cnfs_k3d_todoapp.sh"),
+            ("engines",             "bash .devcontainer/test/integration_engines.sh"),
+            ("k3d-apps",            "bash .devcontainer/test/integration_k3d_apps.sh"),
+            ("dt-apponly",          "bash .devcontainer/test/integration_appmon_k3d_todoapp.sh"),
+            ("dt-cnfs",             "bash .devcontainer/test/integration_cnfs_k3d_todoapp.sh"),
+            ("k3d-aitraveladvisor", "bash .devcontainer/test/integration_k3d_aitraveladvisor.sh"),
         ]:
             for target_arch in ("arm64", "amd64"):
                 await pool.rpush(f"queue:test:{target_arch}", json.dumps({

--- a/ops-server/worker-agent/config.py
+++ b/ops-server/worker-agent/config.py
@@ -42,6 +42,7 @@ SLOT_BASE_DIR = Path(os.environ.get("SLOT_BASE_DIR", str(WORKDIR / "slots")))
 DT_ENVIRONMENT = os.environ.get("DT_ENVIRONMENT", "")
 DT_OPERATOR_TOKEN = os.environ.get("DT_OPERATOR_TOKEN", "")
 DT_INGEST_TOKEN = os.environ.get("DT_INGEST_TOKEN", "")
+DT_LLM_TOKEN = os.environ.get("DT_LLM_TOKEN", "")
 
 # Timeouts
 TEST_TIMEOUT = int(os.environ.get("TEST_TIMEOUT", "900"))  # 15 min

--- a/ops-server/worker-agent/executor.py
+++ b/ops-server/worker-agent/executor.py
@@ -42,6 +42,7 @@ from .config import (
     DT_ENVIRONMENT,
     DT_OPERATOR_TOKEN,
     DT_INGEST_TOKEN,
+    DT_LLM_TOKEN,
     TEST_TIMEOUT,
     TEST_IMAGE,
     WORKER_ARCH,
@@ -732,6 +733,7 @@ def _write_env_file(
         "DT_ENVIRONMENT":    DT_ENVIRONMENT,
         "DT_OPERATOR_TOKEN": DT_OPERATOR_TOKEN,
         "DT_INGEST_TOKEN":   DT_INGEST_TOKEN,
+        "DT_LLM_TOKEN":      DT_LLM_TOKEN,
     }
     if orbital_job_id:
         resolved["ORBITAL_JOB_ID"] = orbital_job_id


### PR DESCRIPTION
## Summary

- Add `integration_k3d_aitraveladvisor.sh`: dedicated framework test that deploys the full AI Travel Advisor stack (Ollama → Weaviate → app) on K3d and asserts ingress reachability
- The test also verifies that the weaviate PVC uses `storageClassName: local-path` — guarding against regression of the fix in #49
- Register `k3d-aitraveladvisor` suite in `FRAMEWORK_SUITES` (dashboard) and nightly `scheduler.py` so it runs in Orbital
- Add `DT_LLM_TOKEN` to `worker-agent/config.py` and `executor.py` `_write_env_file` so workers pass this credential into framework tests (mirrors how `DT_OPERATOR_TOKEN` / `DT_INGEST_TOKEN` are handled)

## Context

The gen-ai lab (`enablement-gen-ai-llm-observability`) had a `sed` workaround in `post-create.sh` to patch the weaviate StorageClass from `standard` → `local-path` at runtime. That workaround is removed in the companion PR (dynatrace-wwse/enablement-gen-ai-llm-observability). This test suite is the regression guard.

## Test plan

- [x] `integration_k3d_aitraveladvisor.sh` queued to Orbital AMD64 worker (branch `feat/ai-travel-advisor-test`) — job `worker-x86_64-amd002-codespaces-framework-1780403188904-399f04` running
- [ ] Test exits 0 (skip) if `DT_LLM_TOKEN` not in worker `.env`; exits 0 (pass) when credential is present
- [ ] `k3d-aitraveladvisor` appears in `/api/framework/suites` response after deploy
- [ ] Add `DT_LLM_TOKEN` to `/home/ops/.env` on both master and AMD worker to enable full test run

## Notes

The test gracefully skips on ARM64 (Ollama has no ARM image) and when `DT_LLM_TOKEN` is absent. Once the token is added to the worker `.env`, the suite runs end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)