### PR TITLE
feat(ops): worker writes per-tenant minted tokens, never CoE on other tenants

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -1232,7 +1232,10 @@ async def api_terminate_job(job_id: str, request: Request):
 
     # Revoke provisioned DT tokens for this session (best-effort, non-blocking)
     meta = await pool.hgetall(f"job:running:{job_id}")
-    if meta.get("dt_token_ids") and meta.get("dt_tenant_url"):
+    # Only Orbital-minted tokens carry a stored auth cred here. App-minted tokens
+    # (multi-tenancy) are revoked by the app itself — Orbital holds no tenant cred.
+    if (meta.get("dt_token_ids") and meta.get("dt_tenant_url")
+            and (meta.get("dt_auth_token") or meta.get("dt_oauth_client_id"))):
         from provisioning import DTTokenProvisioner
         try:
             token_ids = json.loads(meta["dt_token_ids"])
@@ -3273,6 +3276,11 @@ class ArenaProvisionRequest(BaseModel):
     oauthClientId: str = ""
     oauthClientSecret: str = ""
     apiToken: str = ""          # existing token with apiTokens.write scope
+    # Preferred (multi-tenancy): the app self-mints per-tenant tokens and passes the
+    # VALUES here, so Orbital never holds a tenant minting credential. The app owns
+    # the lifecycle and revokes via its own identity on terminate.
+    dtEnv: dict[str, str] = {}   # env_var -> token value (DT_OPERATOR_TOKEN, ...)
+    dtTokenIds: list[str] = []   # ids the app will revoke (Orbital does not)
 
 
 @app.post("/api/arena/provision")
@@ -3306,7 +3314,15 @@ async def api_arena_provision(body: ArenaProvisionRequest):
     token_provisioned = False
 
     tenant_url = body.tenantUrl.rstrip("/") if body.tenantUrl else ""
-    if tenant_url and (body.apiToken or (body.oauthClientId and body.oauthClientSecret)):
+    if body.dtEnv:
+        # Preferred: the app already minted per-tenant tokens with its own identity.
+        # Use the values directly; the app owns revocation (Orbital holds no tenant cred).
+        dt_env = dict(body.dtEnv)
+        provisioned_token_ids = list(body.dtTokenIds)
+        token_provisioned = True
+        if not tenant_url:
+            tenant_url = (dt_env.get("DT_ENVIRONMENT") or "").rstrip("/")
+    elif tenant_url and (body.apiToken or (body.oauthClientId and body.oauthClientSecret)):
         try:
             provisioner = DTTokenProvisioner(
                 tenant_url=tenant_url,
@@ -3345,6 +3361,10 @@ async def api_arena_provision(body: ArenaProvisionRequest):
     }
     if dt_env:
         job["dt_env"] = dt_env
+    # Tenant the worker should bind to — drives the multi-tenancy guard in
+    # _write_env_file (CoE → static creds; non-CoE → minted only, never CoE).
+    if tenant_url:
+        job["tenant"] = tenant_url
 
     redis_meta = {
         "job_id":       job_id,
@@ -3995,7 +4015,10 @@ async def api_arena_terminate(job_id: str):
 
     # Best-effort: revoke provisioned DT tokens
     meta = await pool.hgetall(f"job:running:{job_id}")
-    if meta.get("dt_token_ids") and meta.get("dt_tenant_url"):
+    # Only Orbital-minted tokens carry a stored auth cred here. App-minted tokens
+    # (multi-tenancy) are revoked by the app itself — Orbital holds no tenant cred.
+    if (meta.get("dt_token_ids") and meta.get("dt_tenant_url")
+            and (meta.get("dt_auth_token") or meta.get("dt_oauth_client_id"))):
         from provisioning import DTTokenProvisioner
         try:
             token_ids = json.loads(meta["dt_token_ids"])

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -923,7 +923,8 @@ class WorkerManager:
         log.info("Cloning %s @ %s for job %s", head_repo, ref, job_id)
         await self._git_clone(head_repo, ref, repo_dir)
         await self._make_world_writable(repo_dir)
-        self._write_env_file(repo_dir / ".devcontainer" / ".env", arch="arm64", job_id=job_id)
+        self._write_env_file(repo_dir / ".devcontainer" / ".env", arch="arm64", job_id=job_id,
+                             dt_env=job.get("dt_env"), tenant=job.get("tenant", ""))
 
         # Sysbox-isolated nested containers (see executor.py for the same
         # architecture): outer Sysbox container runs docker:25-dind; inner
@@ -1144,7 +1145,8 @@ class WorkerManager:
         log.info("Cloning %s @ %s for daemon %s", head_repo, ref, job_id)
         await self._git_clone(head_repo, ref, repo_dir)
         await self._make_world_writable(repo_dir)
-        self._write_env_file(repo_dir / ".devcontainer" / ".env", arch="arm64", job_id=job_id)
+        self._write_env_file(repo_dir / ".devcontainer" / ".env", arch="arm64", job_id=job_id,
+                             dt_env=job.get("dt_env"), tenant=job.get("tenant", ""))
 
         workspace  = f"/workspaces/{repo_name}"
         env_file_inside = f"{workspace}/.devcontainer/.env"
@@ -1429,7 +1431,8 @@ class WorkerManager:
         log.info("Cloning %s @ %s for framework-sysbox %s (%s)", repo, ref, suite, job_id)
         await self._git_clone(repo, ref, repo_dir)
         await self._make_world_writable(repo_dir)
-        self._write_env_file(repo_dir / ".devcontainer" / ".env", arch="arm64", job_id=job_id)
+        self._write_env_file(repo_dir / ".devcontainer" / ".env", arch="arm64", job_id=job_id,
+                             dt_env=job.get("dt_env"), tenant=job.get("tenant", ""))
 
         workspace  = f"/workspaces/{repo_name}"
         env_file_inside = f"{workspace}/.devcontainer/.env"
@@ -1779,7 +1782,8 @@ class WorkerManager:
         )
         return content
 
