### PR TITLE
fix(nginx): restore /videos/ location (k8s-101 lab video 404'd)

### DIFF
--- a/ops-server/nginx/ops-server.conf
+++ b/ops-server/nginx/ops-server.conf
@@ -335,6 +335,18 @@ server {
         proxy_read_timeout     60;
     }
 
+    # ── Self-hosted enablement videos (served to the DT App's <video> player) ──
+    # Static files on disk; the app references e.g.
+    # /videos/enablement/app/kubernetes-monitoring.mp4. Range requests enabled
+    # for seeking. (Lives in the canonical conf so a redeploy can't drop it.)
+    location /videos/ {
+        alias /home/ops/public_html/videos/;
+        add_header Accept-Ranges bytes;
+        add_header Access-Control-Allow-Origin "*";
+        types { video/mp4 mp4; video/webm webm; video/ogg ogv; }
+        default_type application/octet-stream;
+    }
+
     # ── Public: dashboard UI + read-only API ───────────────────────────────
     location / {
         proxy_pass http://127.0.0.1:8080;


### PR DESCRIPTION
Self-hosted videos (kubernetes-monitoring.mp4) live at /home/ops/public_html/videos/ but the /videos/ nginx location was dropped from the canonical conf → app video player 404. Restored (alias + Range + mp4 type). Verified 200 + 206. Already deployed live.