### PR TITLE
feat(ops): auto-allow app outbound on deploy (fix sprint/dev content refresh)

### DIFF
--- a/ops-server/dashboard/app_deploy.py
+++ b/ops-server/dashboard/app_deploy.py
@@ -249,6 +249,52 @@ async def _mint_coe_token(action: str) -> str | None:
     return None
 
 
+OUTBOUND_SCHEMA = "builtin:dt-javascript-runtime.allowed-outbound-connections"
+# Hosts the app's functions must reach for content delivery + manual GitHub imports.
+OUTBOUND_HOSTS = [
+    "autonomous-enablements.whydevslovedynatrace.com",
+    "raw.githubusercontent.com",
+    "api.github.com",
+]
+
+
+async def _ensure_outbound_allowlist(token: str, tenant_url: str) -> str:
+    """If the tenant enforces a JS-runtime outbound allowlist (sprint/dev do, prod usually
+    doesn't), add the content-delivery hosts so the app's functions can reach Orbital + GitHub.
+    Only ever adds hosts to an existing enforced list — never creates or tightens a restriction.
+    Best-effort; needs settings:objects:read+write on the token."""
+    base = tenant_url.rstrip("/") + "/platform/classic/environment-api/v2/settings/objects"
+    h = {"Authorization": f"Bearer {token}"}
+    try:
+        async with httpx.AsyncClient(timeout=20) as c:
+            r = await c.get(base, headers=h, params={
+                "schemaIds": OUTBOUND_SCHEMA, "scopes": "environment", "fields": "objectId,value"})
+            if r.status_code == 403:
+                return "skipped (token lacks settings:objects:read/write)"
+            if r.status_code != 200:
+                return f"skipped (settings read HTTP {r.status_code})"
+            items = r.json().get("items", [])
+            if not items:
+                return "no enforced allowlist (outbound open)"
+            obj = items[0]
+            aoc = (obj.get("value") or {}).get("allowedOutboundConnections", {})
+            if not aoc.get("enforced"):
+                return "outbound not enforced (open)"
+            hosts = list(aoc.get("hostList", []))
+            missing = [x for x in OUTBOUND_HOSTS if x not in hosts]
+            if not missing:
+                return "allowlist already complete"
+            hosts.extend(missing)
+            pr = await c.put(f"{base}/{obj['objectId']}", headers={**h, "Content-Type": "application/json"},
+                             json={"value": {"allowedOutboundConnections": {"enforced": True, "hostList": hosts}}})
+            if pr.status_code in (200, 201, 204):
+                return f"added {len(missing)} host(s) to the outbound allowlist"
+            return f"allowlist update failed (HTTP {pr.status_code})"
+    except Exception as exc:
+        log.warning("outbound allowlist for %s: %s", tenant_url, exc)
+        return f"allowlist error: {exc}"
+
+
 async def _register_in_content_service(user: str, tenant_url: str) -> dict | None:
     """Best-effort: add the tenant to the delivery table so its content can be managed."""
     try:
@@ -423,6 +469,9 @@ async def deploy_with_token(body: dict, x_auth_user: str | None = Header(default
         return {"ok": True, "tenant": tenant_id, "action": "undeploy"}
 
     res = await _deploy_with_status(token, tenant)
+    allowlist = ""
+    if res["status"] != "error":
+        allowlist = await _ensure_outbound_allowlist(token, tenant)  # use token before discarding
     del token
     if res["status"] == "error":
         await _audit(user, tenant_id, "deploy", "deploy-error", via=via, rc=res.get("rc"))
@@ -431,9 +480,9 @@ async def deploy_with_token(body: dict, x_auth_user: str | None = Header(default
     profile = (reg or {}).get("profile")
     url = _app_url(tenant)
     await _audit(user, tenant_id, "deploy", res["status"], via=via,
-                 **{k: res[k] for k in ("from", "to") if res.get(k)}, url=url, profile=profile)
+                 **{k: res[k] for k in ("from", "to") if res.get(k)}, url=url, profile=profile, allowlist=allowlist)
     return {"ok": True, "tenant": tenant_id, "status": res["status"], "from": res.get("from"),
-            "version": res.get("to"), "url": url, "profile": profile}
+            "version": res.get("to"), "url": url, "profile": profile, "allowlist": allowlist}
 
 
 @router.get("/api/deploy/audit")

--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -3189,7 +3189,7 @@ async function goRegister(action) {
             else {
                 const v = j.version || '?';
                 const s = j.status === 'up-to-date' ? `already up-to-date (v${v})` : j.status === 'upgraded' ? `upgraded v${j.from} → v${v}` : `installed v${v}`;
-                m.innerHTML = `✓ ${s} — <a href="${escapeHtml(j.url || '#')}" target="_blank">open app</a>` + (j.profile ? ` · content profile ${escapeHtml(j.profile)}` : '');
+                m.innerHTML = `✓ ${s} — <a href="${escapeHtml(j.url || '#')}" target="_blank">open app</a>` + (j.profile ? ` · content profile ${escapeHtml(j.profile)}` : '') + (j.allowlist ? `<br><span class="content-hint">outbound: ${escapeHtml(j.allowlist)}</span>` : '');
             }
             loadRegisterAudit();
         } else if (r.status === 401) {

--- a/ops-server/dashboard/templates/index.html
+++ b/ops-server/dashboard/templates/index.html
@@ -708,6 +708,7 @@
                     <li><code>app-engine:apps:install</code> — install / upgrade the app</li>
                     <li><code>app-engine:apps:run</code> — run the app's functions</li>
                     <li><code>app-engine:apps:delete</code> — only needed for Undeploy</li>
+                    <li><code>settings:objects:read</code> + <code>settings:objects:write</code> — auto-allow the app to reach Orbital + GitHub (required on sprint/dev, which enforce an outbound allowlist)</li>
                 </ul>
             </div>
             <div class="content-card">


### PR DESCRIPTION
Sprint/dev tenants enforce a JS-runtime outbound allowlist (`builtin:dt-javascript-runtime.allowed-outbound-connections`), blocking the app's functions from reaching Orbital → 'host not in allowlist' on content refresh. It's a **tenant setting**, not app.config (`connect-src` is not a valid app.config CSP key).

On deploy, `_ensure_outbound_allowlist()` adds `autonomous-enablements…`, `raw.githubusercontent.com`, `api.github.com` to the tenant's hostList — only when the list is already enforced + missing them (never creates/tightens). Needs `settings:objects:read+write` on the token. Result shown in the deploy response + audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)