-    def _write_env_file(self, env_path: Path, arch: str, job_id: str = ""):
+    def _write_env_file(self, env_path: Path, arch: str, job_id: str = "",
+                        dt_env: dict | None = None, tenant: str = ""):
         """Mirror the GHA workflow's .env writing.
 
         Adds K3D_* port overrides so the in-container k3d cluster doesn't
@@ -1792,16 +1796,54 @@ class WorkerManager:
 
         ORBITAL_JOB_ID is passed so the framework can compute the wildcard
         subdomain URL for each app (e.g. astroshop--<slug>.autonomous-enablements.*).
+
+        Multi-tenancy DT credentials (hard rule: never use CoE tokens on another
+        tenant):
+          - ``dt_env`` present  → the app minted per-tenant tokens; write THOSE.
+          - tenant is CoE / unset (internal framework tests, COE trainings) → the
+            static CoE creds are fine.
+          - non-CoE tenant with NO minted tokens → write the tenant URL but NO
+            tokens (fail closed). The repo's ``variablesNeeded`` then fails the
+            codespace loudly if it requires them — we never leak CoE creds.
         """
         import socket
+        from urllib.parse import urlparse
         external_hostname = os.environ.get("EXTERNAL_HOSTNAME") or socket.gethostname()
+
+        dt_env = dt_env or {}
+        coe_host = (urlparse(DT_ENVIRONMENT).hostname or "").lower()
+        job_host = ""
+        if tenant:
+            job_host = (urlparse(tenant if "://" in tenant else f"https://{tenant}").hostname or "").lower()
+        is_coe = (not job_host) or job_host == coe_host
+
+        if dt_env:
+            dt_environment = dt_env.get("DT_ENVIRONMENT") or tenant or DT_ENVIRONMENT
+            dt_operator = dt_env.get("DT_OPERATOR_TOKEN", "")
+            dt_ingest = dt_env.get("DT_INGEST_TOKEN", "")
+            dt_oneagent = dt_env.get("DT_ONEAGENT_TOKEN", "")
+        elif is_coe:
+            dt_environment, dt_operator, dt_ingest, dt_oneagent = (
+                DT_ENVIRONMENT, DT_OPERATOR_TOKEN, DT_INGEST_TOKEN, "")
+        else:
+            log.warning(
+                "Job %s targets non-CoE tenant %s but no per-tenant tokens were "
+                "provided; writing .env WITHOUT DT tokens (the repo's variablesNeeded "
+                "will report if any are required).", job_id, tenant)
+            dt_environment, dt_operator, dt_ingest, dt_oneagent = (tenant or ""), "", "", ""
+
+        dt_lines = (
+            f"DT_ENVIRONMENT={dt_environment}\n"
+            f"DT_OPERATOR_TOKEN={dt_operator}\n"
+            f"DT_INGEST_TOKEN={dt_ingest}\n"
+        )
+        if dt_oneagent:
+            dt_lines += f"DT_ONEAGENT_TOKEN={dt_oneagent}\n"
 
         env_path.parent.mkdir(parents=True, exist_ok=True)
         env_path.write_text(
-            f"DT_ENVIRONMENT={DT_ENVIRONMENT}\n"
-            f"DT_OPERATOR_TOKEN={DT_OPERATOR_TOKEN}\n"
-            f"DT_INGEST_TOKEN={DT_INGEST_TOKEN}\n"
-            f"K3D_CLUSTER_NAME=master-{arch}\n"
+            dt_lines
+            + f"K3D_CLUSTER_NAME=master-{arch}\n"
             f"K3D_LB_HTTP_PORT=30080\n"
             f"K3D_LB_HTTPS_PORT=30443\n"
             f"K3D_API_PORT=6444\n"

--- a/ops-server/workers/test_manager_env.py
+++ b/ops-server/workers/test_manager_env.py
@@ -1,0 +1,83 @@
+"""Tests for _write_env_file multi-tenancy DT-credential selection.
+
+Hard rule: never write CoE tokens into a non-CoE tenant's job .env.
+
+Run: /home/ops/ops-venv/bin/python -m workers.test_manager_env
+  or pytest workers/test_manager_env.py
+"""
+
+from pathlib import Path
+
+import workers.manager as m
+
+COE = "https://geu80787.apps.dynatrace.com"
+
+
+def _write(tmp: Path, **kw) -> dict:
+    """Call _write_env_file on a bare instance (it uses no instance state) and
+    parse the resulting .env into a dict."""
+    inst = m.WorkerManager.__new__(m.WorkerManager)
+    env_path = tmp / ".devcontainer" / ".env"
+    # Patch module credential globals to known values for the assertions.
+    m.DT_ENVIRONMENT = COE
+    m.DT_OPERATOR_TOKEN = "COE-STATIC-OPERATOR-VALUE"
+    m.DT_INGEST_TOKEN = "COE-STATIC-INGEST-VALUE"
+    inst._write_env_file(env_path, arch="arm64", job_id="job-1", **kw)
+    out = {}
+    for line in env_path.read_text().splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            out[k] = v
+    return out
+
+
+def test_coe_tenant_uses_static(tmp_path):
+    # No tenant (internal framework test) → static CoE creds are fine.
+    env = _write(tmp_path)
+    assert env["DT_OPERATOR_TOKEN"] == "COE-STATIC-OPERATOR-VALUE"
+    assert env["DT_INGEST_TOKEN"] == "COE-STATIC-INGEST-VALUE"
+    assert env["DT_ENVIRONMENT"] == COE
+
+
+def test_coe_url_tenant_uses_static(tmp_path):
+    # Tenant explicitly == CoE → static is correct.
+    env = _write(tmp_path, tenant=COE)
+    assert env["DT_OPERATOR_TOKEN"] == "COE-STATIC-OPERATOR-VALUE"
+
+
+def test_minted_tokens_used_for_non_coe(tmp_path):
+    other = "https://sro97894.apps.dynatrace.com"
+    minted = {
+        "DT_ENVIRONMENT": other,
+        "DT_OPERATOR_TOKEN": "MINTED-OPERATOR-VALUE",
+        "DT_INGEST_TOKEN": "MINTED-INGEST-VALUE",
+        "DT_ONEAGENT_TOKEN": "MINTED-ONEAGENT-VALUE",
+    }
+    env = _write(tmp_path, dt_env=minted, tenant=other)
+    assert env["DT_OPERATOR_TOKEN"] == "MINTED-OPERATOR-VALUE"
+    assert env["DT_INGEST_TOKEN"] == "MINTED-INGEST-VALUE"
+    assert env["DT_ONEAGENT_TOKEN"] == "MINTED-ONEAGENT-VALUE"
+    assert env["DT_ENVIRONMENT"] == other
+    # CoE statics must NOT leak in.
+    assert "STATIC" not in env["DT_OPERATOR_TOKEN"]
+    assert "STATIC" not in env["DT_INGEST_TOKEN"]
+
+
+def test_non_coe_without_minted_fails_closed(tmp_path):
+    # Non-CoE tenant, no minted tokens → write tenant URL but NO tokens (never CoE).
+    other = "https://sro97894.apps.dynatrace.com"
+    env = _write(tmp_path, tenant=other)
+    assert env["DT_ENVIRONMENT"] == other
+    assert env["DT_OPERATOR_TOKEN"] == ""
+    assert env["DT_INGEST_TOKEN"] == ""
+    assert "DT_ONEAGENT_TOKEN" not in env  # omitted when unset
+
+
+if __name__ == "__main__":
+    import tempfile
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            with tempfile.TemporaryDirectory() as d:
+                fn(Path(d))
+            print(f"ok {name}")
+    print("all manager-env tests passed")


### PR DESCRIPTION
Closes the CoE-leak in the training worker (A3). provision accepts app-minted tokens (dtEnv+dtTokenIds) and tags the job tenant; _write_env_file is tenant-aware (minted->those; CoE->static; non-CoE+none->fail closed, never CoE); terminate only revokes Orbital-minted (app self-revokes). +4 unit tests. Pairs with the app-side mint/revoke PR.