### PR TITLE
Orbital SSO-delegated app deploy — P1 (OAuth flow) + P2 (deploy/undeploy)

### DIFF
--- a/.devcontainer/test/integration_cnfs_k3d_todoapp.sh
+++ b/.devcontainer/test/integration_cnfs_k3d_todoapp.sh
@@ -47,6 +47,20 @@ k3d cluster list -o json 2>/dev/null \
   | python3 -c "import sys,json; [print(c['name']) for c in json.load(sys.stdin)]" 2>/dev/null \
   | xargs -r k3d cluster delete 2>/dev/null || true
 
+# Guaranteed teardown on ANY exit (success, failure, timeout, SIGTERM).
+# Deletes the K3d cluster (and its docker network/volumes) so the worker host
+# is never left cluttered regardless of how the test ends.
+_cnfs_cleanup() {
+  printInfoSection "Cleanup trap: tearing down K3d cluster + k3d-* networks"
+  deleteK3dCluster 2>/dev/null || true
+  k3d cluster list -o json 2>/dev/null \
+    | python3 -c "import sys,json; [print(c['name']) for c in json.load(sys.stdin)]" 2>/dev/null \
+    | xargs -r k3d cluster delete 2>/dev/null || true
+  docker network prune -f 2>/dev/null || true
+  docker volume prune -f 2>/dev/null || true
+}
+trap _cnfs_cleanup EXIT INT TERM
+
 # 1. Start K3d cluster
 printInfoSection "1/5  Starting K3d cluster"
 export CLUSTER_ENGINE=k3d

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -49,6 +49,47 @@ app = FastAPI(title="Enablement Ops Dashboard", version="2.0.0")
 from dashboard.content_service import router as content_router  # noqa: E402
 app.include_router(content_router)
 
