### PR TITLE
feat(worker): weighted scheduler + heavy-lane routing

### DIFF
--- a/ops-server/worker-agent/agent.py
+++ b/ops-server/worker-agent/agent.py
@@ -35,6 +35,8 @@ from .config import (
     WORKER_ID,
     WORKER_ARCH,
     WORKER_CAPACITY,
+    WORKER_COST_BUDGET,
+    WORKER_MAX_HEAVY,
     WORKER_HOST,
     WORKER_SSH_HOST,
     MASTER_REDIS_URL,
@@ -54,6 +56,7 @@ from .executor import (
     _wait_for_inner_docker,
     _pipe_image_to_sysbox,
 )
+from .scheduler import WeightedScheduler, classify
 
 LOCK_TTL_SECONDS = 7200
 
@@ -291,6 +294,13 @@ class WorkerAgent:
         self.pool: redis.Redis | None = None
         self.active_jobs: dict[str, dict] = {}
         self.semaphore = asyncio.Semaphore(WORKER_CAPACITY)
+        # Weighted admission + heavy-lane routing in front of the physical slot
+        # pool. Light jobs still fill every slot; heavy jobs (dt-cnfs) are
+        # throttled by cost budget and a bounded heavy lane so they cannot OOM
+        # the worker by co-scheduling.
+        self.scheduler = WeightedScheduler.from_capacity(
+            WORKER_CAPACITY, WORKER_COST_BUDGET, WORKER_MAX_HEAVY
+        )
         self._running = True
         self._terminated_jobs: set[str] = set()
         self._shutdown = False
@@ -309,6 +319,10 @@ class WorkerAgent:
         log.info(
             "Connected to master Redis. Worker: %s (arch=%s, capacity=%d)",
             WORKER_ID, WORKER_ARCH, WORKER_CAPACITY,
+        )
+        log.info(
+            "Weighted scheduler: budget=%d cost units, heavy lane=%d concurrent",
+            self.scheduler.budget, self.scheduler.max_heavy,
         )
 
         await self._register()
@@ -498,6 +512,7 @@ class WorkerAgent:
                     "active_jobs": str(len(self.active_jobs)),
                     "last_heartbeat": datetime.now(timezone.utc).isoformat(),
                     "status": "ready" if len(self.active_jobs) < WORKER_CAPACITY else "busy",
+                    **{k: str(v) for k, v in self.scheduler.stats().items()},
                     **metrics,
                 })
                 await self.pool.expire(worker_key, REGISTRATION_TTL)
@@ -583,6 +598,14 @@ class WorkerAgent:
             ttl = 86400 if job.get("type") == "daemon" else LOCK_TTL_SECONDS
             await self.pool.expire(running_key, ttl)
 
+            # Weighted admission: block until the cost budget + heavy lane
+            # allow this job. Cheap jobs pass immediately; heavy jobs (dt-cnfs)
+            # wait for a heavy-lane permit so they never co-schedule into an OOM.
+            cost, lane = classify(job)
+            await self.scheduler.acquire(job)
+            log.info("Admitted %s: cost=%d lane=%s | %s", job_id, cost, lane,
+                     self.scheduler.stats())
+
             # Acquire a pre-warmed slot. Blocks if all capacity is in use.
             slot = await self.sysbox_pool.acquire()
             self._job_slots[job_id] = slot
@@ -604,6 +627,9 @@ class WorkerAgent:
                 job["status"] = "failed"
                 healthy = False
             finally:
+                # Release the weighted reservation (cost + heavy lane) on every
+                # exit path — ok, fail, timeout, or terminated.
+                await self.scheduler.release(job)
                 self._job_slots.pop(job_id, None)
                 # Terminated daemon jobs have their Sysbox force-removed externally.
                 # docker wait returns normally (no exception), so healthy stays True.

--- a/ops-server/worker-agent/config.py
+++ b/ops-server/worker-agent/config.py
@@ -21,6 +21,11 @@ def _detect_host_ip() -> str:
 WORKER_ID = os.environ.get("WORKER_ID", f"worker-{platform.machine()}-{uuid.uuid4().hex[:6]}")
 WORKER_ARCH = os.environ.get("WORKER_ARCH", "arm64" if platform.machine() in ("aarch64", "arm64") else "amd64")
 WORKER_CAPACITY = int(os.environ.get("WORKER_CAPACITY", "6"))
