### PR TITLE
fix(ops): deploy timeout + robust deploy UI (504 HTML → JSON parse error)

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -89,28 +89,38 @@ used once and never stored. We log user + tenant + action, never the token.</p>
 </div>
 
 <h3>Recent deploy activity</h3>
-<table id=audit><tbody><tr><td class=hint>loading…</td></tr></tbody></table>
+<table id=audit><thead><tr><th>when</th><th>user</th><th>tenant</th><th>action</th><th>result</th><th>version</th><th>via</th></tr></thead>
+<tbody><tr><td class=hint>loading…</td></tr></tbody></table>
 <script>
 async function goToken(action){
   const t=document.getElementById('ttenant').value.trim(), k=document.getElementById('ttoken').value.trim();
   const m=document.getElementById('tmsg'); if(!t){m.textContent='tenant required';return;}
-  m.textContent=action+'ing… (deploy can take a minute)';
+  m.textContent=action+'ing… (a deploy can take a minute or two)';
   try{
     const r=await fetch('/api/deploy/token',{method:'POST',headers:{'Content-Type':'application/json'},
       body:JSON.stringify({action,tenant:t,token:k})});
-    const j=await r.json();
+    const raw=await r.text();
+    let j={}; try{ j=JSON.parse(raw); }catch(_){ /* non-JSON (e.g. gateway error page) */ }
     if(r.ok){document.getElementById('ttoken').value='';
-      if(action!=='deploy'){m.textContent='✓ undeployed';}
-      else{const s=j.status==='up-to-date'?`already up-to-date (v${j.version})`
-        :j.status==='upgraded'?`upgraded v${j.from} → v${j.version}`:`installed v${j.version}`;
-        m.innerHTML=`✓ ${s} — <a href="${j.url}">${j.url}</a>`+(j.profile?` · profile ${j.profile}`:'');}}
-    else m.textContent='✗ '+(j.detail||'failed');
-  }catch(e){m.textContent='✗ '+e;}
+      if(action!=='deploy'){m.textContent='✓ undeployed '+(t);}
+      else{const v=j.version||'?';
+        const s=j.status==='up-to-date'?`already up-to-date (v${v})`
+          :j.status==='upgraded'?`upgraded v${j.from} → v${v}`:`installed v${v}`;
+        m.innerHTML=`✓ ${s} — <a href="${j.url}">${j.url}</a>`+(j.profile?` · content profile ${j.profile}`:'');}
+      loadAudit();
+    } else {
+      m.textContent='✗ '+(j.detail || `failed (HTTP ${r.status})`+(r.status>=502?' — the server may still be finishing; check the activity log':''));
+      loadAudit();
+    }
+  }catch(e){m.textContent='✗ network error: '+e;}
 }
-fetch('/api/deploy/audit?limit=30').then(r=>r.ok?r.json():{audit:[]}).then(({audit})=>{
-  const b=document.querySelector('#audit tbody');
-  b.innerHTML=audit.length?audit.map(a=>`<tr><td>${a.ts}</td><td>${a.user}</td><td>${a.tenant}</td><td>${a.action}</td><td>${a.result}</td></tr>`).join(''):'<tr><td class=hint>none yet</td></tr>';
-}).catch(()=>{});
+function loadAudit(){
+  fetch('/api/deploy/audit?limit=30').then(r=>r.ok?r.json():{audit:[]}).then(({audit})=>{
+    const b=document.querySelector('#audit tbody');
+    b.innerHTML=audit.length?audit.map(a=>`<tr><td>${(a.ts||'').replace('T',' ').slice(0,19)}</td><td>${a.user||''}</td><td>${a.tenant||''}</td><td>${a.action||''}</td><td>${a.result||''}</td><td>${a.to||a.version||''}</td><td>${a.via||''}</td></tr>`).join(''):'<tr><td class=hint>none yet</td></tr>';
+  }).catch(()=>{});
+}
+loadAudit();
 </script></main></body></html>"""
 
 

--- a/ops-server/nginx/ops-server.conf
+++ b/ops-server/nginx/ops-server.conf
@@ -134,6 +134,9 @@ server {
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # dt-app build+deploy can take minutes — don't let nginx 504 mid-deploy (default 60s).
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
     }
 
     location = /api/sync/run {


### PR DESCRIPTION
**Bug:** deploying via /deploy showed `SyntaxError: Unexpected token '<', "<html>..."`.

**Cause:** `/api/deploy/token` had no nginx `proxy_read_timeout` → default 60s. A `dt-app` build+deploy takes minutes → nginx returns a **504 HTML** page → the UI's `response.json()` parsed HTML → the error. The deploy actually **succeeded** server-side (verified via COE-ingested logs: tenant `sro97894` installed 1.0.131).

**Fix:**
- nginx `proxy_read_timeout/proxy_send_timeout 600s` on `/api/deploy/`.
- UI parses text→JSON (no crash on HTML), shows a 'still finishing' hint on 5xx, refreshes the log.
- Activity log now shows **version** + **via** columns — every deployment shows its deployed version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)