+# SSO-delegated app deploy (Phase 1: OAuth flow + audit).
+from dashboard.app_deploy import router as deploy_router  # noqa: E402
+app.include_router(deploy_router)
+
+_DEPLOY_PAGE = """<!doctype html><html><head><meta charset=utf-8><title>Deploy app to a tenant</title>
+<style>body{font-family:system-ui;background:#0d1117;color:#e6edf3;margin:0}
+header{padding:14px 22px;background:#161b22;border-bottom:1px solid #30363d;font-weight:600}
+main{max-width:680px;margin:0 auto;padding:24px}
+input{background:#0d1117;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:8px 12px;width:380px}
+button{background:#6c6cff;color:#fff;border:0;border-radius:6px;padding:8px 16px;cursor:pointer;font-weight:600;margin-left:6px}
+button.sec{background:#30363d}
+.hint{opacity:.6;font-size:13px}
+table{width:100%;border-collapse:collapse;margin-top:18px;font-size:13px}
+td,th{padding:5px 8px;border-bottom:1px solid #21262d;text-align:left}
+</style></head><body>
+<header>Deploy the Enablement App to a Dynatrace tenant</header>
+<main>
+<p class=hint>You sign in with <b>your</b> Dynatrace SSO; the app is installed into the entered
+tenant only. No app token is stored. We log user + tenant + action, never credentials.</p>
+<div>
+  <input id=tenant placeholder="https://abc12345.apps.dynatrace.com">
+  <button onclick="go('deploy')">Sign in &amp; Deploy</button>
+  <button class=sec onclick="go('undeploy')">Undeploy</button>
+</div>
+<h3>Recent deploy activity</h3>
+<table id=audit><tbody><tr><td class=hint>loading…</td></tr></tbody></table>
+<script>
+function go(action){const t=document.getElementById('tenant').value.trim();if(!t)return;
+  location.href='/api/deploy/start?action='+action+'&tenant='+encodeURIComponent(t);}
+fetch('/api/deploy/audit?limit=30').then(r=>r.ok?r.json():{audit:[]}).then(({audit})=>{
+  const b=document.querySelector('#audit tbody');
+  b.innerHTML=audit.length?audit.map(a=>`<tr><td>${a.ts}</td><td>${a.user}</td><td>${a.tenant}</td><td>${a.action}</td><td>${a.result}</td></tr>`).join(''):'<tr><td class=hint>none yet</td></tr>';
+}).catch(()=>{});
+</script></main></body></html>"""
+
+
+@app.get("/deploy", response_class=HTMLResponse)
+async def deploy_page():
+    """Deploy UI. Page public; /api/deploy/* is writer-gated by nginx."""
+    return HTMLResponse(_DEPLOY_PAGE)
+
 _PROFILES_PAGE = """<!doctype html><html><head><meta charset=utf-8>
 <title>Content Profiles</title><style>
 body{font-family:system-ui,sans-serif;margin:0;background:#0d1117;color:#e6edf3}

--- a/ops-server/dashboard/app_deploy.py
+++ b/ops-server/dashboard/app_deploy.py
@@ -1,0 +1,197 @@
+"""SSO-delegated app deploy (Phase 1: OAuth flow + audit).
+
+Lets an org member deploy/undeploy the Enablement App into a given Dynatrace tenant using
+**their own** Dynatrace SSO (Authorization Code + PKCE, public client, no secret) — no
+per-tenant OAuth client. The delegated token is obtained live, held in memory, used once,
+and discarded. We audit user + tenant + action, never the token.
+
+Phase 1 implements: domain validation, SSO discovery, PKCE, signed state (in Redis), the
+authorize redirect, the callback + token exchange, and the audit log. The actual
+registry install/uninstall (POST/DELETE …/app-engine/registry/v1/apps) is Phase 2 — the
+callback currently obtains the token, audits, and reports "authenticated, ready to deploy".
+
+Spec: dynatrace-app-enablements/docs/orbital-sso-deploy.md
+"""
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import secrets
+from datetime import datetime, timezone
+from urllib.parse import urlencode, urlparse
+
+import httpx
+import redis.asyncio as redis
+from fastapi import APIRouter, Header, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from webhook.config import REDIS_URL
+from dashboard.content_service import classify_tenant
+
+log = logging.getLogger("ops-dashboard.deploy")
+
+# Registered Orbital public OAuth client (dt0s12-type, PKCE, no secret). Set in /home/ops/.env.
+DEPLOY_CLIENT_ID = os.environ.get("DEPLOY_CLIENT_ID", "")
+DEPLOY_REDIRECT_URI = os.environ.get(
+    "DEPLOY_REDIRECT_URI",
+    "https://autonomous-enablements.whydevslovedynatrace.com/auth/dt-callback",
+)
+DEPLOY_SCOPES = os.environ.get(
+    "DEPLOY_SCOPES",
+    "app-engine:apps:install app-engine:apps:run app-engine:apps:delete app-settings:objects:write",
+)
+APP_ID = "my.dynatrace.enablements"
+DEFAULT_SSO = "https://sso.dynatrace.com"
+FLOW_TTL = 600  # seconds a started flow stays valid
+AUDIT_KEY = "audit:deploy"
+
+router = APIRouter(tags=["deploy"])
+_redis: redis.Redis | None = None
+
+
+def _pool() -> redis.Redis:
+    global _redis
+    if _redis is None:
+        _redis = redis.from_url(REDIS_URL, decode_responses=True)
+    return _redis
+
+
+def _require_writer(x_auth_user: str | None) -> str:
+    if not x_auth_user:
+        raise HTTPException(401, "Sign in (org member) to deploy.")
+    return x_auth_user
+
+
+def _pkce() -> tuple[str, str]:
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(48)).rstrip(b"=").decode()
+    challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+async def discover_sso(tenant_url: str) -> str:
+    """Discover the tenant's SSO origin (HEAD /platform/oauth2/authorization/dynatrace-sso →
+    Location origin). Falls back to the default SSO."""
+    try:
+        u = urlparse(tenant_url if "://" in tenant_url else f"https://{tenant_url}")
+        probe = f"{u.scheme}://{u.netloc}/platform/oauth2/authorization/dynatrace-sso"
+        async with httpx.AsyncClient(timeout=8, follow_redirects=False) as c:
+            r = await c.head(probe)
+            loc = r.headers.get("location")
+            if 300 <= r.status_code < 400 and loc:
+                p = urlparse(loc)
+                return f"{p.scheme}://{p.netloc}"
+    except Exception as exc:
+        log.warning("SSO discovery failed for %s: %s", tenant_url, exc)
+    return DEFAULT_SSO
+
+
+async def _audit(user: str, tenant: str, action: str, result: str, **extra) -> None:
+    rec = {"user": user, "tenant": tenant, "action": action, "result": result,
+           "ts": datetime.now(timezone.utc).isoformat(), **extra}
+    try:
+        p = _pool()
+        await p.lpush(AUDIT_KEY, json.dumps(rec))
+        await p.ltrim(AUDIT_KEY, 0, 499)
+    except Exception as exc:  # never let auditing break the flow
+        log.warning("audit write failed: %s", exc)
+    # token is never part of `rec`
+    log.info("DEPLOY-AUDIT %s", {k: v for k, v in rec.items()})
+
+
+@router.get("/api/deploy/start")
+async def deploy_start(tenant: str, action: str = "deploy", x_auth_user: str | None = Header(default=None)):
+    """Begin the SSO flow for a tenant. Validates the Dynatrace domain, then 302s to the
+    Dynatrace authorize endpoint (PKCE). nginx gates this to org members (X-Auth-User)."""
+    user = _require_writer(x_auth_user)
+    if action not in ("deploy", "undeploy"):
+        raise HTTPException(400, "action must be deploy or undeploy.")
+    tenant_id, domain = classify_tenant(tenant)  # 403 if not a Dynatrace domain
+    if not DEPLOY_CLIENT_ID:
+        raise HTTPException(503, "Deploy not configured: register the Orbital OAuth client and set DEPLOY_CLIENT_ID.")
+
+    sso = await discover_sso(tenant)
+    verifier, challenge = _pkce()
+    state = secrets.token_urlsafe(24)
+    await _pool().setex(
+        f"deploy:flow:{state}", FLOW_TTL,
+        json.dumps({"tenant": tenant, "tenant_id": tenant_id, "domain": domain,
+                    "verifier": verifier, "user": user, "action": action, "sso": sso}),
+    )
+    authorize = f"{sso}/oauth2/authorize?" + urlencode({
+        "client_id": DEPLOY_CLIENT_ID,
+        "redirect_uri": DEPLOY_REDIRECT_URI,
+        "response_type": "code",
+        "code_challenge_method": "S256",
+        "code_challenge": challenge,
+        "scope": DEPLOY_SCOPES,
+        "state": state,
+    })
+    await _audit(user, tenant_id, action, "auth-started", domain=domain)
+    return RedirectResponse(authorize, status_code=302)
+
+
+@router.get("/auth/dt-callback", response_class=HTMLResponse)
+async def deploy_callback(request: Request):
+    """Dynatrace SSO redirect target. Validates state, exchanges the code for the user's
+    delegated token, audits, and reports. (Phase 2 will run the registry install/uninstall
+    here.) Public route — auth is carried by the OAuth state, not a GitHub session."""
+    params = request.query_params
+    err = params.get("error")
+    state = params.get("state") or ""
+    code = params.get("code") or ""
+
+    raw = await _pool().get(f"deploy:flow:{state}") if state else None
+    if not raw:
+        return HTMLResponse(_page("Invalid or expired deploy session.", ok=False), status_code=400)
+    flow = json.loads(raw)
+    await _pool().delete(f"deploy:flow:{state}")  # one-time use
+    user, tenant_id, action = flow["user"], flow["tenant_id"], flow["action"]
+
+    if err:
+        await _audit(user, tenant_id, action, "auth-error", error=err)
+        return HTMLResponse(_page(f"Sign-in failed: {err}", ok=False), status_code=400)
+
+    # Exchange the code (public client + PKCE, no secret) for the delegated token.
+    try:
+        async with httpx.AsyncClient(timeout=15) as c:
+            tok = await c.post(f"{flow['sso']}/sso/oauth2/token", data={
+                "grant_type": "authorization_code",
+                "client_id": DEPLOY_CLIENT_ID,
+                "code": code,
+                "redirect_uri": DEPLOY_REDIRECT_URI,
+                "code_verifier": flow["verifier"],
+            }, headers={"Content-Type": "application/x-www-form-urlencoded"})
+        if tok.status_code != 200:
+            await _audit(user, tenant_id, action, "token-error", status=tok.status_code)
+            return HTMLResponse(_page(f"Token exchange failed (HTTP {tok.status_code}).", ok=False), status_code=502)
+        token = tok.json().get("access_token", "")  # held in memory only, never logged/stored
+    except Exception as exc:
+        await _audit(user, tenant_id, action, "token-error", message=str(exc))
+        return HTMLResponse(_page(f"Token exchange error: {exc}", ok=False), status_code=502)
+
+    # ── Phase 2 goes here: POST/DELETE {tenant}/platform/app-engine/registry/v1/apps with
+    #    `Authorization: Bearer {token}`, then register-tenant + show the app URL. ──
+    del token  # discard the credential (Phase 1 stops after authentication)
+    await _audit(user, tenant_id, action, "authenticated")
+    app_url = f"{flow['tenant'].rstrip('/')}/ui/apps/{APP_ID}"
+    return HTMLResponse(_page(
+        f"Authenticated as <b>{user}</b> for <b>{tenant_id}</b> ({action}). "
+        f"Ready to {action} — registry call lands in Phase 2.<br><br>"
+        f"App URL (after deploy): <a href='{app_url}'>{app_url}</a>", ok=True))
+
+
+@router.get("/api/deploy/audit")
+async def deploy_audit(limit: int = 50, x_auth_user: str | None = Header(default=None)):
+    _require_writer(x_auth_user)
+    rows = await _pool().lrange(AUDIT_KEY, 0, max(0, min(limit, 500) - 1))
+    return {"audit": [json.loads(r) for r in rows]}
+
+
+def _page(msg: str, ok: bool) -> str:
+    color = "#2da44e" if ok else "#f85149"
+    return (f"<!doctype html><html><head><meta charset=utf-8><title>Deploy</title></head>"
+            f"<body style='font-family:system-ui;background:#0d1117;color:#e6edf3;padding:40px'>"
+            f"<h2 style='color:{color}'>{'✓' if ok else '✗'} App deploy</h2><p>{msg}</p>"
+            f"<p><a style='color:#9d9dff' href='/deploy'>← back</a></p></body></html>")

--- a/ops-server/dashboard/app_deploy.py
+++ b/ops-server/dashboard/app_deploy.py
@@ -5,14 +5,21 @@ Lets an org member deploy/undeploy the Enablement App into a given Dynatrace ten
 per-tenant OAuth client. The delegated token is obtained live, held in memory, used once,
 and discarded. We audit user + tenant + action, never the token.
 
-Phase 1 implements: domain validation, SSO discovery, PKCE, signed state (in Redis), the
-authorize redirect, the callback + token exchange, and the audit log. The actual
-registry install/uninstall (POST/DELETE …/app-engine/registry/v1/apps) is Phase 2 — the
-callback currently obtains the token, audits, and reports "authenticated, ready to deploy".
+Flow: domain validation → SSO discovery → PKCE → signed state (Redis) → authorize redirect →
+callback + token exchange → **deploy/undeploy** → register tenant for content → audit.
+
+Deploy shells `dt-app deploy` with the delegated token as DT_APP_PLATFORM_TOKEN (dt-app
+builds/signs/uploads the archive). Undeploy calls the registry DELETE directly. On success we
+show the app URL + log "deployed"; on error we show + log it. The token lives only in memory
+for the one call and is never logged or persisted.
+
+Needs the registered Orbital public OAuth client (set DEPLOY_CLIENT_ID); until then
+/api/deploy/start returns a clear 503.
 
 Spec: dynatrace-app-enablements/docs/orbital-sso-deploy.md
 """
 
