### PR TITLE
fix(ops): remove hardcoded Redis password — read from env

### DIFF
--- a/ops-server/monitoring/push_metrics.py
+++ b/ops-server/monitoring/push_metrics.py
@@ -23,7 +23,7 @@ _dt_env_raw = os.environ.get("DT_ENVIRONMENT", "").rstrip("/")
 # Metrics ingest API is on the live domain, not the apps domain.
 DT_ENV = _dt_env_raw.replace(".apps.dynatrace.com", ".live.dynatrace.com")
 DT_TOKEN = os.environ.get("DT_INGEST_TOKEN", "")
-REDIS_AUTH = "50258583a5c8d515dc8a553a26e1a17d"
+REDIS_AUTH = os.environ.get("REDIS_PASSWORD") or sys.exit("REDIS_PASSWORD not set in environment")
 HOST = socket.gethostname().split(".")[0]  # short hostname
 
 

--- a/ops-server/tools/capacity_stress_test.py
+++ b/ops-server/tools/capacity_stress_test.py
@@ -17,6 +17,7 @@ Usage:
   python3 capacity_stress_test.py --variant astroshop --dry-run
 """
 
+import os
 import argparse
 import asyncio
 import json
@@ -33,7 +34,7 @@ from typing import Optional
 import redis.asyncio as aioredis
 
 # ── Config ────────────────────────────────────────────────────────────────────
-REDIS_PWD    = "50258583a5c8d515dc8a553a26e1a17d"
+REDIS_PWD    = os.environ.get("REDIS_PASSWORD") or sys.exit("REDIS_PASSWORD not set in environment")
 REDIS_URL    = f"redis://:{REDIS_PWD}@localhost:6379/0"
 ORBITAL_BASE = "https://autonomous-enablements.whydevslovedynatrace.com"
 

--- a/ops-server/tools/cleanup_worker.py
+++ b/ops-server/tools/cleanup_worker.py
@@ -3,13 +3,14 @@
 Terminate all running daemon jobs on a specific worker and wait for it to go idle.
 Usage: python3 cleanup_worker.py <worker_id>
 """
+import os
 import asyncio
 import sys
 import time
 
 import redis.asyncio as aioredis
 
-REDIS_PWD   = "50258583a5c8d515dc8a553a26e1a17d"
+REDIS_PWD   = os.environ.get("REDIS_PASSWORD") or sys.exit("REDIS_PASSWORD not set in environment")
 REDIS_URL   = f"redis://:{REDIS_PWD}@localhost:6379/0"
 IDLE_TIMEOUT = 300   # max 5 min to drain
 SLOT_TIMEOUT = 180   # max 3 min for slots to re-initialise

--- a/ops-server/tools/run_evening_sequence.sh
+++ b/ops-server/tools/run_evening_sequence.sh
@@ -10,7 +10,7 @@ OPS_VENV="/home/ops/ops-venv/bin/python"
 PYTHON="python3"
 DATE="$(date -u +%Y%m%d)"
 LOG_DIR="/tmp/evening-$DATE"
-REDIS_PWD="50258583a5c8d515dc8a553a26e1a17d"
+REDIS_PWD="${REDIS_PASSWORD:?REDIS_PASSWORD not set - source /home/ops/.env}"
 ORBITAL_API="https://autonomous-enablements.whydevslovedynatrace.com"
 
 mkdir -p "$LOG_DIR"

--- a/ops-server/tools/run_stress_suite.sh
+++ b/ops-server/tools/run_stress_suite.sh
@@ -8,7 +8,7 @@ TOOLS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DATE="$(date -u +%Y%m%d-%H%M)"
 LOG_DIR="/tmp/stress-suite-$DATE"
 WORKER_ID="worker-x86_64-amd001"
-REDIS_AUTH="50258583a5c8d515dc8a553a26e1a17d"
+REDIS_AUTH="${REDIS_PASSWORD:?REDIS_PASSWORD not set - source /home/ops/.env}"
 PYTHON="python3"
 
 mkdir -p "$LOG_DIR"

--- a/ops-server/tools/stress_test_direct.py
+++ b/ops-server/tools/stress_test_direct.py
@@ -24,6 +24,7 @@ Results written to stress-test-direct-<timestamp>.json
 """
 from __future__ import annotations
 
+import os
 import argparse
 import json
 import sys
@@ -42,7 +43,7 @@ except ImportError:
 ORBITAL_API = "https://autonomous-enablements.whydevslovedynatrace.com"
 REDIS_HOST = "127.0.0.1"
 REDIS_PORT = 6379
-REDIS_PASSWORD = "50258583a5c8d515dc8a553a26e1a17d"
+REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD") or sys.exit("REDIS_PASSWORD not set in environment")
 
 CPU_SAT_PCT   = 90.0   # AMD worker saturation threshold
 MEM_SAT_PCT   = 90.0   # AMD worker saturation threshold


### PR DESCRIPTION
GitGuardian flagged the Redis password committed in 5f5056c (stress/ops tools + metrics pusher). All hardcoded literals replaced with reads from `REDIS_PASSWORD` (from `/home/ops/.env` via each service's EnvironmentFile). The leaked password has been **rotated** on the Redis server, so the value in 5f5056c is now dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)