### PR TITLE
fix(ops): delete worker keys on graceful shutdown

### DIFF
--- a/ops-server/worker-agent/agent.py
+++ b/ops-server/worker-agent/agent.py
@@ -430,6 +430,15 @@ class WorkerAgent:
                 break
             await asyncio.sleep(1)
         await self.sysbox_pool.shutdown()
+        # Remove our Redis registration + legacy port pool so they don't linger
+        # until TTL expiry. Critically, a worker recommissioned under a new id
+        # would otherwise leave an orphaned port pool behind (the 68ec97 leak).
+        try:
+            await self.pool.delete(
+                f"worker:{WORKER_ID}", f"worker:{WORKER_ID}:app_ports_free"
+            )
+        except Exception as e:
+            log.warning("Could not delete worker keys on shutdown: %s", e)
         log.info("Shutdown cleanup complete (active=%d)", len(self.active_jobs))
         asyncio.get_running_loop().stop()
 

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -327,6 +327,14 @@ class WorkerManager:
             if not self.active_jobs:
                 break
             await asyncio.sleep(1)
+        # Remove the master's worker record + port pool so they don't linger
+        # until TTL expiry (mirrors the worker-agent shutdown cleanup).
+        try:
+            await self.pool.delete(
+                "worker:master-arm64", "worker:master:app_ports_free"
+            )
+        except Exception as e:
+            log.warning("Could not delete master worker keys on shutdown: %s", e)
         log.info("Shutdown cleanup complete (active=%d)", len(self.active_jobs))
         # Don't sys.exit — let asyncio.gather unwind naturally so the systemd
         # restart cycle stays clean.


### PR DESCRIPTION
## Problem
The worker hash is recreated via `hset` every heartbeat, but the legacy `worker:{id}:app_ports_free` pool is only `rpush`'d at register and merely `expire`'d in the heartbeat — `expire` can't resurrect an expired key. So worker records + port pools lingered until TTL after a clean stop, and a worker recommissioned under a new id left an orphaned, never-consumed port pool behind (the `worker-x86_64-68ec97` leak observed in Redis this session).

## Fix
Explicit `pool.delete()` of `worker:{id}` + `worker:{id}:app_ports_free` in `WorkerAgent._handle_shutdown`, mirrored in `WorkerManager._handle_shutdown` for the master (`worker:master-arm64` + `worker:master:app_ports_free`). Guarded so a Redis hiccup during shutdown never blocks the stop path.

Already deployed + verified live on master, amd001, amd002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)