### PR TITLE
Content delivery by Dynatrace domain + tenant→profile table (no content keys)

### DIFF
--- a/ops-server/content/profiles/core.json
+++ b/ops-server/content/profiles/core.json
@@ -1,0 +1,20 @@
+{
+  "profileId": "core",
+  "description": "Production default — Learning Bytes (micro-labs) + Kubernetes 101.",
+  "sources": [
+    {
+      "key": "learning-bytes",
+      "category": "learning-byte",
+      "categoryLabel": "Learning Bytes",
+      "repo": "dynatrace-wwse/enablement-learning-bytes",
+      "branch": "main"
+    },
+    {
+      "key": "kubernetes-101",
+      "category": "hands-on",
+      "categoryLabel": "Hands-On Trainings",
+      "repo": "dynatrace-wwse/enablement-kubernetes-101",
+      "branch": "main"
+    }
+  ]
+}

--- a/ops-server/content/tenant_map.json
+++ b/ops-server/content/tenant_map.json
@@ -1,6 +1,6 @@
 {
   "defaults": {
-    "prod": "all",
+    "prod": "core",
     "sprint": "all",
     "dev": "all"
   },

--- a/ops-server/content/tenant_map.json
+++ b/ops-server/content/tenant_map.json
@@ -1,0 +1,10 @@
+{
+  "defaults": {
+    "prod": "all",
+    "sprint": "all",
+    "dev": "all"
+  },
+  "tenants": {
+    "geu80787": "all"
+  }
+}

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -109,6 +109,83 @@ async def profiles_page():
     """Profile management UI. The page is public; its API calls are writer-gated."""
     return HTMLResponse(_PROFILES_PAGE)
 
+
+_TENANTS_PAGE = """<!doctype html><html><head><meta charset=utf-8>
+<title>Content Delivery</title><style>
+body{font-family:system-ui,sans-serif;margin:0;background:#0d1117;color:#e6edf3}
+header{padding:14px 22px;background:#161b22;border-bottom:1px solid #30363d;font-weight:600}
+header a{color:#9d9dff;margin-left:14px;font-weight:400;font-size:14px}
+main{max-width:760px;margin:0 auto;padding:22px}
+h3{border-bottom:1px solid #30363d;padding-bottom:6px}
+table{width:100%;border-collapse:collapse;margin:8px 0}
+td,th{padding:6px 8px;border-bottom:1px solid #21262d;text-align:left}
+input{background:#0d1117;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:6px 10px}
+select{background:#0d1117;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:6px 10px}
+button{background:#6c6cff;color:#fff;border:0;border-radius:6px;padding:7px 16px;cursor:pointer;font-weight:600}
+button.sec{background:#30363d}
+.msg{font-size:13px;margin-left:10px;opacity:.85}
+.hint{opacity:.6;font-size:13px}
+</style></head><body>
+<header>Content Delivery — which profile each tenant receives
+  <a href="/profiles">edit profiles →</a></header>
+<main>
+<p class=hint>Authentication is by Dynatrace domain. Defaults apply per environment class;
+a tenant id override wins. Tenant id = the subdomain (e.g. <code>geu80787</code>).</p>
+<h3>Domain defaults</h3>
+<table id=defaults></table>
+<h3>Tenant overrides</h3>
+<table id=tenants><tbody></tbody></table>
+<div style="margin:8px 0">
+  <input id=newtid placeholder="tenant-id (e.g. geu80787)" size=24>
+  <select id=newpid></select>
+  <button class=sec onclick="addRow()">+ Add tenant</button>
+</div>
+<div style="margin-top:18px">
+  <button onclick="save()">Save delivery table</button>
+  <span class=msg id=msg></span>
+</div>
+</main>
+<script>
+const API="/api/content/admin/tenant-map";
+let PROFILES=[], DOMAINS=[];
+function opts(sel){return PROFILES.map(p=>`<option ${p===sel?'selected':''}>${p}</option>`).join('');}
+async function load(){
+  const r=await fetch(API);
+  if(!r.ok){document.body.innerHTML='<p style=padding:22px>Sign in as an org member to manage delivery.</p>';return;}
+  const {map,profiles,domains}=await r.json(); PROFILES=profiles; DOMAINS=domains;
+  document.getElementById('newpid').innerHTML=opts(profiles[0]);
+  document.getElementById('defaults').innerHTML='<tr><th>Domain</th><th>Default profile</th></tr>'+
+    domains.map(d=>`<tr><td>${d}</td><td><select id="d-${d}">${opts((map.defaults||{})[d])}</select></td></tr>`).join('');
+  const tb=document.querySelector('#tenants tbody'); tb.innerHTML='';
+  Object.entries(map.tenants||{}).forEach(([t,p])=>tb.appendChild(row(t,p)));
+}
+function row(tid,pid){
+  const tr=document.createElement('tr');
+  tr.innerHTML=`<td><code>${tid}</code></td><td><select>${opts(pid)}</select></td>
+    <td><button class=sec onclick="this.closest('tr').remove()">remove</button></td>`;
+  tr.dataset.tid=tid; return tr;
+}
+function addRow(){
+  const tid=document.getElementById('newtid').value.trim(); if(!tid)return;
+  document.querySelector('#tenants tbody').appendChild(row(tid,document.getElementById('newpid').value));
+  document.getElementById('newtid').value='';
+}
+async function save(){
+  const defaults={}; DOMAINS.forEach(d=>defaults[d]=document.getElementById('d-'+d).value);
+  const tenants={}; document.querySelectorAll('#tenants tbody tr').forEach(tr=>{
+    tenants[tr.dataset.tid]=tr.querySelector('select').value;});
+  const r=await fetch(API,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({defaults,tenants})});
+  const j=await r.json(); document.getElementById('msg').textContent=r.ok?`saved (${j.tenants} tenant override(s))`:(j.detail||'error');
+}
+load();
+</script></body></html>"""
+
+
+@app.get("/tenants", response_class=HTMLResponse)
+async def tenants_page():
+    """Delivery-table UI (tenant → profile). Page public; API writer-gated."""
+    return HTMLResponse(_TENANTS_PAGE)
+
 DASHBOARD_DIR = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=DASHBOARD_DIR / "static"), name="static")
 templates = Jinja2Templates(directory=DASHBOARD_DIR / "templates")