+import asyncio
 import base64
 import hashlib
 import json
@@ -20,6 +27,7 @@ import logging
 import os
 import secrets
 from datetime import datetime, timezone
+from pathlib import Path
 from urllib.parse import urlencode, urlparse
 
 import httpx
@@ -28,7 +36,7 @@ from fastapi import APIRouter, Header, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from webhook.config import REDIS_URL
-from dashboard.content_service import classify_tenant
+from dashboard.content_service import classify_tenant, register_tenant
 
 log = logging.getLogger("ops-dashboard.deploy")
 
@@ -46,6 +54,9 @@ APP_ID = "my.dynatrace.enablements"
 DEFAULT_SSO = "https://sso.dynatrace.com"
 FLOW_TTL = 600  # seconds a started flow stays valid
 AUDIT_KEY = "audit:deploy"
+# Local checkout of the app repo (has node_modules/dt-app) used to build + deploy.
+APP_REPO_DIR = os.environ.get("APP_REPO_DIR", "/home/ops/enablement-framework/dynatrace-app-enablements")
+DEPLOY_TIMEOUT = int(os.environ.get("DEPLOY_TIMEOUT", "600"))
 
 router = APIRouter(tags=["deploy"])
 _redis: redis.Redis | None = None
@@ -98,6 +109,65 @@ async def _audit(user: str, tenant: str, action: str, result: str, **extra) -> N
         log.warning("audit write failed: %s", exc)
     # token is never part of `rec`
     log.info("DEPLOY-AUDIT %s", {k: v for k, v in rec.items()})
