### PR TITLE
chore: bump framework version to 1.5.0

### DIFF
--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -13,7 +13,7 @@
 #                    Local to the container → fast access, lost on container rebuild
 
 # Framework version pin — sync push-update updates this line
-FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.4.1}"
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.5.0}"
 
 REPO_PATH="$(pwd)"
 RepositoryName="$(basename "$REPO_PATH")"


### PR DESCRIPTION
Bumps `FRAMEWORK_VERSION` default in `source_framework.sh` to **1.5.0** ahead of tagging + fleet sync.

1.5.0 includes:
- NodePort app-exposure path removed — ingress-only (#55)
- per-environment app-exposure URL fix in `printGreeting` (#56)

🤖 Generated with [Claude Code](https://claude.com/claude-code)