### PR TITLE
fix(webhook): stop logging Redis URL (password) on startup

### DIFF
--- a/ops-server/webhook/server.py
+++ b/ops-server/webhook/server.py
@@ -26,7 +26,7 @@ pool: redis.Redis | None = None
 async def startup():
     global pool
     pool = redis.from_url(REDIS_URL, decode_responses=True)
-    log.info("Connected to Redis at %s", REDIS_URL)
+    log.info("Connected to Redis")
 
 
 @app.on_event("shutdown")


### PR DESCRIPTION
The webhook logged the full `REDIS_URL` (incl. password) to journald on every startup — secondary plaintext-credential leak into local logs. Now logs a bare "Connected to Redis".

🤖 Generated with [Claude Code](https://claude.com/claude-code)