### PR TITLE
feat(ops): secret-safe token validation + surface failed-creation logs

### DIFF
--- a/.devcontainer/test/unit/test_env_management.bats
+++ b/.devcontainer/test/unit/test_env_management.bats
@@ -256,6 +256,46 @@ source_functions() {
   [[ "$output" == *"MY_CUSTOM_VAR is set"* ]]
 }
 
+# A repo declares a required token (e.g. via devcontainer.json secrets +
+# post-create's `variablesNeeded DT_OPERATOR_TOKEN:true`) but the secret is not
+# injected at runtime — creation must fail loudly by NAME, never silently.
+@test "variablesNeeded: declared-but-undefined required token fails by name" {
+  source_functions
+  unset DT_OPERATOR_TOKEN
+
+  run variablesNeeded DT_OPERATOR_TOKEN:true
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"DT_OPERATOR_TOKEN is required but not set"* ]]
+  [[ "$output" == *"Missing required variables: DT_OPERATOR_TOKEN"* ]]
+}
+
+# Security: a valid token value (or any prefix of it) must never be echoed —
+# the validator confirms format without leaking the secret to the console/logs.
+@test "variablesNeeded: never leaks the token value to output" {
+  source_functions
+  local secret="dt0c01.ABCDEFGHIJKLMNOPQRSTUVWX.SECRETSECRETSECRETSECRETSECRETSECRETSECRETSECRETSECRETSE"
+  export DT_OPERATOR_TOKEN="$secret"
+
+  run variablesNeeded DT_OPERATOR_TOKEN:true
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"valid Dynatrace token format"* ]]
+  # No part of the public id or secret leaks (check the distinctive segments).
+  [[ "$output" != *"ABCDEFGHIJKLMNOPQRSTUVWX"* ]]
+  [[ "$output" != *"SECRETSECRET"* ]]
+  [[ "$output" != *"dt0c01.ABC"* ]]
+}
+
+# An invalid declared token must fail without printing the bad value either.
+@test "variablesNeeded: invalid token fails without leaking the value" {
+  source_functions
+  export DT_OPERATOR_TOKEN="dt0c01.SHOULDNOTLEAKTHISVALUE12345"
+
+  run variablesNeeded DT_OPERATOR_TOKEN:true
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"invalid token format"* ]]
+  [[ "$output" != *"SHOULDNOTLEAKTHISVALUE"* ]]
+}
+
 # ============================================================
 # enableMCP / disableMCP tests
 # ============================================================

--- a/.devcontainer/util/functions.sh
+++ b/.devcontainer/util/functions.sh
@@ -1070,10 +1070,10 @@ variablesNeeded() {
     # Validate Dynatrace tokens (DT_*TOKEN pattern)
     if [[ "$var_name" == DT_*TOKEN ]]; then
       if [[ "$var_value" == dt0c01.* || "$var_value" == dt0s01.* ]] && [ ${#var_value} -gt 60 ]; then
-        printInfo "$var_name: valid Dynatrace token format (${var_value:0:14}xxx...)"
+        # Never echo the token value (or any prefix of it) — avoid leaking secrets to the console.
+        printInfo "$var_name: valid Dynatrace token format"
       else
-        printError "$var_name: invalid token format. Expected dt0c01.* or dt0s01.* with min 60 chars"
-        printError "  Got: ${var_value:0:20}... (length: ${#var_value})"
+        printError "$var_name: invalid token format. Expected dt0c01.* or dt0s01.* with min 60 chars (length: ${#var_value})"
         if [ "$required" = "true" ]; then
           has_errors=1
         fi

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -3393,10 +3393,25 @@ async def api_arena_session_status(job_id: str):
       queued      → worker hasn't picked up the job yet
       provisioning → worker is running postCreate/postStart (cluster setup, ~5-15 min)
       ready       → "Daemon ready" appeared in livelog — shell is available
-      expired     → job:running key missing (terminated or TTL elapsed)
+      failed      → creation failed; the retained log explains why (logAvailable)
+      terminated  → explicitly terminated
+      expired     → job:running key missing and no terminal record (TTL elapsed)
     """
     meta = await pool.hgetall(f"job:running:{job_id}")
     if not meta:
+        # job:running is gone — distinguish a FAILED creation (so the student can
+        # read the retained log) from a plain TTL-expiry. job:final outlives the
+        # running key (written by the worker's finally block, 7-day TTL).
+        final = await pool.hgetall(f"job:final:{job_id}")
+        fstatus = final.get("status")
+        if fstatus in ("failed", "terminated", "completed"):
+            return {
+                "jobId":        job_id,
+                "status":       fstatus,
+                "error":        final.get("error", ""),
+                "finishedAt":   final.get("finished_at", ""),
+                "logAvailable": bool(await pool.exists(f"job:log:{job_id}")),
+            }
         return {"jobId": job_id, "status": "expired"}
 
     # Check livelog for readiness signal written by execute_daemon

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -548,6 +548,17 @@ class WorkerManager:
                 await self._publish_log(job)
                 await self.pool.rpush("jobs:completed", json.dumps(job))
                 await self.pool.ltrim("jobs:completed", -500, -1)
+                # Terminal-status record that OUTLIVES job:running (deleted below),
+                # so session-status can report a failed creation and point the
+                # student at the retained log (job:log:{id}) instead of a bare
+                # "expired". TTL matches the log (7 days).
+                final_rec = {
+                    "status":      job.get("status", "completed"),
+                    "finished_at": job["finished_at"],
+                    "error":       str((job.get("result") or {}).get("error", ""))[:500],
+                }
+                await self.pool.hset(f"job:final:{job_id}", mapping=final_rec)
+                await self.pool.expire(f"job:final:{job_id}", 7 * 24 * 3600)
                 if running_key:
                     await self.pool.delete(running_key)
                 if lock_key:


### PR DESCRIPTION
## Token validation (`variablesNeeded`)
- **Stop leaking token values** — previously printed the first 14/20 chars of a token to the console/logs. Now validates format + presence, logging **by name only**.
- 3 new unit tests: declared-but-undefined required token fails by name; value never leaked on success; invalid token fails without leaking.

## Failed-creation logs visible to the student
- `manager.py` writes `job:final:{id}` (status + error, 7-day TTL) that outlives the deleted `job:running` key.
- `session-status` returns `failed` (+ `error`, `logAvailable`) instead of bare `expired`, so the app can point the student at the retained creation log (`job:log:{id}`).

Ties to the k8s-101 golden-example validation (separate PR) and the app-side failed-log UI (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)