### PR TITLE
feat(ops): Register Tenant tab (writer-only) — app deploy via token in the dashboard

### DIFF
--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -100,6 +100,7 @@ function activateTab(view) {
     if (view === 'agentic') loadAgentic();
     if (view === 'framework') loadFramework();
     if (view === 'content') loadContent();
+    if (view === 'register') loadRegister();
 }
 
 document.querySelectorAll('.tab').forEach(tab => {
@@ -3154,4 +3155,67 @@ async function loadContent() {
     } catch (e) {
         document.getElementById('content-profiles').innerHTML = '<p class="content-hint">Failed to load content overview.</p>';
     }
+}
+
+// ── Register Tenant tab (app deploy via platform token / COE auto) ────────────
+let regWired = false;
+
+function wireRegister() {
+    if (regWired) return; regWired = true;
+    document.getElementById('reg-deploy').addEventListener('click', () => goRegister('deploy'));
+    document.getElementById('reg-undeploy').addEventListener('click', () => goRegister('undeploy'));
+}
+
+function setRegBusy(b) {
+    document.getElementById('reg-spin').classList.toggle('busy', b);
+    document.getElementById('reg-bar').hidden = !b;
+    document.getElementById('reg-deploy').disabled = b;
+    document.getElementById('reg-undeploy').disabled = b;
+}
+
+async function goRegister(action) {
+    const t = document.getElementById('reg-tenant').value.trim();
+    const k = document.getElementById('reg-token').value.trim();
+    const m = document.getElementById('reg-msg');
+    if (!t) { m.textContent = 'tenant required'; return; }
+    m.textContent = ''; setRegBusy(true);
+    try {
+        const r = await fetch('/api/deploy/token', { method: 'POST', headers: { 'Content-Type': 'application/json' }, credentials: 'same-origin', body: JSON.stringify({ action, tenant: t, token: k }) });
+        const raw = await r.text();
+        let j = {}; try { j = JSON.parse(raw); } catch (_) { /* non-JSON gateway page */ }
+        if (r.ok) {
+            document.getElementById('reg-token').value = '';
+            if (action !== 'deploy') { m.textContent = '✓ undeployed ' + t; }
+            else {
+                const v = j.version || '?';
+                const s = j.status === 'up-to-date' ? `already up-to-date (v${v})` : j.status === 'upgraded' ? `upgraded v${j.from} → v${v}` : `installed v${v}`;
+                m.innerHTML = `✓ ${s} — <a href="${escapeHtml(j.url || '#')}" target="_blank">open app</a>` + (j.profile ? ` · content profile ${escapeHtml(j.profile)}` : '');
+            }
+            loadRegisterAudit();
+        } else {
+            m.textContent = '✗ ' + (j.detail || (`failed (HTTP ${r.status})` + (r.status >= 502 ? ' — the server may still be finishing; check the activity log' : '')));
+            loadRegisterAudit();
+        }
+    } catch (e) {
+        m.textContent = '✗ network error: ' + e;
+    } finally {
+        setRegBusy(false);
+    }
+}
+
+async function loadRegisterAudit() {
+    try {
+        const r = await fetch('/api/deploy/audit?limit=30', { credentials: 'same-origin' });
+        const data = r.ok ? await r.json() : { audit: [] };
+        const audit = data.audit || [];
+        const b = document.querySelector('#reg-audit tbody');
+        b.innerHTML = audit.length
+            ? audit.map(a => `<tr><td>${escapeHtml((a.ts || '').replace('T', ' ').slice(0, 19))}</td><td>${escapeHtml(a.user || '')}</td><td>${escapeHtml(a.tenant || '')}</td><td>${escapeHtml(a.action || '')}</td><td>${escapeHtml(a.result || '')}</td><td>${escapeHtml(a.to || a.version || '')}</td><td>${escapeHtml(a.via || '')}</td></tr>`).join('')
+            : '<tr><td colspan="7" class="content-hint">none yet</td></tr>';
+    } catch (e) { /* ignore */ }
+}
+
+function loadRegister() {
+    wireRegister();
+    loadRegisterAudit();
 }

--- a/ops-server/dashboard/static/style.css
+++ b/ops-server/dashboard/static/style.css
@@ -1482,3 +1482,12 @@ body.role-writer .tab-writer-only { display: inline-block; }
 .content-profile-row .pr-head { display: flex; align-items: center; gap: 10px; }
 .content-profile-row .pr-actions { margin-left: auto; display: flex; gap: 6px; }
 @media (max-width: 700px) { .content-repos { column-count: 1; } }
+
+/* ─── Register Tenant tab ─────────────────────────────────────── */
+.reg-spin { display: none; align-items: center; gap: 10px; margin-top: 12px; font-size: 0.84rem; color: var(--text-2); }
+.reg-spin.busy { display: flex; }
+.reg-spinner { width: 18px; height: 18px; border: 3px solid var(--border-soft); border-top-color: var(--accent); border-radius: 50%; animation: reg-sp 0.8s linear infinite; flex-shrink: 0; }
+@keyframes reg-sp { to { transform: rotate(360deg); } }
+.reg-bar { height: 4px; background: var(--border-soft); border-radius: 3px; overflow: hidden; margin-top: 10px; }
+.reg-bar > i { display: block; height: 100%; width: 30%; background: var(--accent); border-radius: 3px; animation: reg-slide 1.4s ease-in-out infinite; }
+@keyframes reg-slide { 0% { margin-left: -30%; } 100% { margin-left: 100%; } }

--- a/ops-server/dashboard/templates/index.html
+++ b/ops-server/dashboard/templates/index.html
@@ -51,6 +51,7 @@
             <button class="tab" data-view="framework">Framework</button>
             <button class="tab" data-view="nightly">Nightly</button>
             <button class="tab tab-writer-only" data-view="content" id="tab-content">Content Service</button>
+            <button class="tab tab-writer-only" data-view="register" id="tab-register">Register Tenant</button>
             <button class="tab tab-help" id="help-btn" title="Help &amp; keyboard shortcuts (?)">?</button>
         </div>
     </nav>
@@ -696,6 +697,38 @@
                     </div>
                 </div>
             </div>
+        </section>
+
+        <section id="view-register" class="view">
+            <p class="content-hint">Install / upgrade the Enablement App into a Dynatrace tenant with a platform token. The token is used once and never stored — we log user + tenant + action, never the token.</p>
+            <div class="content-card">
+                <h3 style="margin:0 0 8px">Platform token scopes</h3>
+                <p class="content-hint" style="margin:0 0 6px">Create a platform token in the <strong>target</strong> tenant (Settings → Platform tokens) with:</p>
+                <ul style="margin:0;padding-left:18px;font-size:0.83rem">
+                    <li><code>app-engine:apps:install</code> — install / upgrade the app</li>
+                    <li><code>app-engine:apps:run</code> — run the app's functions</li>
+                    <li><code>app-engine:apps:delete</code> — only needed for Undeploy</li>
+                </ul>
+                <p class="content-hint" style="margin:8px 0 0"><strong>COE tenant</strong> (geu80787): leave the token blank — Orbital deploys it automatically. Any other tenant needs a token.</p>
+            </div>
+            <div class="content-card">
+                <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px">
+                    <input type="text" id="reg-tenant" placeholder="https://abc12345.apps.dynatrace.com" style="width:340px">
+                    <input type="password" id="reg-token" placeholder="platform token — blank for COE" style="width:300px">
+                </div>
+                <div style="display:flex;align-items:center;gap:10px">
+                    <button class="btn btn-small" id="reg-deploy" data-action>Deploy / Upgrade</button>
+                    <button class="btn btn-small btn-secondary" id="reg-undeploy" data-action>Undeploy</button>
+                    <span id="reg-msg" class="content-msg"></span>
+                </div>
+                <div id="reg-spin" class="reg-spin"><div class="reg-spinner"></div><span>Working… building &amp; deploying the app. This can take a minute or two — <strong>please don't refresh or close this page.</strong></span></div>
+                <div id="reg-bar" class="reg-bar" hidden><i></i></div>
+            </div>
+            <h3 style="margin:24px 0 8px">Recent deploy activity</h3>
+            <table id="reg-audit">
+                <thead><tr><th>When</th><th>User</th><th>Tenant</th><th>Action</th><th>Result</th><th>Version</th><th>Via</th></tr></thead>
+                <tbody><tr><td colspan="7" class="loading">Loading…</td></tr></tbody>
+            </table>
         </section>
     </main>
 


### PR DESCRIPTION
Moves the `/deploy` UI into the Orbital dashboard as a **Register Tenant** tab, matching the Content Service pattern: writer-gated, token form (COE auto when blank), scopes info, loading spinner/bar + 'don't refresh', activity log. Reuses `/api/deploy/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)