### PR TITLE
fix(zsh): rename reserved `status` variable for zsh compatibility

### DIFF
--- a/.devcontainer/makefile.sh
+++ b/.devcontainer/makefile.sh
@@ -77,14 +77,14 @@ run(){
 }
 
 start(){
-    status=$(docker inspect -f '{{.State.Status}}' "$IMAGENAME")
-    if [ "$status" = "exited" ] || [ "$status" = "dead" ]; then
+    container_state=$(docker inspect -f '{{.State.Status}}' "$IMAGENAME")
+    if [ "$container_state" = "exited" ] || [ "$container_state" = "dead" ]; then
         echo "Container is stopped removing container."
         # Add repository name to the environment variables for the container
         docker rm $IMAGENAME
         echo "Starting a new container"
         run 
-    elif  [ "$status" = "running" ]; then 
+    elif  [ "$container_state" = "running" ]; then
         echo "Container $IMAGENAME is running, attaching new shell to it"
         docker exec -it $IMAGENAME zsh 
     else
@@ -161,14 +161,14 @@ integration(){
     CMD_TEST=" ./.devcontainer/test/integration.sh"
     CMD+="$CMD_TEST"
     
-    status=$(docker inspect -f '{{.State.Status}}' "$IMAGENAME")
-    if [ "$status" = "exited" ] || [ "$status" = "dead" ]; then
+    container_state=$(docker inspect -f '{{.State.Status}}' "$IMAGENAME")
+    if [ "$container_state" = "exited" ] || [ "$container_state" = "dead" ]; then
         echo "Container is stopped removing container."
         # Add repository name to the environment variables for the container
         docker rm $IMAGENAME
         echo "Starting a new container"
         run 
-    elif  [ "$status" = "running" ]; then 
+    elif  [ "$container_state" = "running" ]; then
         # FIXME: Better to load test functions in framework or call the script from a function in the framework in an extra shell. 
         echo "Container $IMAGENAME is running, running the tests inside the running container (WIP)..."
         docker exec -t $IMAGENAME "zsh"

--- a/.devcontainer/test/test_functions.sh
+++ b/.devcontainer/test/test_functions.sh
@@ -261,7 +261,7 @@ assertAstroshopContent() {
   fi
 
   # 3. Static asset reachability — extract src/href pointing to relative asset paths
-  local assets asset_url status ok=0 fail=0
+  local assets asset_url http_status ok=0 fail=0
   assets=$(echo "$html" | \
     grep -oiE '(src|href)="(/[^"]+\.(png|jpg|jpeg|gif|webp|svg|css|js|woff2?))"' | \
     grep -oE '"[^"]+"' | tr -d '"' | sort -u | head -10)
@@ -270,16 +270,16 @@ assertAstroshopContent() {
     printWarn "No static asset URLs found in HTML — skipping asset HTTP checks"
   else
     while IFS= read -r asset_url; do
-      status=$(curl --silent --output /dev/null \
+      http_status=$(curl --silent --output /dev/null \
         --write-out "%{http_code}" \
         --max-time 10 \
         -H "Host: ${ip_host}" \
         "${target}${asset_url}" 2>/dev/null)
-      if [[ "$status" =~ ^(200|304)$ ]]; then
-        printInfo "✅ ${asset_url} → HTTP ${status}"
+      if [[ "$http_status" =~ ^(200|304)$ ]]; then
+        printInfo "✅ ${asset_url} → HTTP ${http_status}"
         ok=$((ok + 1))
       else
-        printWarn "⚠️  ${asset_url} → HTTP ${status}"
+        printWarn "⚠️  ${asset_url} → HTTP ${http_status}"
         fail=$((fail + 1))
       fi
     done <<< "$assets"

--- a/.devcontainer/util/functions.sh
+++ b/.devcontainer/util/functions.sh
@@ -742,8 +742,8 @@ startK3dCluster(){
 
   # Check if K3d cluster exists
   if k3d cluster list 2>/dev/null | grep -q "enablement"; then
-    local status
-    status=$(k3d cluster list -o json 2>/dev/null | python3 -c "
+    local cluster_state
+    cluster_state=$(k3d cluster list -o json 2>/dev/null | python3 -c "
 import sys, json
 clusters = json.load(sys.stdin)
 for c in clusters:
@@ -754,7 +754,7 @@ for c in clusters:
         break
 " 2>/dev/null)
 
-    if [[ "$status" == "running" ]]; then
+    if [[ "$cluster_state" == "running" ]]; then
       printWarn "K3d cluster already running, attaching..."
       attachK3dCluster
     else


### PR DESCRIPTION
## Summary
`$status` is a reserved built-in in zsh (alias for `$?`, the last exit code). Assigning to it silently breaks under the zsh shells the framework runs in. This renames the local variables to non-reserved names.

| File | Function | Rename |
|---|---|---|
| `.devcontainer/makefile.sh` | `start()` / `integration()` | `status` → `container_state` |
| `.devcontainer/util/functions.sh` | `startK3dCluster()` | `status` → `cluster_state` |
| `.devcontainer/test/test_functions.sh` | `assertAstroshopContent()` | `status` → `http_status` |

Pure variable rename — no behavioral change. Docker `--filter "status=..."` strings left untouched (CLI args, not shell vars).

**Out of scope:** the k3d volume-mount hardening from `fix/k3dvolume` is intentionally excluded per request — only the zsh variable fix is included here.

## Test plan
- [x] `bats .devcontainer/test/unit/` → 125/125 pass
- [x] `bash -n` syntax check on all 3 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)