--- a/ops-server/dashboard/content_service.py
+++ b/ops-server/dashboard/content_service.py
@@ -1,25 +1,33 @@
-"""Content distribution service (Phase 1 of multi-tenant content delivery).
+"""Content distribution service (multi-tenant content delivery).
 
 Orbital is the ONLY place that holds the GitHub token. Tenants pull curated
-*profiles* and proxied repo content from here using a per-install *content key*
-(header ``X-Content-Key``) — never a GitHub token, never a per-user secret.
+*profiles* and proxied repo content from here. Authentication is by **Dynatrace
+domain**: content can only be pulled by a Dynatrace tenant (production, sprint, or
+development apps domain). The caller passes its tenant URL; the service validates the
+domain suffix, derives the tenant id, and resolves which profile to deliver from a
+tenant→profile table (with per-domain defaults). No per-tenant key.
 
 Security model (important): the raw proxy injects the Orbital GitHub token, so it
-would otherwise be an open read of every private dynatrace-wwse repo. Two guards:
-  1. A valid content key is REQUIRED on every endpoint.
+would otherwise be an open read of every private dynatrace-wwse repo. Guards:
+  1. The caller must present a Dynatrace tenant URL (prod/sprint/dev domain suffix).
   2. The raw proxy only serves ``owner/repo`` pairs referenced by a profile
      (allowlist), and rejects path traversal.