+# Weighted scheduler overrides (optional; derived from WORKER_CAPACITY when unset).
+# WORKER_COST_BUDGET  — total in-flight cost units the worker admits at once.
+# WORKER_MAX_HEAVY    — max concurrent heavy-lane jobs (e.g. dt-cnfs).
+WORKER_COST_BUDGET = int(os.environ["WORKER_COST_BUDGET"]) if os.environ.get("WORKER_COST_BUDGET") else None
+WORKER_MAX_HEAVY = int(os.environ["WORKER_MAX_HEAVY"]) if os.environ.get("WORKER_MAX_HEAVY") else None
 # Private IP of this worker (auto-detected; override via WORKER_HOST env var).
 WORKER_HOST = os.environ.get("WORKER_HOST") or _detect_host_ip()
 # Optional SSH alias the master uses to reach this worker (defaults to WORKER_HOST).

--- a/ops-server/worker-agent/scheduler.py
+++ b/ops-server/worker-agent/scheduler.py
@@ -1,0 +1,184 @@
+"""Weighted scheduler + lane routing for the worker agent.
+
+Pure, dependency-free logic (asyncio only) so it can be unit-tested without
+Redis or Docker.
+
+Why this exists
+---------------
+The worker used to gate concurrency with a flat ``Semaphore(WORKER_CAPACITY)``
+and a pool of identical Sysbox slots: every job cost exactly one slot, whether
+it was a static shell unit test (``bats``, <0.5 GB) or a full Dynatrace
+CloudNativeFullStack run (``dt-cnfs`` — Operator + ActiveGate + k3d, ~3-4 GB).
+That meant the worker either ran too few slots (wasting capacity on light
+jobs) or oversubscribed and OOMed when several heavy jobs landed together.
+
+Two independent gates now sit in front of the physical slot:
+
+1. **Cost budget** — each job has an integer *cost* (light=1, medium=2,
+   heavy=4). Jobs are admitted while the sum of in-flight costs stays within
+   ``budget``. Heavy jobs reserve more of the budget, so fewer run at once,
+   while cheap jobs keep filling the remaining headroom — dense packing
+   without OOM.
+
+2. **Heavy lane** — jobs classified ``heavy`` additionally need a permit from a
+   small lane of ``max_heavy`` concurrent slots. This stops several
+   memory-hungry jobs from co-scheduling even when the cost budget alone would
+   allow it. Light jobs never touch this lane, so they are never blocked by it.
+
+Both reservations are released when the job finishes — any status (ok, fail,
+timeout, terminated) — by the caller's ``finally`` block.
+
+The physical Sysbox slot pool (``WORKER_CAPACITY`` slots) remains the hard cap
+on simultaneous jobs; this scheduler only decides *which* queued jobs are
+allowed to claim a slot next.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+# Cost tiers.
+COST_LIGHT = 1
+COST_MEDIUM = 2
+COST_HEAVY = 4
+
+# A job at or above this cost is treated as heavy-lane traffic.
+HEAVY_THRESHOLD = COST_HEAVY
+
+# Known framework suites → cost. Suite id is carried on the job as job["suite"].
+SUITE_COST = {
+    "bats": COST_LIGHT,            # static shell unit tests, no cluster
+    "engines": COST_MEDIUM,        # k3d (+ kind) engine bring-up
+    "k3d-apps": COST_MEDIUM,       # demo apps on k3d
+    "dt-apponly": COST_MEDIUM,     # Operator + ActiveGate + CSI app injection
+    "k3d-aitraveladvisor": COST_MEDIUM,
+    "dt-cnfs": COST_HEAVY,         # CNFS: Operator + ActiveGate + k3d, ~3-4 GB
+}
+
+# Suites that must run in the constrained heavy lane regardless of cost lookups.
+HEAVY_SUITES = {"dt-cnfs"}
+
+# Fallback cost by job type when no suite is present (e.g. PR / nightly repo tests).
+TYPE_COST = {
+    "framework-test": COST_MEDIUM,
+    "integration-test": COST_MEDIUM,
+    "daemon": COST_MEDIUM,
+}
+
+
+def cost_of(job: dict) -> int:
+    """Resolve a job's cost.
+
+    Precedence: explicit ``job["cost"]`` → suite table → type table → light.
+    Always at least 1.
+    """
+    explicit = job.get("cost")
+    if explicit is not None:
+        try:
+            return max(1, int(explicit))
+        except (TypeError, ValueError):
+            pass
+    suite = job.get("suite") or job.get("framework_suite")
+    if suite in SUITE_COST:
+        return SUITE_COST[suite]
+    return TYPE_COST.get(job.get("type"), COST_LIGHT)
+
+
+def lane_of(job: dict) -> str:
+    """Classify a job into the ``"heavy"`` or ``"light"`` lane.
+
+    Precedence: explicit ``job["lane"]`` → known heavy suite → ``requires_native``
+    flag → cost at/above ``HEAVY_THRESHOLD`` → light.
+    """
+    explicit = job.get("lane")
+    if explicit in ("heavy", "light"):
+        return explicit
+    suite = job.get("suite") or job.get("framework_suite")
+    if suite in HEAVY_SUITES:
+        return "heavy"
+    if job.get("requires_native"):
+        return "heavy"
+    return "heavy" if cost_of(job) >= HEAVY_THRESHOLD else "light"
+
+
+def classify(job: dict) -> tuple[int, str]:
+    """Return ``(cost, lane)`` for a job — convenience for logging."""
+    return cost_of(job), lane_of(job)
+
+
+class WeightedScheduler:
+    """Admission control by cost budget + a bounded heavy lane.
+
+    Not tied to Redis/Docker — callers ``await acquire(job)`` before claiming a
+    physical slot and ``await release(job)`` in their ``finally``.
+    """
+
+    def __init__(self, budget: int, max_heavy: int) -> None:
+        # budget must allow at least one heavy job to ever run.
+        self.budget = max(int(budget), COST_HEAVY)
+        # at least one heavy permit, else heavy jobs would deadlock forever.
+        self.max_heavy = max(int(max_heavy), 1)
+        self._in_flight_cost = 0
+        self._heavy_in_flight = 0
+        self._cond = asyncio.Condition()
+
+    @classmethod
+    def from_capacity(
+        cls,
+        capacity: int,
+        budget: int | None = None,
+        max_heavy: int | None = None,
+    ) -> "WeightedScheduler":
+        """Derive sensible defaults from the worker's slot capacity.
+
+        - ``budget``    defaults to ``capacity * COST_MEDIUM`` (light jobs can
+          still fill every slot; heavy jobs are throttled by weight).
+        - ``max_heavy`` defaults to ``capacity // 3`` (at least 1) — roughly one
+          heavy lane per three slots.
+        """
+        capacity = max(int(capacity), 1)
+        if budget is None:
+            budget = capacity * COST_MEDIUM
+        if max_heavy is None:
+            max_heavy = max(1, capacity // 3)
+        return cls(budget, max_heavy)
+
+    # ── pure predicate (unit-testable without awaiting) ──────────────────────
+    def can_admit(self, job: dict) -> bool:
+        """Whether ``job`` could be admitted right now.
+
+        Heavy-lane capacity is always enforced. Cost budget is enforced unless
+        nothing is in flight, in which case a single job is always admitted so
+        an oversized job (cost > budget) can still make progress alone.
+        """
+        if lane_of(job) == "heavy" and self._heavy_in_flight >= self.max_heavy:
+            return False
+        if self._in_flight_cost == 0:
+            return True
+        return self._in_flight_cost + cost_of(job) <= self.budget
+
+    # ── async admission ──────────────────────────────────────────────────────
+    async def acquire(self, job: dict) -> None:
+        """Block until ``job`` can be admitted, then reserve its cost + lane."""
+        async with self._cond:
+            await self._cond.wait_for(lambda: self.can_admit(job))
+            self._in_flight_cost += cost_of(job)
+            if lane_of(job) == "heavy":
+                self._heavy_in_flight += 1
+
+    async def release(self, job: dict) -> None:
+        """Release ``job``'s reservation and wake any waiters."""
+        async with self._cond:
+            self._in_flight_cost = max(0, self._in_flight_cost - cost_of(job))
+            if lane_of(job) == "heavy":
+                self._heavy_in_flight = max(0, self._heavy_in_flight - 1)
+            self._cond.notify_all()
+
+    def stats(self) -> dict:
+        """Snapshot for heartbeat/observability."""
+        return {
+            "sched_budget": self.budget,
+            "sched_in_flight_cost": self._in_flight_cost,
+            "sched_max_heavy": self.max_heavy,
+            "sched_heavy_in_flight": self._heavy_in_flight,
+        }