+
+
+def _app_url(tenant_url: str) -> str:
+    return f"{tenant_url.rstrip('/')}/ui/apps/{APP_ID}"
+
+
+def _registry_url(tenant_url: str, app_id: str | None = None) -> str:
+    base = f"{tenant_url.rstrip('/')}/platform/app-engine/registry/v1/apps"
+    return f"{base}/{app_id}" if app_id else base
+
+
+def _app_version() -> str:
+    try:
+        return json.loads((Path(APP_REPO_DIR) / "app.config.json").read_text()).get("version", "?")
+    except Exception:
+        return "?"
+
+
+async def _run_deploy(token: str, tenant_url: str) -> tuple[int, str]:
+    """Shell `dt-app deploy` with the delegated token as DT_APP_PLATFORM_TOKEN (dt-app builds,
+    signs and POSTs the archive to the registry — correct by construction). Token is passed via
+    the child env only, never logged."""
+    binary = Path(APP_REPO_DIR) / "node_modules" / ".bin" / "dt-app"
+    if not binary.exists():
+        return 127, f"dt-app not found in {APP_REPO_DIR} (is the app repo checked out with node_modules?)"
+    env = {**os.environ, "DT_APP_PLATFORM_TOKEN": token, "DT_APP_ENVIRONMENT_URL": tenant_url,
+           "DT_APP_DEACTIVATE_SPINNER": "1", "CI": "1"}
+    proc = await asyncio.create_subprocess_exec(
+        str(binary), "deploy", "--non-interactive", cwd=APP_REPO_DIR, env=env,
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT)
+    try:
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=DEPLOY_TIMEOUT)
+    except asyncio.TimeoutError:
+        proc.kill()
+        return 124, "deploy timed out"
+    return proc.returncode or 0, out.decode(errors="replace")[-1500:]
+
+
+async def _run_undeploy(token: str, tenant_url: str) -> tuple[bool, str]:
+    """Uninstall via the registry API directly (no packaging needed)."""
+    try:
+        async with httpx.AsyncClient(timeout=30) as c:
+            r = await c.delete(_registry_url(tenant_url, APP_ID), headers={"Authorization": f"Bearer {token}"})
+        if r.status_code in (200, 202, 204):
+            return True, "uninstalled"
+        if r.status_code == 404:
+            return True, "app was not installed"
+        return False, f"HTTP {r.status_code}: {r.text[:300]}"
+    except Exception as exc:
+        return False, str(exc)
+
+
+async def _register_in_content_service(user: str, tenant_url: str) -> dict | None:
+    """Best-effort: add the tenant to the delivery table so its content can be managed."""
+    try:
+        return await register_tenant({"tenant": tenant_url}, x_auth_user=user)
+    except Exception as exc:
+        log.warning("register-tenant failed for %s: %s", tenant_url, exc)
+        return None
 
 
 @router.get("/api/deploy/start")
