### PR TITLE
fix(greeting): per-environment app exposure URL in printGreeting

### DIFF
--- a/.devcontainer/test/test_functions.sh
+++ b/.devcontainer/test/test_functions.sh
@@ -16,9 +16,11 @@ assertDynatraceCloudNative(){
 }
 
 assertRunningApp(){
-  # Assert an app is reachable via BOTH ingress hosts:
+  # Assert an app is reachable via its ingress hosts:
   #   1. magic-DNS public IP host: <app>.<detected-ip>.<MAGIC_DOMAIN>
   #   2. server hostname host:     <app>.<detected-hostname>
+  #   3. Orbital only: wildcard subdomain host
+  #        <app>--<job-slug>.autonomous-enablements.whydevslovedynatrace.com
   # Probes localhost on the configured ingress port (K3D_LB_HTTP_PORT, default 80).
   # Required for parallel-worker testing where each worker's k3d binds to a
   # non-default port (e.g. 30080) and is reachable only via Host-header curl.
@@ -32,13 +34,32 @@ assertRunningApp(){
   local name_host="${app_name}.${detected_hostname}"
   local target="http://localhost:${port}"
 
-  printInfoSection "Testing app via ingress on ${target}"
+  # Build the list of hosts to probe. In Orbital, also assert the app answers
+  # on its wildcard subdomain host (the URL users actually hit). The host-less
+  # catch-all ingress rule routes a Host-header curl on localhost.
+  local hosts=("$ip_host" "$name_host")
+  if [[ "$(detectRunEnvironment)" == "orbital" ]]; then
+    local osd=""
+    if [[ -f "$APP_REGISTRY" ]]; then
+      osd=$(awk -F'|' -v a="$app_name" '$1==a {print $7}' "$APP_REGISTRY" 2>/dev/null | grep -v '^$' | tail -1)
+    fi
+    if [[ -z "$osd" && -n "${ORBITAL_JOB_ID:-}" ]]; then
+      osd=$(computeOrbitalSubdomain "$app_name")
+    fi
+    if [[ -n "$osd" ]]; then
+      hosts+=("${osd}.autonomous-enablements.whydevslovedynatrace.com")
+    else
+      printWarn "Orbital env but no subdomain found for '$app_name' — skipping subdomain probe"
+    fi
+  fi
+
+  printInfoSection "Testing app via ingress on ${target} (hosts: ${hosts[*]})"
 
   # Retry — ingress-nginx needs a moment to reconcile a freshly-created
   # Ingress resource. In parallel-worker runs the curl can race the
   # controller, so probe up to 8 times with 3s spacing per host.
   local h failed=0
-  for h in "$ip_host" "$name_host"; do
+  for h in "${hosts[@]}"; do
     local ok=0 i
     for i in $(seq 1 8); do
       if curl --silent --fail --max-time 5 -H "Host: $h" "$target" > /dev/null; then

--- a/.devcontainer/test/unit/test_greeting.bats
+++ b/.devcontainer/test/unit/test_greeting.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# Tests for printGreeting / printRunningApplications app-exposure output.
+# greeting.sh runs as a standalone bash process (printGreeting -> `bash greeting.sh`)
+# that sources only variables.sh — NOT functions.sh. These tests guard that the
+# per-environment app URL is printed correctly (orbital / codespaces / local)
+# without depending on functions.sh being loaded.
+
+setup() {
+  export TEST_DIR="$(mktemp -d)"
+  export HOME="$TEST_DIR/home"
+  mkdir -p "$HOME"
+
+  export FAKE_REPO="$TEST_DIR/workspaces/test-enablement"
+  mkdir -p "$FAKE_REPO/.devcontainer/util"
+  export REPO_PATH="$FAKE_REPO"
+  export APP_REGISTRY="$TEST_DIR/app-registry"
+
+  # Minimal variables.sh stub (greeting.sh sources this). No colors needed —
+  # unset color vars expand to empty since greeting.sh does not use `set -u`.
+  cat > "$FAKE_REPO/.devcontainer/util/variables.sh" <<'VARSEOF'
+RepositoryName="test-enablement"
+INSTANTIATION_TYPE="local-docker-container"
+export APP_REGISTRY="${APP_REGISTRY:-${HOME}/.cache/dt-framework/app-registry}"
+VARSEOF
+
+  # Use the real greeting.sh under test
+  cp "$BATS_TEST_DIRNAME/../../util/greeting.sh" \
+     "$FAKE_REPO/.devcontainer/util/greeting.sh"
+
+  # Cluster appears running so printApplications calls printRunningApplications
+  export CLUSTER_STATUS="running"
+  export CLUSTER_TYPE="K3d (K3s)"
+
+  # Registry: 7 fields incl. orbital subdomain
+  echo "todoapp|todoapp|todoapp|8080|todoapp.10.0.0.1.sslip.io|todoapp--34ea2d-k8s-101|todoapp--34ea2d-k8s-101" > "$APP_REGISTRY"
+
+  # Mock kubectl (printKubernetesInformation calls `kubectl version`)
+  kubectl() { return 0; }
+  export -f kubectl
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+run_greeting() {
+  run bash "$FAKE_REPO/.devcontainer/util/greeting.sh"
+}
+
+@test "greeting: orbital prints wildcard subdomain URL" {
+  export ORBITAL_ENVIRONMENT=true
+  unset CODESPACE_NAME CODESPACES
+  run_greeting
+  [[ "$output" == *"https://todoapp--34ea2d-k8s-101.autonomous-enablements.whydevslovedynatrace.com"* ]]
+}
+
+@test "greeting: orbital detected via K3D_CLUSTER_NAME=master-* prefix" {
+  unset ORBITAL_ENVIRONMENT CODESPACE_NAME CODESPACES
+  export K3D_CLUSTER_NAME="master-k8s-101-abc"
+  run_greeting
+  [[ "$output" == *"https://todoapp--34ea2d-k8s-101.autonomous-enablements.whydevslovedynatrace.com"* ]]
+}
+
+@test "greeting: codespaces prints port-80 github.dev URL" {
+  unset ORBITAL_ENVIRONMENT K3D_CLUSTER_NAME
+  export CODESPACE_NAME="myspace" CODESPACES=true
+  run_greeting
+  [[ "$output" == *"https://myspace-80.app.github.dev"* ]]
+}
+
+@test "greeting: local prints sslip.io magic-DNS URL" {
+  unset ORBITAL_ENVIRONMENT CODESPACE_NAME CODESPACES K3D_CLUSTER_NAME
+  run_greeting
+  [[ "$output" == *"http://todoapp.10.0.0.1.sslip.io"* ]]
+}
+
+@test "greeting: does not depend on detectRunEnvironment (no command-not-found)" {
+  export ORBITAL_ENVIRONMENT=true
+  run_greeting
+  [[ "$output" != *"detectRunEnvironment: command not found"* ]]
+  [[ "$output" != *"command not found"* ]]
+}
+
+@test "greeting: empty registry shows the deployApp hint, no URLs" {
+  : > "$APP_REGISTRY"
+  unset ORBITAL_ENVIRONMENT CODESPACE_NAME CODESPACES K3D_CLUSTER_NAME
+  run_greeting
+  [[ "$output" == *"No applications are running"* ]]
+  [[ "$output" != *"is reachable under"* ]]
+}

--- a/.devcontainer/util/greeting.sh
+++ b/.devcontainer/util/greeting.sh
@@ -77,16 +77,29 @@ printRunningApplications(){
 
     local running_app=false
 
-    # Apps are exposed via ingress — show them from the registry
+    # Determine the run environment from raw signals. greeting.sh runs as a
+    # standalone bash process that sources only variables.sh — functions.sh
+    # (and detectRunEnvironment) is NOT available here, so detect inline using
+    # the same signals detectRunEnvironment uses:
+    #   orbital    → ORBITAL_ENVIRONMENT=true or K3D_CLUSTER_NAME=master-*
+    #   codespaces → CODESPACE_NAME set
+    #   local      → fallback (magic-DNS sslip.io)
+    local _greet_env="local"
+    if [[ "${ORBITAL_ENVIRONMENT:-}" == "true" ]] || [[ "${K3D_CLUSTER_NAME:-}" == master-* ]]; then
+        _greet_env="orbital"
+    elif [[ -n "${CODESPACE_NAME:-}" ]]; then
+        _greet_env="codespaces"
+    fi
+
+    # Apps are exposed via ingress — show them from the registry, with the URL
+    # form matching the run environment.
     if [[ -f "$APP_REGISTRY" ]] && [[ -s "$APP_REGISTRY" ]]; then
-        local _greet_env
-        _greet_env=$(detectRunEnvironment)
         local _fwd_domain="${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN:-app.github.dev}"
         while IFS='|' read -r app_name namespace service_name service_port ingress_host cs_port orbital_subdomain; do
             running_app=true
             if [[ "$_greet_env" == "orbital" && -n "$orbital_subdomain" ]]; then
                 echo -e "${CYAN}   $app_name ${NORMAL}is reachable under ${RESET}https://${orbital_subdomain}.autonomous-enablements.whydevslovedynatrace.com"
-            elif [[ $CODESPACES == true ]]; then
+            elif [[ "$_greet_env" == "codespaces" ]]; then
                 echo -e "${CYAN}   $app_name ${NORMAL}is reachable under ${RESET}https://${CODESPACE_NAME}-80.${_fwd_domain}"
             else
                 echo -e "${CYAN}   $app_name ${NORMAL}is reachable under ${RESET}http://${ingress_host}"


### PR DESCRIPTION
## Bug
`greeting.sh` runs as a standalone `bash` subprocess (`printGreeting` → `bash greeting.sh`) that sources only `variables.sh`, not `functions.sh`. It called `detectRunEnvironment` (undefined there) → the orbital branch never fired → **Orbital printed the unreachable sslip.io URL** instead of the wildcard subdomain.

## Fix
Inline env detection in `greeting.sh` (same signals: `ORBITAL_ENVIRONMENT` / `K3D_CLUSTER_NAME=master-*` / `CODESPACE_NAME`).

| Env | URL |
|---|---|
| Orbital | `https://<app>--<slug>.autonomous-enablements.whydevslovedynatrace.com` |
| Codespaces | `https://<CODESPACE_NAME>-80.app.github.dev` |
| Local | `http://<app>.<ip>.sslip.io` |

## Tests
- new `test_greeting.bats` (6) — all three URLs + `master-*` signal + no-command-not-found regression + empty registry
- `assertRunningApp` now also probes the Orbital wildcard-subdomain host end-to-end when in Orbital

**124/124 unit tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)