--- a/ops-server/worker-agent/test_scheduler.py
+++ b/ops-server/worker-agent/test_scheduler.py
@@ -1,0 +1,207 @@
+"""Tests for the worker's weighted scheduler + lane routing.
+
+Pure logic — no Redis, Docker, or psutil — so it runs anywhere.
+
+Runnable two ways (mirrors dashboard/test_content_service.py):
+  - pytest:     /home/ops/ops-venv/bin/python -m pytest worker-agent/test_scheduler.py
+  - standalone: cd ops-server && /home/ops/ops-venv/bin/python -m worker-agent.test_scheduler
+"""
+
+import asyncio
+
+from .scheduler import (
+    WeightedScheduler,
+    cost_of,
+    lane_of,
+    classify,
+    COST_LIGHT,
+    COST_MEDIUM,
+    COST_HEAVY,
+)
+
+
+# ── cost classification ──────────────────────────────────────────────────────
+
+def test_cost_of_by_suite():
+    assert cost_of({"suite": "bats"}) == COST_LIGHT
+    assert cost_of({"suite": "engines"}) == COST_MEDIUM
+    assert cost_of({"suite": "dt-apponly"}) == COST_MEDIUM
+    assert cost_of({"suite": "dt-cnfs"}) == COST_HEAVY
+    # framework_suite is an accepted alias for suite
+    assert cost_of({"framework_suite": "dt-cnfs"}) == COST_HEAVY
+
+
+def test_cost_of_explicit_wins_and_is_floored():
+    assert cost_of({"cost": 7, "suite": "bats"}) == 7      # explicit beats suite
+    assert cost_of({"cost": "3"}) == 3                     # string coerced
+    assert cost_of({"cost": 0}) == 1                       # floored to >= 1
+    assert cost_of({"cost": -5}) == 1
+    assert cost_of({"cost": "bad", "suite": "bats"}) == COST_LIGHT  # bad → fallback
+
+
+def test_cost_of_by_type_and_default():
+    assert cost_of({"type": "integration-test"}) == COST_MEDIUM
+    assert cost_of({"type": "daemon"}) == COST_MEDIUM
+    assert cost_of({"type": "framework-test"}) == COST_MEDIUM
+    assert cost_of({}) == COST_LIGHT
+    assert cost_of({"type": "unknown-type"}) == COST_LIGHT
+
+
+# ── lane classification ──────────────────────────────────────────────────────
+
+def test_lane_of():
+    assert lane_of({"suite": "dt-cnfs"}) == "heavy"
+    assert lane_of({"suite": "bats"}) == "light"
+    assert lane_of({"requires_native": True}) == "heavy"
+    assert lane_of({"cost": COST_HEAVY}) == "heavy"        # at threshold
+    assert lane_of({"cost": COST_MEDIUM}) == "light"
+    assert lane_of({}) == "light"
+
+
+def test_lane_explicit_overrides():
+    assert lane_of({"lane": "heavy", "suite": "bats"}) == "heavy"
+    assert lane_of({"lane": "light", "suite": "dt-cnfs"}) == "light"
+
+
+def test_classify():
+    assert classify({"suite": "dt-cnfs"}) == (COST_HEAVY, "heavy")
+    assert classify({"suite": "bats"}) == (COST_LIGHT, "light")
+
+
+# ── from_capacity defaults + clamps ──────────────────────────────────────────
+
+def test_from_capacity_defaults():
+    s = WeightedScheduler.from_capacity(6)
+    assert s.budget == 6 * COST_MEDIUM          # 12
+    assert s.max_heavy == 2                      # 6 // 3
+
+
+def test_from_capacity_clamps():
+    # capacity 1 → budget 2 clamped up to COST_HEAVY; max_heavy floored to 1
+    s = WeightedScheduler.from_capacity(1)
+    assert s.budget == COST_HEAVY
+    assert s.max_heavy == 1
+    # explicit too-small values are clamped
+    s2 = WeightedScheduler.from_capacity(6, budget=3, max_heavy=0)
+    assert s2.budget == COST_HEAVY
+    assert s2.max_heavy == 1
+
+
+# ── can_admit (pure predicate) ───────────────────────────────────────────────
+
+def test_can_admit_respects_budget():
+    s = WeightedScheduler(budget=4, max_heavy=5)
+    a = {"cost": 2, "lane": "light"}
+    asyncio.run(s.acquire(a))
+    asyncio.run(s.acquire({"cost": 2, "lane": "light"}))   # in_flight == 4 == budget
+    assert not s.can_admit({"cost": 2, "lane": "light"})   # would exceed
+    assert not s.can_admit({"cost": 1, "lane": "light"})
+
+
+def test_can_admit_progress_when_idle():
+    # An oversized job (cost > budget) is still admitted when nothing is in flight.
+    s = WeightedScheduler(budget=4, max_heavy=2)
+    assert s.can_admit({"cost": 99, "lane": "light"})
+
+
+def test_can_admit_heavy_lane_cap():
+    s = WeightedScheduler(budget=100, max_heavy=1)   # budget wide; isolate lane
+    asyncio.run(s.acquire({"suite": "dt-cnfs"}))     # lane full
+    assert not s.can_admit({"suite": "dt-cnfs"})     # second heavy blocked
+    assert s.can_admit({"suite": "bats"})            # light unaffected
+
+
+# ── async admission: blocks then unblocks ────────────────────────────────────
+
+def test_heavy_lane_blocks_until_release():
+    async def run():
+        s = WeightedScheduler(budget=100, max_heavy=1)
+        await s.acquire({"suite": "dt-cnfs"})
+        assert s.stats()["sched_heavy_in_flight"] == 1
+
+        waiter = asyncio.create_task(s.acquire({"suite": "dt-cnfs"}))
+        await asyncio.sleep(0.02)
+        assert not waiter.done()                     # blocked on the heavy lane
+
+        await s.release({"suite": "dt-cnfs"})
+        await asyncio.wait_for(waiter, 1)            # released → admitted
+        assert s.stats()["sched_heavy_in_flight"] == 1
+    asyncio.run(run())
+
+
+def test_budget_blocks_until_release():
+    async def run():
+        s = WeightedScheduler(budget=4, max_heavy=5)
+        a = {"cost": 2, "lane": "light"}
+        await s.acquire(a)
+        await s.acquire({"cost": 2, "lane": "light"})   # in_flight == budget
+
+        waiter = asyncio.create_task(s.acquire({"cost": 2, "lane": "light"}))
+        await asyncio.sleep(0.02)
+        assert not waiter.done()                        # blocked on budget
+
+        await s.release(a)                              # frees 2 units
+        await asyncio.wait_for(waiter, 1)
+        assert s.stats()["sched_in_flight_cost"] == 4
+    asyncio.run(run())
+
+
+def test_light_not_blocked_by_full_heavy_lane():
+    async def run():
+        s = WeightedScheduler(budget=100, max_heavy=1)
+        await s.acquire({"suite": "dt-cnfs"})           # heavy lane saturated
+        # A light job must still be admitted immediately.
+        await asyncio.wait_for(s.acquire({"suite": "bats"}), 1)
+        assert s.stats()["sched_heavy_in_flight"] == 1
+    asyncio.run(run())
+
+
+# ── acquire/release bookkeeping ──────────────────────────────────────────────
+
+def test_acquire_release_roundtrip():
+    async def run():
+        s = WeightedScheduler(budget=10, max_heavy=2)
+        j = {"suite": "dt-cnfs"}
+        await s.acquire(j)
+        st = s.stats()
+        assert st["sched_in_flight_cost"] == COST_HEAVY
+        assert st["sched_heavy_in_flight"] == 1
+
+        await s.release(j)
+        st = s.stats()
+        assert st["sched_in_flight_cost"] == 0
+        assert st["sched_heavy_in_flight"] == 0
+    asyncio.run(run())
+
+
+def test_release_floors_at_zero():
+    async def run():
+        s = WeightedScheduler(budget=10, max_heavy=2)
+        await s.release({"suite": "dt-cnfs"})           # release without acquire
+        st = s.stats()
+        assert st["sched_in_flight_cost"] == 0
+        assert st["sched_heavy_in_flight"] == 0
+    asyncio.run(run())
+
+
+def test_mixed_packing_one_heavy_plus_lights():
+    async def run():
+        # 6-slot worker defaults: budget 12, heavy lane 2.
+        s = WeightedScheduler.from_capacity(6)
+        await s.acquire({"suite": "dt-cnfs"})           # heavy: cost 4
+        # Light unit tests (cost 1) keep filling the remaining budget headroom.
+        for _ in range(8):                               # 4 + 8*1 = 12 == budget
+            assert s.can_admit({"suite": "bats"})
+            await s.acquire({"suite": "bats"})
+        assert s.stats()["sched_in_flight_cost"] == 12
+        assert not s.can_admit({"suite": "bats"})       # budget exhausted
+        assert not s.can_admit({"suite": "dt-cnfs"})    # also over budget
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for t in tests:
+        t()
+        print(f"  PASS {t.__name__}")
+    print(f"\n{len(tests)}/{len(tests)} scheduler tests passed")