@@ -171,15 +241,36 @@ async def deploy_callback(request: Request):
         await _audit(user, tenant_id, action, "token-error", message=str(exc))
         return HTMLResponse(_page(f"Token exchange error: {exc}", ok=False), status_code=502)
 
-    # ── Phase 2 goes here: POST/DELETE {tenant}/platform/app-engine/registry/v1/apps with
-    #    `Authorization: Bearer {token}`, then register-tenant + show the app URL. ──
-    del token  # discard the credential (Phase 1 stops after authentication)
-    await _audit(user, tenant_id, action, "authenticated")
-    app_url = f"{flow['tenant'].rstrip('/')}/ui/apps/{APP_ID}"
+    tenant_url = flow["tenant"]
+    app_url = _app_url(tenant_url)
+    version = _app_version()
+
+    if action == "undeploy":
+        ok, msg = await _run_undeploy(token, tenant_url)
+        del token  # discard the credential
+        await _audit(user, tenant_id, "undeploy", "undeployed" if ok else "undeploy-error", detail=msg)
+        return HTMLResponse(_page(
+            f"App <b>{APP_ID}</b> undeployed from <b>{tenant_id}</b>." if ok
+            else f"Undeploy failed for <b>{tenant_id}</b>: {msg}", ok=ok),
+            status_code=200 if ok else 502)
+
+    # deploy
+    rc, out = await _run_deploy(token, tenant_url)
+    del token  # discard the credential before doing anything else
+    if rc != 0:
+        await _audit(user, tenant_id, "deploy", "deploy-error", version=version, rc=rc)
+        return HTMLResponse(_page(
+            f"Deploy to <b>{tenant_id}</b> failed (exit {rc}).<br><br>"
+            f"<pre style='white-space:pre-wrap;color:#f0c674'>{out}</pre>", ok=False), status_code=502)
+
+    reg = await _register_in_content_service(user, tenant_url)
+    profile = (reg or {}).get("profile")
+    await _audit(user, tenant_id, "deploy", "deployed", version=version, url=app_url, profile=profile)
     return HTMLResponse(_page(
-        f"Authenticated as <b>{user}</b> for <b>{tenant_id}</b> ({action}). "
-        f"Ready to {action} — registry call lands in Phase 2.<br><br>"
-        f"App URL (after deploy): <a href='{app_url}'>{app_url}</a>", ok=True))
+        f"App deployed successfully to <b>{tenant_id}</b> (v{version}).<br><br>"
+        f"Open: <a href='{app_url}'>{app_url}</a><br>"
+        + (f"Content profile: <b>{profile}</b> — open the app and Refresh to load it."
+           if profile else "Tenant registered for content delivery."), ok=True))
 
 
 @router.get("/api/deploy/audit")