+  Note: the tenant URL is a claim (server-to-server call from AppEngine). The content
+  is internal enablement material; for stronger isolation, restrict by AppEngine egress
+  IPs at the edge. The domain suffix check stops arbitrary internet callers.
 
 Routes (mounted under /api/content, reachable server-to-server via the nginx
 catch-all, same as /api/arena/*):
-  GET /api/content/profiles/{profile_id}
-  GET /api/content/repos/{owner}/{repo}/raw/{path}
+  GET /api/content/manifest?tenant=<tenantUrl>        — resolves the tenant's profile
+  GET /api/content/repos/{owner}/{repo}/raw/{path}?tenant=<tenantUrl>
+  GET/PUT /api/content/admin/profiles, /api/content/admin/tenant-map  (writer-gated)
 """
 
 import json
 import logging
 import os
 from pathlib import Path
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Header, HTTPException
@@ -30,23 +38,61 @@ GH_TOKEN = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN", "")
 GH_API = "https://api.github.com"
 RAW_BASE = "https://raw.githubusercontent.com"
 
-# Comma-separated allowed content keys. Tenants present one as X-Content-Key.
-# These gate access to the proxy (which holds the GitHub token) — keep them set.
-CONTENT_KEYS = {
-    k.strip() for k in os.environ.get("CONTENT_KEYS", "").split(",") if k.strip()
+# Allowed Dynatrace apps-domain suffixes → environment class. Env-overridable
+# (CONTENT_DOMAIN_SUFFIXES="suffix:class,suffix:class").
+_DEFAULT_DOMAINS = {
+    ".apps.dynatrace.com": "prod",
+    ".sprint.apps.dynatracelabs.com": "sprint",
+    ".dev.apps.dynatracelabs.com": "dev",
 }
+def _load_domain_suffixes() -> dict:
+    raw = os.environ.get("CONTENT_DOMAIN_SUFFIXES", "")
+    if not raw:
+        return dict(_DEFAULT_DOMAINS)
+    out = {}
+    for pair in raw.split(","):
+        suffix, _, cls = pair.strip().partition(":")
+        if suffix and cls:
+            out[suffix] = cls
+    return out or dict(_DEFAULT_DOMAINS)
+DOMAIN_SUFFIXES = _load_domain_suffixes()
 
 PROFILES_DIR = Path(__file__).parent.parent / "content" / "profiles"
+TENANT_MAP_FILE = Path(__file__).parent.parent / "content" / "tenant_map.json"
 
 router = APIRouter(prefix="/api/content", tags=["content"])
 
 
-def _require_key(content_key: str | None) -> None:
-    if not CONTENT_KEYS:
-        # Fail closed: with no keys configured the proxy must not be reachable.
-        raise HTTPException(503, "Content service not configured (no CONTENT_KEYS).")
-    if not content_key or content_key not in CONTENT_KEYS:
-        raise HTTPException(401, "Invalid or missing X-Content-Key.")
+def classify_tenant(tenant_url: str | None) -> tuple[str, str]:
+    """Validate a Dynatrace tenant URL and return (tenant_id, domain_class).
+    Raises 403 if the domain is not a recognised Dynatrace apps domain."""
+    if not tenant_url:
+        raise HTTPException(403, "Missing tenant URL.")
+    host = urlparse(tenant_url if "://" in tenant_url else f"https://{tenant_url}").hostname or ""
+    host = host.lower()
+    for suffix, cls in DOMAIN_SUFFIXES.items():
+        if host.endswith(suffix):
+            tenant_id = host[: -len(suffix)].split(".")[0]
+            if tenant_id:
+                return tenant_id, cls
+    raise HTTPException(403, "Content is only served to Dynatrace tenants (prod/sprint/dev).")
+
+
+def _load_tenant_map() -> dict:
+    if TENANT_MAP_FILE.is_file():
+        try:
+            return json.loads(TENANT_MAP_FILE.read_text())
+        except Exception as exc:  # pragma: no cover - defensive
+            log.warning("Bad tenant_map.json: %s", exc)
+    return {"defaults": {"prod": "all", "sprint": "all", "dev": "all"}, "tenants": {}}
+
+
+def resolve_profile(tenant_id: str, domain_class: str) -> str:
+    """tenant-specific mapping wins; else the per-domain default; else 'all'."""
+    m = _load_tenant_map()
+    return (m.get("tenants", {}).get(tenant_id)
+            or m.get("defaults", {}).get(domain_class)
+            or "all")
 
 
 def _require_writer(x_auth_user: str | None) -> None:
@@ -99,12 +145,8 @@ async def _latest_sha(owner: str, repo: str, branch: str) -> str | None:
     return None
 
 
-@router.get("/profiles/{profile_id}")
-async def get_profile(profile_id: str, x_content_key: str | None = Header(default=None)):
-    """Return a profile manifest: its sources plus each repo's latest commit sha
-    (so the tenant app can diff and refresh)."""
-    _require_key(x_content_key)
-    profile = _load_profile(profile_id)
+async def _build_sources(profile: dict) -> list[dict]:
+    """Expand a profile's sources with each repo's latest commit sha."""
     sources = []
     for src in profile.get("sources", []):
         repo_full = src.get("repo", "")
@@ -119,7 +161,26 @@ async def get_profile(profile_id: str, x_content_key: str | None = Header(defaul
             "branch": branch,
             "version": sha,
         })
-    return {"profileId": profile.get("profileId", profile_id), "sources": sources}
+    return sources
+
+
+@router.get("/manifest")
+async def get_manifest(tenant: str | None = None):
+    """Resolve the calling tenant's profile (by tenant id + domain) and return its
+    sources + commit shas. The app calls this with its own environment URL as `tenant`."""
+    tenant_id, domain_class = classify_tenant(tenant)
+    profile_id = resolve_profile(tenant_id, domain_class)
+    profile = _load_profile(profile_id)
+    log.info("Manifest: tenant=%s (%s) → profile=%s", tenant_id, domain_class, profile_id)
+    return {"profileId": profile_id, "tenant": tenant_id, "domain": domain_class,
+            "sources": await _build_sources(profile)}
+
+
+@router.get("/profiles/{profile_id}")
+async def get_profile(profile_id: str, tenant: str | None = None):
+    """Return a specific profile's manifest (tenant-domain gated). Mostly for preview."""
+    classify_tenant(tenant)
+    return {"profileId": profile_id, "sources": await _build_sources(_load_profile(profile_id))}
 
 
 @router.get("/repos/{owner}/{repo}/raw/{path:path}")
@@ -128,11 +189,11 @@ async def proxy_raw(
     repo: str,
     path: str,
     ref: str = "main",
-    x_content_key: str | None = Header(default=None),
+    tenant: str | None = None,
 ):
     """Proxy a raw file from a profile-allowlisted private repo, injecting the
-    Orbital GitHub token. The tenant never sees the token."""
-    _require_key(x_content_key)
+    Orbital GitHub token. The tenant never sees the token. Domain-gated."""
+    classify_tenant(tenant)
 
     repo_full = f"{owner}/{repo}".lower()
     if repo_full not in _allowed_repos():
@@ -210,3 +271,36 @@ async def delete_profile(profile_id: str, x_auth_user: str | None = Header(defau
     if path.is_file():
         path.unlink()
     return {"ok": True}
+
+
+# ── Tenant → profile mapping (the delivery table; writer-gated) ──────────────
+
+@router.get("/admin/tenant-map")
+async def get_tenant_map(x_auth_user: str | None = Header(default=None)):
+    """The delivery table: per-domain defaults + per-tenant overrides, plus the
+    available profile ids and recognised domain classes for the editor."""
+    _require_writer(x_auth_user)
+    profiles = sorted(p.stem for p in PROFILES_DIR.glob("*.json")) if PROFILES_DIR.is_dir() else []
+    return {"map": _load_tenant_map(), "profiles": profiles, "domains": sorted(set(DOMAIN_SUFFIXES.values()))}
+
+
+@router.put("/admin/tenant-map")
+async def put_tenant_map(body: dict, x_auth_user: str | None = Header(default=None)):
+    """Replace the tenant→profile table. Validates referenced profiles exist."""
+    _require_writer(x_auth_user)
+    defaults = body.get("defaults") or {}
+    tenants = body.get("tenants") or {}
+    if not isinstance(defaults, dict) or not isinstance(tenants, dict):
+        raise HTTPException(400, "Expected {defaults:{}, tenants:{}}.")
+    known = {p.stem for p in PROFILES_DIR.glob("*.json")} if PROFILES_DIR.is_dir() else set()
+    for who, pid in [*defaults.items(), *tenants.items()]:
+        if pid and pid not in known:
+            raise HTTPException(400, f"Unknown profile '{pid}' for '{who}'.")
+    clean = {
+        "defaults": {str(k): str(v) for k, v in defaults.items() if v},
+        "tenants": {str(k): str(v) for k, v in tenants.items() if v},
+    }
+    TENANT_MAP_FILE.parent.mkdir(parents=True, exist_ok=True)
+    TENANT_MAP_FILE.write_text(json.dumps(clean, indent=2) + "\n")
+    log.info("Tenant map saved by %s (%d tenant override(s))", x_auth_user, len(clean["tenants"]))
+    return {"ok": True, "tenants": len(clean["tenants"])}

--- a/ops-server/dashboard/content_service.py
+++ b/ops-server/dashboard/content_service.py
@@ -304,3 +304,21 @@ async def put_tenant_map(body: dict, x_auth_user: str | None = Header(default=No
     TENANT_MAP_FILE.write_text(json.dumps(clean, indent=2) + "\n")
     log.info("Tenant map saved by %s (%d tenant override(s))", x_auth_user, len(clean["tenants"]))
     return {"ok": True, "tenants": len(clean["tenants"])}
+
+
+@router.post("/admin/register-tenant")
+async def register_tenant(body: dict, x_auth_user: str | None = Header(default=None)):
+    """Auto-register a tenant when the app is deployed there, so its content can be
+    managed. Adds the tenant with its per-domain default profile if not already present
+    (an existing override is left untouched). Returns the resolved profile."""
+    _require_writer(x_auth_user)
+    tenant_id, domain_class = classify_tenant(body.get("tenant"))
+    m = _load_tenant_map()
+    tenants = m.setdefault("tenants", {})
+    added = tenant_id not in tenants
+    if added:
+        tenants[tenant_id] = m.get("defaults", {}).get(domain_class, "all")
+        TENANT_MAP_FILE.parent.mkdir(parents=True, exist_ok=True)
+        TENANT_MAP_FILE.write_text(json.dumps(m, indent=2) + "\n")
+        log.info("Registered tenant %s (%s) → profile %s by %s", tenant_id, domain_class, tenants[tenant_id], x_auth_user)
+    return {"ok": True, "tenant": tenant_id, "domain": domain_class, "profile": tenants[tenant_id], "added": added}

--- a/ops-server/dashboard/test_content_service.py
+++ b/ops-server/dashboard/test_content_service.py
@@ -1,0 +1,134 @@
+"""Tests for the content distribution service security guards + profile logic.
+
+Runnable two ways:
+  - pytest:   /home/ops/ops-venv/bin/python -m pytest dashboard/test_content_service.py
+  - standalone: /home/ops/ops-venv/bin/python -m dashboard.test_content_service
+"""
+
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+
+from fastapi import HTTPException
+
+from dashboard import content_service as cs
+
+
+def _setup(tmp: Path, keys=("k1",)):
+    """Point the module at a temp profiles dir + known keys."""
+    profiles = tmp / "profiles"
+    profiles.mkdir(parents=True, exist_ok=True)
+    (profiles / "all.json").write_text(json.dumps({
+        "profileId": "all",
+        "sources": [
+            {"key": "lb", "category": "learning-byte", "categoryLabel": "Learning Bytes",
+             "repo": "dynatrace-wwse/enablement-learning-bytes", "branch": "main"},
+        ],
+    }))
+    cs.PROFILES_DIR = profiles
+    cs.CONTENT_KEYS = set(keys)
+
+
+def _expect_http(status, fn, *args, **kwargs):
+    try:
+        if asyncio.iscoroutinefunction(fn):
+            asyncio.run(fn(*args, **kwargs))
+        else:
+            fn(*args, **kwargs)
+    except HTTPException as e:
+        assert e.status_code == status, f"expected {status}, got {e.status_code}"
+        return
+    raise AssertionError(f"expected HTTPException {status}, none raised")
+
+
+def test_require_key():
+    with tempfile.TemporaryDirectory() as d:
+        _setup(Path(d))
+        # missing / wrong key → 401
+        _expect_http(401, cs._require_key, None)
+        _expect_http(401, cs._require_key, "nope")
+        # valid key → no raise
+        cs._require_key("k1")
+        # no keys configured → fail closed (503)
+        cs.CONTENT_KEYS = set()
+        _expect_http(503, cs._require_key, "k1")
+
+
+def test_valid_id():
+    assert cs._valid_id("all")
+    assert cs._valid_id("se-onboarding")
+    assert cs._valid_id("a_b-1")
+    assert not cs._valid_id("")
+    assert not cs._valid_id("../etc")
+    assert not cs._valid_id("a/b")
+
+
+def test_require_writer():
+    _expect_http(401, cs._require_writer, None)
+    _expect_http(401, cs._require_writer, "")
+    cs._require_writer("alice")  # any non-empty X-Auth-User passes (nginx pre-validated)
+
+
+def test_allowed_repos():
+    with tempfile.TemporaryDirectory() as d:
+        _setup(Path(d))
+        repos = cs._allowed_repos()
+        assert "dynatrace-wwse/enablement-learning-bytes" in repos
+
+
+def test_proxy_rejects_non_allowlisted_repo():
+    with tempfile.TemporaryDirectory() as d:
+        _setup(Path(d))
+        # valid key, but the repo is not in any profile → 403
+        _expect_http(403, cs.proxy_raw, "dynatrace-wwse", "some-private-repo", "README.md",
+                     ref="main", x_content_key="k1")
+
+
+def test_proxy_rejects_path_traversal():
+    with tempfile.TemporaryDirectory() as d:
+        _setup(Path(d))
+        _expect_http(400, cs.proxy_raw, "dynatrace-wwse", "enablement-learning-bytes",
+                     "../secret", ref="main", x_content_key="k1")
+        _expect_http(400, cs.proxy_raw, "dynatrace-wwse", "enablement-learning-bytes",
+                     "docs/x.md", ref="../main", x_content_key="k1")
+
+
+def test_proxy_requires_key_before_anything():
+    with tempfile.TemporaryDirectory() as d:
+        _setup(Path(d))
+        _expect_http(401, cs.proxy_raw, "dynatrace-wwse", "enablement-learning-bytes",
+                     "mkdocs.yaml", ref="main", x_content_key=None)
+
+
+def test_load_profile_rejects_bad_id():
+    with tempfile.TemporaryDirectory() as d:
+        _setup(Path(d))
+        _expect_http(400, cs._load_profile, "../etc")
+        _expect_http(404, cs._load_profile, "does-not-exist")
+        assert cs._load_profile("all")["profileId"] == "all"
+
+
+def test_put_profile_validates_sources():
+    with tempfile.TemporaryDirectory() as d:
+        _setup(Path(d))
+        # empty sources → 400
+        _expect_http(400, cs.put_profile, "myprofile", {"sources": []}, x_auth_user="alice")
+        # source without owner/repo → 400
+        _expect_http(400, cs.put_profile, "myprofile", {"sources": [{"repo": "norepo"}]}, x_auth_user="alice")
+        # valid → writes the file
+        res = asyncio.run(cs.put_profile("myprofile",
+            {"description": "x", "sources": [{"repo": "dynatrace-wwse/enablement-kubernetes-101", "category": "hands-on"}]},
+            x_auth_user="alice"))
+        assert res["ok"] and res["sources"] == 1
+        assert (cs.PROFILES_DIR / "myprofile.json").is_file()
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for t in tests:
+        t()
+        print(f"  PASS {t.__name__}")
+        passed += 1
+    print(f"\n{passed}/{len(tests)} content-service tests passed")

--- a/ops-server/dashboard/test_content_service.py
+++ b/ops-server/dashboard/test_content_service.py
@@ -16,11 +16,11 @@ from fastapi import HTTPException
 from dashboard import content_service as cs
 
 
-def _setup(tmp: Path, tenants=None):
+def _setup(tmp: Path, tenants=None, defaults=None):
     content = tmp / "content"
     profiles = content / "profiles"
     profiles.mkdir(parents=True, exist_ok=True)
-    for pid in ("all", "minimal"):
+    for pid in ("all", "minimal", "core"):
         (profiles / f"{pid}.json").write_text(json.dumps({
             "profileId": pid,
             "sources": [{"key": "lb", "category": "learning-byte", "categoryLabel": "Learning Bytes",
@@ -29,7 +29,7 @@ def _setup(tmp: Path, tenants=None):
     cs.PROFILES_DIR = profiles
     cs.TENANT_MAP_FILE = content / "tenant_map.json"
     cs.TENANT_MAP_FILE.write_text(json.dumps({
-        "defaults": {"prod": "all", "sprint": "minimal", "dev": "minimal"},
+        "defaults": defaults or {"prod": "core", "sprint": "all", "dev": "all"},
         "tenants": tenants or {"geu80787": "all"},
     }))
 
@@ -60,11 +60,35 @@ def test_resolve_profile():
         _setup(Path(d))
         # explicit tenant mapping wins
         assert cs.resolve_profile("geu80787", "prod") == "all"
-        # unknown tenant → per-domain default
-        assert cs.resolve_profile("other", "sprint") == "minimal"
-        assert cs.resolve_profile("other", "prod") == "all"
+        # unknown tenant → per-domain default: prod→core, sprint/dev→all
+        assert cs.resolve_profile("other", "prod") == "core"
+        assert cs.resolve_profile("other", "sprint") == "all"
+        assert cs.resolve_profile("other", "dev") == "all"
         # unknown domain → 'all' fallback
         assert cs.resolve_profile("other", "weird") == "all"
+
+
+def test_register_tenant():
+    with tempfile.TemporaryDirectory() as d:
+        _setup(Path(d), tenants={})
+        # a prod tenant registers with the prod default (core)
+        r = asyncio.run(cs.register_tenant({"tenant": "https://cust1.apps.dynatrace.com"}, x_auth_user="alice"))
+        assert r == {"ok": True, "tenant": "cust1", "domain": "prod", "profile": "core", "added": True}
+        # idempotent: second register does not change an existing entry
+        r2 = asyncio.run(cs.register_tenant({"tenant": "https://cust1.apps.dynatrace.com"}, x_auth_user="alice"))
+        assert r2["added"] is False and r2["profile"] == "core"
+        # a sprint tenant registers with 'all'
+        rs = asyncio.run(cs.register_tenant({"tenant": "https://x.sprint.apps.dynatracelabs.com"}, x_auth_user="alice"))
+        assert rs["domain"] == "sprint" and rs["profile"] == "all"
+        # persisted
+        assert json.loads(cs.TENANT_MAP_FILE.read_text())["tenants"]["cust1"] == "core"
+
+
+def test_register_tenant_requires_writer_and_dt_domain():
+    with tempfile.TemporaryDirectory() as d:
+        _setup(Path(d))
+        _expect_http(401, cs.register_tenant, {"tenant": "https://x.apps.dynatrace.com"}, x_auth_user=None)
+        _expect_http(403, cs.register_tenant, {"tenant": "https://evil.example.com"}, x_auth_user="alice")
 
 
 def test_manifest_resolves_by_tenant():

--- a/ops-server/dashboard/test_content_service.py
+++ b/ops-server/dashboard/test_content_service.py
@@ -1,4 +1,5 @@
-"""Tests for the content distribution service security guards + profile logic.
+"""Tests for the content distribution service: Dynatrace-domain auth, tenant→profile
+resolution, repo allowlist, path-traversal, writer gate, and table validation.
 
 Runnable two ways:
   - pytest:   /home/ops/ops-venv/bin/python -m pytest dashboard/test_content_service.py
@@ -15,120 +16,135 @@ from fastapi import HTTPException
 from dashboard import content_service as cs
 
 
-def _setup(tmp: Path, keys=("k1",)):
-    """Point the module at a temp profiles dir + known keys."""
-    profiles = tmp / "profiles"
+def _setup(tmp: Path, tenants=None):
+    content = tmp / "content"
+    profiles = content / "profiles"
     profiles.mkdir(parents=True, exist_ok=True)
-    (profiles / "all.json").write_text(json.dumps({
-        "profileId": "all",
-        "sources": [
-            {"key": "lb", "category": "learning-byte", "categoryLabel": "Learning Bytes",
-             "repo": "dynatrace-wwse/enablement-learning-bytes", "branch": "main"},
-        ],
-    }))
+    for pid in ("all", "minimal"):
+        (profiles / f"{pid}.json").write_text(json.dumps({
+            "profileId": pid,
+            "sources": [{"key": "lb", "category": "learning-byte", "categoryLabel": "Learning Bytes",
+                         "repo": "dynatrace-wwse/enablement-learning-bytes", "branch": "main"}],
+        }))
     cs.PROFILES_DIR = profiles
-    cs.CONTENT_KEYS = set(keys)
+    cs.TENANT_MAP_FILE = content / "tenant_map.json"
+    cs.TENANT_MAP_FILE.write_text(json.dumps({
+        "defaults": {"prod": "all", "sprint": "minimal", "dev": "minimal"},
+        "tenants": tenants or {"geu80787": "all"},
+    }))
 
 
 def _expect_http(status, fn, *args, **kwargs):
     try:
-        if asyncio.iscoroutinefunction(fn):
-            asyncio.run(fn(*args, **kwargs))
-        else:
-            fn(*args, **kwargs)
+        asyncio.run(fn(*args, **kwargs)) if asyncio.iscoroutinefunction(fn) else fn(*args, **kwargs)
     except HTTPException as e:
         assert e.status_code == status, f"expected {status}, got {e.status_code}"
         return
     raise AssertionError(f"expected HTTPException {status}, none raised")
 
 
-def test_require_key():
+def test_classify_tenant_domains():
+    assert cs.classify_tenant("https://geu80787.apps.dynatrace.com/") == ("geu80787", "prod")
+    assert cs.classify_tenant("https://abc12345.sprint.apps.dynatracelabs.com") == ("abc12345", "sprint")
+    assert cs.classify_tenant("https://xyz.dev.apps.dynatracelabs.com/ui") == ("xyz", "dev")
+
+
+def test_classify_tenant_rejects_non_dynatrace():
+    _expect_http(403, cs.classify_tenant, None)
+    _expect_http(403, cs.classify_tenant, "https://evil.example.com")
+    _expect_http(403, cs.classify_tenant, "https://geu80787.apps.dynatrace.com.evil.com")  # suffix spoof
+
+
+def test_resolve_profile():
     with tempfile.TemporaryDirectory() as d:
         _setup(Path(d))
-        # missing / wrong key → 401
-        _expect_http(401, cs._require_key, None)
-        _expect_http(401, cs._require_key, "nope")
-        # valid key → no raise
-        cs._require_key("k1")
-        # no keys configured → fail closed (503)
-        cs.CONTENT_KEYS = set()
-        _expect_http(503, cs._require_key, "k1")
+        # explicit tenant mapping wins
+        assert cs.resolve_profile("geu80787", "prod") == "all"
+        # unknown tenant → per-domain default
+        assert cs.resolve_profile("other", "sprint") == "minimal"
+        assert cs.resolve_profile("other", "prod") == "all"
+        # unknown domain → 'all' fallback
+        assert cs.resolve_profile("other", "weird") == "all"
 
 
-def test_valid_id():
-    assert cs._valid_id("all")
-    assert cs._valid_id("se-onboarding")
-    assert cs._valid_id("a_b-1")
-    assert not cs._valid_id("")
-    assert not cs._valid_id("../etc")
-    assert not cs._valid_id("a/b")
+def test_manifest_resolves_by_tenant():
+    with tempfile.TemporaryDirectory() as d:
+        _setup(Path(d), tenants={"cust1": "minimal"})
+        res = asyncio.run(cs.get_manifest(tenant="https://cust1.apps.dynatrace.com"))
+        assert res["tenant"] == "cust1"
+        assert res["domain"] == "prod"
+        assert res["profileId"] == "minimal"
+        assert isinstance(res["sources"], list)
 
 
-def test_require_writer():
-    _expect_http(401, cs._require_writer, None)
-    _expect_http(401, cs._require_writer, "")
-    cs._require_writer("alice")  # any non-empty X-Auth-User passes (nginx pre-validated)
-
-
-def test_allowed_repos():
+def test_manifest_rejects_non_dynatrace_domain():
     with tempfile.TemporaryDirectory() as d:
         _setup(Path(d))
-        repos = cs._allowed_repos()
-        assert "dynatrace-wwse/enablement-learning-bytes" in repos
+        _expect_http(403, cs.get_manifest, tenant="https://evil.example.com")
+        _expect_http(403, cs.get_manifest, tenant=None)
+
+
+def test_proxy_requires_dynatrace_tenant():
+    with tempfile.TemporaryDirectory() as d:
+        _setup(Path(d))
+        _expect_http(403, cs.proxy_raw, "dynatrace-wwse", "enablement-learning-bytes",
+                     "mkdocs.yaml", ref="main", tenant=None)
+        _expect_http(403, cs.proxy_raw, "dynatrace-wwse", "enablement-learning-bytes",
+                     "mkdocs.yaml", ref="main", tenant="https://evil.example.com")
 
 
 def test_proxy_rejects_non_allowlisted_repo():
     with tempfile.TemporaryDirectory() as d:
         _setup(Path(d))
-        # valid key, but the repo is not in any profile → 403
         _expect_http(403, cs.proxy_raw, "dynatrace-wwse", "some-private-repo", "README.md",
-                     ref="main", x_content_key="k1")
+                     ref="main", tenant="https://geu80787.apps.dynatrace.com")
 
 
 def test_proxy_rejects_path_traversal():
     with tempfile.TemporaryDirectory() as d:
         _setup(Path(d))
-        _expect_http(400, cs.proxy_raw, "dynatrace-wwse", "enablement-learning-bytes",
-                     "../secret", ref="main", x_content_key="k1")
-        _expect_http(400, cs.proxy_raw, "dynatrace-wwse", "enablement-learning-bytes",
-                     "docs/x.md", ref="../main", x_content_key="k1")
+        t = "https://geu80787.apps.dynatrace.com"
+        _expect_http(400, cs.proxy_raw, "dynatrace-wwse", "enablement-learning-bytes", "../secret", ref="main", tenant=t)
+        _expect_http(400, cs.proxy_raw, "dynatrace-wwse", "enablement-learning-bytes", "docs/x.md", ref="../m", tenant=t)
 
 
-def test_proxy_requires_key_before_anything():
+def test_valid_id_and_load_profile():
     with tempfile.TemporaryDirectory() as d:
         _setup(Path(d))
-        _expect_http(401, cs.proxy_raw, "dynatrace-wwse", "enablement-learning-bytes",
-                     "mkdocs.yaml", ref="main", x_content_key=None)
-
-
-def test_load_profile_rejects_bad_id():
-    with tempfile.TemporaryDirectory() as d:
-        _setup(Path(d))
+        assert cs._valid_id("all") and not cs._valid_id("../etc")
         _expect_http(400, cs._load_profile, "../etc")
-        _expect_http(404, cs._load_profile, "does-not-exist")
+        _expect_http(404, cs._load_profile, "nope")
         assert cs._load_profile("all")["profileId"] == "all"
 
 
-def test_put_profile_validates_sources():
+def test_require_writer():
+    _expect_http(401, cs._require_writer, None)
+    cs._require_writer("alice")
+
+
+def test_tenant_map_put_validates_profiles():
     with tempfile.TemporaryDirectory() as d:
         _setup(Path(d))
-        # empty sources → 400
-        _expect_http(400, cs.put_profile, "myprofile", {"sources": []}, x_auth_user="alice")
-        # source without owner/repo → 400
-        _expect_http(400, cs.put_profile, "myprofile", {"sources": [{"repo": "norepo"}]}, x_auth_user="alice")
-        # valid → writes the file
-        res = asyncio.run(cs.put_profile("myprofile",
-            {"description": "x", "sources": [{"repo": "dynatrace-wwse/enablement-kubernetes-101", "category": "hands-on"}]},
+        # unknown profile → 400
+        _expect_http(400, cs.put_tenant_map, {"defaults": {"prod": "ghost"}, "tenants": {}}, x_auth_user="alice")
+        # valid → writes
+        res = asyncio.run(cs.put_tenant_map(
+            {"defaults": {"prod": "all", "sprint": "minimal"}, "tenants": {"cust9": "all"}},
             x_auth_user="alice"))
-        assert res["ok"] and res["sources"] == 1
-        assert (cs.PROFILES_DIR / "myprofile.json").is_file()
+        assert res["ok"] and res["tenants"] == 1
+        saved = json.loads(cs.TENANT_MAP_FILE.read_text())
+        assert saved["tenants"]["cust9"] == "all"
+
+
+def test_tenant_map_put_requires_writer():
+    with tempfile.TemporaryDirectory() as d:
+        _setup(Path(d))
+        _expect_http(401, cs.put_tenant_map, {"defaults": {}, "tenants": {}}, x_auth_user=None)
 
 
 if __name__ == "__main__":
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
-    passed = 0
     for t in tests:
         t()
         print(f"  PASS {t.__name__}")
-        passed += 1
-    print(f"\n{passed}/{len(tests)} content-service tests passed")
+    print(f"\n{len(tests)}/{len(tests)} content-service tests passed")


### PR DESCRIPTION
Replaces the content-key model with **Dynatrace-domain auth + a tenant→profile delivery table**.

- Auth = caller's Dynatrace domain (prod `*.apps.dynatrace.com`, sprint `*.sprint.apps.dynatracelabs.com`, dev `*.dev.apps.dynatracelabs.com`); non-Dynatrace domains rejected.
- `GET /api/content/manifest?tenant=<url>` resolves the profile from `tenant_map.json` (per-domain defaults + per-tenant overrides) → sources + shas.
- Raw proxy gated by domain + repo allowlist + traversal guard (GitHub token stays server-side).
- Delivery-table editor at `/tenants` (writer-gated `/api/content/admin/tenant-map`).
- 12 content-service tests. Deployed + verified live (manifest by tenant=200, non-DT=403, proxy gated).

Includes the content-service guard tests (supersedes closed PR #62).

🤖 Generated with [Claude Code](https://claude.com/claude-code)