### PR TITLE
feat(ops): AMD worker (executor) writes per-tenant tokens, never CoE

### DIFF
--- a/ops-server/worker-agent/executor.py
+++ b/ops-server/worker-agent/executor.py
@@ -427,6 +427,7 @@ async def execute_daemon(
         repo_dir / ".devcontainer" / ".env",
         overrides=dt_env_overrides,
         orbital_job_id=job_id,
+        tenant=job.get("tenant", ""),
     )
 
     start_time = time.time()
@@ -731,23 +732,45 @@ def _write_env_file(
     env_path: Path,
     overrides: dict[str, str] | None = None,
     orbital_job_id: str = "",
+    tenant: str = "",
 ):
     """Write .devcontainer/.env with DT credentials.
 
-    Uses per-session overrides (provisioned tokens) when provided, falls back
-    to the worker-level static env vars (used by integration tests).
+    Multi-tenancy hard rule: never write CoE tokens into a non-CoE tenant's .env.
+      - ``overrides`` present (app-minted per-tenant tokens) → use ONLY those DT
+        creds (never seed the static CoE values underneath them).
+      - tenant is CoE / unset (integration tests, COE trainings) → static CoE creds.
+      - non-CoE tenant with NO minted tokens → write the tenant URL but NO tokens
+        (fail closed). The repo's variablesNeeded fails the codespace loudly if it
+        needs them — CoE creds are never leaked to another tenant.
     """
+    from urllib.parse import urlparse
     env_path.parent.mkdir(parents=True, exist_ok=True)
-    resolved = {
-        "DT_ENVIRONMENT":    DT_ENVIRONMENT,
-        "DT_OPERATOR_TOKEN": DT_OPERATOR_TOKEN,
-        "DT_INGEST_TOKEN":   DT_INGEST_TOKEN,
-        "DT_LLM_TOKEN":      DT_LLM_TOKEN,
-    }
+    overrides = overrides or {}
+    coe_host = (urlparse(DT_ENVIRONMENT).hostname or "").lower()
+    job_host = ""
+    if tenant:
+        job_host = (urlparse(tenant if "://" in tenant else f"https://{tenant}").hostname or "").lower()
+    is_coe = (not job_host) or job_host == coe_host
+
+    if overrides:
+        resolved = dict(overrides)
+    elif is_coe:
+        resolved = {
+            "DT_ENVIRONMENT":    DT_ENVIRONMENT,
+            "DT_OPERATOR_TOKEN": DT_OPERATOR_TOKEN,
+            "DT_INGEST_TOKEN":   DT_INGEST_TOKEN,
+            "DT_LLM_TOKEN":      DT_LLM_TOKEN,
+        }
+    else:
+        log.warning(
+            "Daemon %s targets non-CoE tenant %s with no per-tenant tokens; writing "
+            ".env WITHOUT DT tokens (repo variablesNeeded will report if required).",
+            orbital_job_id, tenant)
+        resolved = {"DT_ENVIRONMENT": tenant or ""}
+
     if orbital_job_id:
         resolved["ORBITAL_JOB_ID"] = orbital_job_id
-    if overrides:
-        resolved.update(overrides)
     env_path.write_text("".join(f"{k}={v}\n" for k, v in resolved.items() if v))
 
 

--- a/ops-server/worker-agent/test_executor_env.py
+++ b/ops-server/worker-agent/test_executor_env.py
@@ -1,0 +1,66 @@
+"""Tests for executor._write_env_file multi-tenancy DT-credential selection.
+
+Hard rule: never write CoE tokens into a non-CoE tenant's daemon .env.
+
+Run: /home/ops/ops-venv/bin/python -m worker-agent.test_executor_env
+"""
+
+import tempfile
+from pathlib import Path
+
+from . import executor as ex
+
+COE = "https://geu80787.apps.dynatrace.com"
+OTHER = "https://sro97894.apps.dynatrace.com"
+
+
+def _write(**kw) -> dict:
+    ex.DT_ENVIRONMENT = COE
+    ex.DT_OPERATOR_TOKEN = "COE-STATIC-OPERATOR-VALUE"
+    ex.DT_INGEST_TOKEN = "COE-STATIC-INGEST-VALUE"
+    ex.DT_LLM_TOKEN = "COE-STATIC-LLM-VALUE"
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / ".env"
+        ex._write_env_file(p, **kw)
+        out = {}
+        for line in p.read_text().splitlines():
+            if "=" in line:
+                k, v = line.split("=", 1)
+                out[k] = v
+        return out
+
+
+def test_coe_uses_static():
+    env = _write()  # integration test: no tenant, no overrides
+    assert env["DT_OPERATOR_TOKEN"] == "COE-STATIC-OPERATOR-VALUE"
+    assert env["DT_ENVIRONMENT"] == COE
+
+
+def test_minted_overrides_used_no_coe_leak():
+    minted = {
+        "DT_ENVIRONMENT": OTHER,
+        "DT_OPERATOR_TOKEN": "MINTED-OP",
+        "DT_INGEST_TOKEN": "MINTED-IN",
+    }
+    env = _write(overrides=minted, tenant=OTHER)
+    assert env["DT_OPERATOR_TOKEN"] == "MINTED-OP"
+    assert env["DT_ENVIRONMENT"] == OTHER
+    # No CoE static must leak in — not even DT_LLM_TOKEN.
+    assert "STATIC" not in env.get("DT_OPERATOR_TOKEN", "")
+    assert "DT_LLM_TOKEN" not in env
+
+
+def test_non_coe_without_minted_fails_closed():
+    env = _write(tenant=OTHER)
+    assert env["DT_ENVIRONMENT"] == OTHER
+    assert "DT_OPERATOR_TOKEN" not in env
+    assert "DT_INGEST_TOKEN" not in env
+    assert "DT_LLM_TOKEN" not in env
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok {name}")
+    print("all executor-env tests passed")


### PR DESCRIPTION
Companion to #81. Arena daemons run on the AMD worker via executor.py (not manager.py). executor applied dt_env overrides but seeded static CoE underneath → leak for non-CoE without minted tokens. Now tenant-aware: minted-only / CoE-static / fail-closed. +3 tests.