--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -1247,19 +1247,25 @@ function renderFrameworkRuns(runs) {
 }
 
 async function triggerFrameworkSuite(suiteId, ref) {
-    if (!isWriter()) { alert('Sign in as a writer to trigger tests.'); return; }
+    if (!isWriter()) { showToast('⚠️ Sign in as a writer to trigger tests.'); return; }
     ref = ref || document.getElementById('framework-ref')?.value || 'main';
+    const label = suiteId === 'all' ? 'all suites' : suiteId;
+    showToast(`⏳ Firing ${label} on ${ref}…`);
     try {
         const res = await fetch(`${API}/api/framework/trigger`, {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({ suite: suiteId, ref, arch: suiteId === 'bats' ? 'arm64' : 'amd64' }),
         });
-        if (!res.ok) { alert(`Error ${res.status}: ${await res.text()}`); return; }
+        if (!res.ok) { showToast(`❌ Error ${res.status}: ${await res.text()}`, 6000); return; }
         const data = await res.json();
-        alert(`Queued: ${data.jobs.map(j => `${j.suite} (${j.arch})`).join(', ')}`);
+        if (!data.jobs || !data.jobs.length) {
+            showToast('⚠️ Nothing queued (suite coming soon or unknown).', 6000);
+            return;
+        }
+        showToast(`✅ Scheduled on ${data.ref}: ${data.jobs.map(j => `${j.suite} (${j.arch})`).join(', ')}`, 6000);
         setTimeout(loadFramework, 2000);
-    } catch (e) { alert(`Error: ${e}`); }
+    } catch (e) { showToast(`❌ Error: ${e}`, 6000); }
 }
 
 // Framework tab events

--- a/ops-server/dashboard/test_app_deploy.py
+++ b/ops-server/dashboard/test_app_deploy.py
@@ -61,6 +61,50 @@ async def _raise_writer(u):
     dep._require_writer(u)
 
 