### PR DESCRIPTION
## Why
The worker gated concurrency with a flat `Semaphore(WORKER_CAPACITY)` and identical Sysbox slots — every job cost one slot whether it was a static `bats` unit test (<0.5 GB) or a full `dt-cnfs` CloudNativeFullStack run (Operator + ActiveGate + k3d, ~3-4 GB). Result: either under-utilise on light jobs, or OOM when several heavy jobs land together. This adds **weighted packing + a bounded heavy lane** so the same VMs run more jobs without colliding — no new hardware.

## What
- **`scheduler.py` (new)** — pure, dependency-free `WeightedScheduler`:
  - **Cost tiers**: light=1, medium=2, heavy=4. Resolved from explicit `job["cost"]` → suite table → job type. `dt-cnfs` = heavy.
  - **Lane routing**: heavy suites / `requires_native` / cost ≥ threshold → **heavy lane** (`max_heavy` concurrent). Everything else → light, never blocked by the heavy lane.
  - **Budget admission** with an idle-progress rule (an oversized job still runs alone) + heavy-lane permit cap. `asyncio.Condition` for blocking `acquire`.
  - `from_capacity()`: budget = capacity×2, heavy lane = capacity//3 (min 1). 6-slot worker → budget 12, heavy lane 2.
- **`agent.py`** — `scheduler.acquire(job)` before claiming a slot; `release(job)` in the `finally` on every exit path (ok/fail/timeout/terminated). Scheduler stats added to the heartbeat for observability.
- **`config.py`** — optional `WORKER_COST_BUDGET` / `WORKER_MAX_HEAVY` overrides.
- **`test_scheduler.py` (new)** — 17 tests: cost/lane classification, budget + heavy-lane admission, blocking-until-release, mixed packing, clamps. Runs standalone (`python -m worker-agent.test_scheduler`) or under pytest; no Redis/Docker.

## Notes
- Classification needs **no enqueue changes** — `dt-cnfs` jobs already carry `suite` + `requires_native`.
- The physical Sysbox slot pool remains the hard concurrency cap; the scheduler only decides which queued job claims a slot next.
- Tests: `17/17 passed` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)