### PR TITLE
fix(ops): Register Tenant tab tweaks — drop COE hint, theme token input, show without login

### DIFF
--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -3192,6 +3192,8 @@ async function goRegister(action) {
                 m.innerHTML = `✓ ${s} — <a href="${escapeHtml(j.url || '#')}" target="_blank">open app</a>` + (j.profile ? ` · content profile ${escapeHtml(j.profile)}` : '');
             }
             loadRegisterAudit();
+        } else if (r.status === 401) {
+            m.textContent = '✗ Sign in as a GitHub org member to deploy.';
         } else {
             m.textContent = '✗ ' + (j.detail || (`failed (HTTP ${r.status})` + (r.status >= 502 ? ' — the server may still be finishing; check the activity log' : '')));
             loadRegisterAudit();

--- a/ops-server/dashboard/static/style.css
+++ b/ops-server/dashboard/static/style.css
@@ -205,7 +205,7 @@ main {
 
 .controls input[type="text"],
 .controls select,
-input[type="text"], select {
+input[type="text"], input[type="password"], select {
     background: var(--surface-2);
     border: 1px solid var(--border-soft);
     color: var(--text);

--- a/ops-server/dashboard/templates/index.html
+++ b/ops-server/dashboard/templates/index.html
@@ -51,7 +51,7 @@
             <button class="tab" data-view="framework">Framework</button>
             <button class="tab" data-view="nightly">Nightly</button>
             <button class="tab tab-writer-only" data-view="content" id="tab-content">Content Service</button>
-            <button class="tab tab-writer-only" data-view="register" id="tab-register">Register Tenant</button>
+            <button class="tab" data-view="register" id="tab-register">Register Tenant</button>
             <button class="tab tab-help" id="help-btn" title="Help &amp; keyboard shortcuts (?)">?</button>
         </div>
     </nav>
@@ -709,12 +709,11 @@
                     <li><code>app-engine:apps:run</code> — run the app's functions</li>
                     <li><code>app-engine:apps:delete</code> — only needed for Undeploy</li>
                 </ul>
-                <p class="content-hint" style="margin:8px 0 0"><strong>COE tenant</strong> (geu80787): leave the token blank — Orbital deploys it automatically. Any other tenant needs a token.</p>
             </div>
             <div class="content-card">
                 <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px">
                     <input type="text" id="reg-tenant" placeholder="https://abc12345.apps.dynatrace.com" style="width:340px">
-                    <input type="password" id="reg-token" placeholder="platform token — blank for COE" style="width:300px">
+                    <input type="password" id="reg-token" placeholder="platform token (dt0s16.…)" style="width:300px">
                 </div>
                 <div style="display:flex;align-items:center;gap:10px">
                     <button class="btn btn-small" id="reg-deploy" data-action>Deploy / Upgrade</button>


### PR DESCRIPTION
- Remove the 'blank for COE' hint (hidden function not advertised).
- Theme the password/token input (was white).
- Show the Register Tenant tab without GitHub login; deploy still needs an org session (friendly 401 message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)