+def test_url_helpers():
+    assert dep._app_url("https://geu80787.apps.dynatrace.com/") == "https://geu80787.apps.dynatrace.com/ui/apps/my.dynatrace.enablements"
+    assert dep._registry_url("https://t.apps.dynatrace.com") == "https://t.apps.dynatrace.com/platform/app-engine/registry/v1/apps"
+    assert dep._registry_url("https://t.apps.dynatrace.com/", "my.dynatrace.enablements").endswith("/registry/v1/apps/my.dynatrace.enablements")
+
+
+def test_undeploy_calls_registry_delete_with_bearer(monkeypatch=None):
+    import httpx
+    captured = {}
+
+    class _Resp:
+        status_code = 204
+        text = ""
+
+    class _Client:
+        def __init__(self, *a, **k): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def delete(self, url, headers=None):
+            captured["url"] = url
+            captured["auth"] = (headers or {}).get("Authorization")
+            return _Resp()
+
+    orig = httpx.AsyncClient
+    httpx.AsyncClient = _Client
+    try:
+        ok, msg = asyncio.run(dep._run_undeploy("tok123", "https://t.apps.dynatrace.com"))
+    finally:
+        httpx.AsyncClient = orig
+    assert ok is True
+    assert captured["url"].endswith("/registry/v1/apps/my.dynatrace.enablements")
+    assert captured["auth"] == "Bearer tok123"
+
+
+def test_deploy_missing_repo_returns_127():
+    saved = dep.APP_REPO_DIR
+    dep.APP_REPO_DIR = "/nonexistent/app/repo"
+    try:
+        rc, out = asyncio.run(dep._run_deploy("tok", "https://t.apps.dynatrace.com"))
+    finally:
+        dep.APP_REPO_DIR = saved
+    assert rc == 127 and "dt-app not found" in out
+
+
 if __name__ == "__main__":
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     for t in tests:

--- a/ops-server/dashboard/test_app_deploy.py
+++ b/ops-server/dashboard/test_app_deploy.py
@@ -1,0 +1,69 @@
+"""Tests for the SSO-delegated deploy flow guards + PKCE (Phase 1).
+
+Run: /home/ops/ops-venv/bin/python -m dashboard.test_app_deploy
+  or pytest dashboard/test_app_deploy.py
+"""
+
+import asyncio
+import base64
+import hashlib
+
+from fastapi import HTTPException
+
+from dashboard import app_deploy as dep
+
+
+def _expect_http(status, coro):
+    try:
+        asyncio.run(coro)
+    except HTTPException as e:
+        assert e.status_code == status, f"expected {status}, got {e.status_code}"
+        return
+    raise AssertionError(f"expected HTTPException {status}, none raised")
+
+
+def test_pkce_challenge_is_s256_of_verifier():
+    verifier, challenge = dep._pkce()
+    expected = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    assert challenge == expected
+    assert "=" not in verifier and "=" not in challenge  # url-safe, unpadded
+    # fresh each call
+    assert dep._pkce()[0] != verifier
+
+
+def test_start_requires_org_member():
+    _expect_http(401, dep.deploy_start(tenant="https://x.apps.dynatrace.com", action="deploy", x_auth_user=None))
+
+
+def test_start_rejects_bad_action():
+    _expect_http(400, dep.deploy_start(tenant="https://x.apps.dynatrace.com", action="nuke", x_auth_user="alice"))
+
+
+def test_start_rejects_non_dynatrace_tenant():
+    _expect_http(403, dep.deploy_start(tenant="https://evil.example.com", action="deploy", x_auth_user="alice"))
+
+
+def test_start_503_when_client_not_configured():
+    saved = dep.DEPLOY_CLIENT_ID
+    dep.DEPLOY_CLIENT_ID = ""
+    try:
+        _expect_http(503, dep.deploy_start(tenant="https://geu80787.apps.dynatrace.com", action="deploy", x_auth_user="alice"))
+    finally:
+        dep.DEPLOY_CLIENT_ID = saved
+
+
+def test_require_writer():
+    assert dep._require_writer("alice") == "alice"
+    _expect_http(401, _raise_writer(None))
+
+
+async def _raise_writer(u):
+    dep._require_writer(u)
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for t in tests:
+        t()
+        print(f"  PASS {t.__name__}")
+    print(f"\n{len(tests)}/{len(tests)} deploy tests passed")

--- a/ops-server/nginx/ops-server.conf
+++ b/ops-server/nginx/ops-server.conf
@@ -120,6 +120,22 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # SSO-delegated app deploy — starting a deploy is org-member-only (writer). The
+    # /auth/dt-callback target stays on the public catch-all (it carries OAuth state).
+    location ~ ^/api/deploy/ {
+        auth_request /oauth2/auth;
+        error_page 401 = @json_unauthorized;
+        auth_request_set $user  $upstream_http_x_auth_request_user;
+        auth_request_set $email $upstream_http_x_auth_request_email;
+        proxy_set_header X-Auth-User  $user;
+        proxy_set_header X-Auth-Email $email;
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location = /api/sync/run {
         auth_request /oauth2/auth;
         error_page 401 = @json_unauthorized;

--- a/ops-server/worker-agent/executor.py
+++ b/ops-server/worker-agent/executor.py
@@ -323,14 +323,21 @@ async def execute_integration_test(
                 await asyncio.wait_for(kill_proc.wait(), timeout=60)
             except Exception:
                 pass
-            try:
-                vol_proc = await asyncio.create_subprocess_exec(
-                    "docker", "volume", "prune", "-f",
-                    stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
-                )
-                await asyncio.wait_for(vol_proc.wait(), timeout=30)
-            except Exception:
-                pass
+            # Volumes then networks. k3d creates a `k3d-<cluster>` docker network
+            # per cluster; without Sysbox isolation these accumulate on the host
+            # and clutter the worker. Prune regardless of exit status.
+            for prune_args in (
+                ["docker", "volume", "prune", "-f"],
+                ["docker", "network", "prune", "-f"],
+            ):
+                try:
+                    prune_proc = await asyncio.create_subprocess_exec(
+                        *prune_args,
+                        stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+                    )
+                    await asyncio.wait_for(prune_proc.wait(), timeout=30)
+                except Exception:
+                    pass
             shutil.rmtree(work_dir, ignore_errors=True)
 
     duration = int(time.time() - start_time)

--- a/ops-server/worker-agent/executor.py
+++ b/ops-server/worker-agent/executor.py
@@ -237,6 +237,7 @@ async def execute_integration_test(
             "-e", "GIT_CONFIG_KEY_0=safe.directory",
             "-e", "GIT_CONFIG_VALUE_0=*",
             "-e", "ORBITAL_ENVIRONMENT=true",
+            "-e", f"ORBITAL_JOB_ID={job_id}",
             "-e", f"ARCH={WORKER_ARCH}",
             TEST_IMAGE,
             "sleep", "infinity",
@@ -495,6 +496,7 @@ async def execute_daemon(
             "-e", "GIT_CONFIG_KEY_0=safe.directory",
             "-e", "GIT_CONFIG_VALUE_0=*",
             "-e", "ORBITAL_ENVIRONMENT=true",
+            "-e", f"ORBITAL_JOB_ID={job_id}",
             "-e", f"ARCH={WORKER_ARCH}",
             TEST_IMAGE, "sleep", "infinity",
         ]


### PR DESCRIPTION
Phase 1 of the SSO deploy (spec: app PR #6). Stacked on #63 (uses `classify_tenant`).

- `/deploy` page + `GET /api/deploy/start` (writer-gated): validate Dynatrace domain, discover SSO, PKCE + state in Redis, redirect to authorize.
- `GET /auth/dt-callback`: exchange code (PKCE, no secret) → user's delegated token (in memory) → audit → report. **Phase 2** drops the registry install/uninstall (`POST/DELETE …/registry/v1/apps`) here.
- `GET /api/deploy/audit` (writer). Logs user+tenant+action, **never the token**.
- nginx gates `/api/deploy/`; callback stays public (carries OAuth state).
- Needs the registered Orbital public OAuth client (`DEPLOY_CLIENT_ID`); until set, start returns a clear 503.
- 6 tests; deployed + smoke-tested (401/403/503/400/page/gated all correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)