### PR TITLE
feat(sync): guard that DT-deploying repos validate credentials first

### DIFF
--- a/sync/commands/validate.py
+++ b/sync/commands/validate.py
@@ -75,11 +75,80 @@ def _validate_local(repo_entry, repo_path):
         else:
             print(f"  ⚠️  Makefile outdated — run sync migrate to update")
 
+    # Verify a DT-deploying post-create.sh validates credentials first
+    _validate_post_create(path)
+
     # Verify README badges and footer
     _validate_readme(repo_entry, path)
 
     # Verify docs structure
     _validate_docs(repo_entry, path)
+
+
+# Deploy functions that consume Dynatrace credentials (DT_OPERATOR_TOKEN) at
+# runtime. A post-create.sh that calls any of these MUST first declare the
+# credentials via variablesNeeded so a missing Codespaces secret fails loudly
+# instead of half-creating the container. dynatraceDeployOperator is always the
+# first DT step, so it is sufficient as the trigger.
+DT_DEPLOY_FUNCS = ("dynatraceDeployOperator",)
+
+
+def check_post_create_credentials(content):
+    """Guard: a DT-deploying post-create.sh must validate credentials first.
+
+    Returns a list of issue strings. Empty list means OK or not applicable
+    (the script does not actively deploy Dynatrace).
+
+    Rules (only active — uncommented — lines count):
+      - find the first line that calls a DT_DEPLOY_FUNCS function
+      - if none: no Dynatrace deploy, nothing to enforce -> []
+      - otherwise require an earlier `variablesNeeded ... DT_OPERATOR_TOKEN:true`
+        line; missing or positioned after the deploy is an issue.
+    """
+    deploy_re = re.compile(r"^\s*(" + "|".join(DT_DEPLOY_FUNCS) + r")\b")
+    validate_re = re.compile(r"^\s*variablesNeeded\b.*\bDT_OPERATOR_TOKEN:true\b")
+
+    deploy_line = None
+    validate_line = None
+    for i, line in enumerate(content.splitlines()):
+        if deploy_line is None and deploy_re.match(line):
+            deploy_line = i
+        if validate_line is None and validate_re.match(line):
+            validate_line = i
+
+    if deploy_line is None:
+        return []
+
+    if validate_line is None:
+        return [
+            "deploys Dynatrace (dynatraceDeployOperator) but never calls "
+            "variablesNeeded DT_OPERATOR_TOKEN:true — missing credentials would "
+            "half-create the container instead of failing loudly"
+        ]
+    if validate_line > deploy_line:
+        return [
+            "variablesNeeded DT_OPERATOR_TOKEN:true runs after "
+            "dynatraceDeployOperator — credential validation must come first"
+        ]
+    return []
+
+
+def _validate_post_create(path):
+    """Validate that a DT-deploying post-create.sh validates credentials first."""
+    from pathlib import Path
+
+    pc = Path(path) / ".devcontainer/post-create.sh"
+    if not pc.exists():
+        print(f"  ❌ post-create.sh missing")
+        return
+
+    issues = check_post_create_credentials(pc.read_text())
+    if issues:
+        print(f"  ⚠️  post-create credentials: {len(issues)} issue(s)")
+        for issue in issues:
+            print(f"    ❌ {issue}")
+    else:
+        print(f"  ✅ post-create credential validation")
 
 
 def _validate_docs(repo_entry, path):

--- a/sync/tests/test_cmd_validate.py
+++ b/sync/tests/test_cmd_validate.py
@@ -1,11 +1,12 @@
 """Tests for sync.commands.validate — repos.yaml + local validation."""
 
+import textwrap
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import pytest
 
-from sync.commands.validate import run
+from sync.commands.validate import run, check_post_create_credentials
 
 
 class TestValidateCommand:
@@ -123,3 +124,105 @@ class TestValidateCommand:
                     run(args)
                     out = capsys.readouterr().out
                     assert "All 1 repos accessible" in out
+
+
+def _pc(body):
+    return textwrap.dedent(body).lstrip("\n")
+
+
+class TestPostCreateCredentialGuard:
+    """The DEPLOYS-DT contract: a post-create.sh that calls
+    dynatraceDeployOperator must validate credentials with
+    `variablesNeeded ... DT_OPERATOR_TOKEN:true` first."""
+
+    def test_validate_before_deploy_passes(self):
+        content = _pc(
+            """
+            #!/bin/bash
+            source .devcontainer/util/source_framework.sh
+            variablesNeeded DT_ENVIRONMENT:true DT_OPERATOR_TOKEN:true DT_INGEST_TOKEN:false || exit 1
+            setUpTerminal
+            startK3dCluster
+            dynatraceDeployOperator
+            deployApplicationMonitoring
+            """
+        )
+        assert check_post_create_credentials(content) == []
+
+    def test_deploy_without_validate_fails(self):
+        content = _pc(
+            """
+            #!/bin/bash
+            source .devcontainer/util/source_framework.sh
+            setUpTerminal
+            dynatraceDeployOperator
+            deployApplicationMonitoring
+            """
+        )
+        issues = check_post_create_credentials(content)
+        assert len(issues) == 1
+        assert "never calls variablesNeeded" in issues[0]
+
+    def test_validate_after_deploy_fails(self):
+        content = _pc(
+            """
+            #!/bin/bash
+            source .devcontainer/util/source_framework.sh
+            dynatraceDeployOperator
+            variablesNeeded DT_OPERATOR_TOKEN:true || exit 1
+            """
+        )
+        issues = check_post_create_credentials(content)
+        assert len(issues) == 1
+        assert "after" in issues[0]
+
+    def test_no_deploy_is_not_applicable(self):
+        content = _pc(
+            """
+            #!/bin/bash
+            source .devcontainer/util/source_framework.sh
+            setUpTerminal
+            startK3dCluster
+            deployTodoApp
+            """
+        )
+        assert check_post_create_credentials(content) == []
+
+    def test_commented_deploy_does_not_trigger(self):
+        # k8s-101 ships dynatraceDeployOperator commented out (students run it
+        # manually as the lab) — the guard must not flag it.
+        content = _pc(
+            """
+            #!/bin/bash
+            source .devcontainer/util/source_framework.sh
+            #dynatraceDeployOperator
+            deployTodoApp
+            """
+        )
+        assert check_post_create_credentials(content) == []
+
+    def test_validate_requires_operator_token_true(self):
+        # A variablesNeeded that does not require the operator token does not
+        # satisfy the contract.
+        content = _pc(
+            """
+            #!/bin/bash
+            variablesNeeded DT_ENVIRONMENT:true
+            dynatraceDeployOperator
+            """
+        )
+        issues = check_post_create_credentials(content)
+        assert len(issues) == 1
+        assert "never calls variablesNeeded" in issues[0]
+
+    def test_indented_deploy_still_triggers(self):
+        content = _pc(
+            """
+            #!/bin/bash
+            if true; then
+                dynatraceDeployOperator
+            fi
+            """
+        )
+        issues = check_post_create_credentials(content)
+        assert len(issues) == 1


### PR DESCRIPTION
## What

Adds `check_post_create_credentials` to `sync validate`. Any repo whose `post-create.sh` **actively** calls `dynatraceDeployOperator` must first call `variablesNeeded ... DT_OPERATOR_TOKEN:true`. Without it, a missing Codespaces secret silently half-creates the container instead of failing loudly.

## Why

The 4 DEPLOYS-DT repos (business-observability, live-debugger-bug-hunting, demo-astroshop-runtime-optimization, bug-busters) deployed the Dynatrace Operator without validating credentials. Companion PRs add the `variablesNeeded` call to each repo; this guard prevents the gap from regressing.

## Notes

- Commented-out deploy lines (e.g. k8s-101 ships `#dynatraceDeployOperator`) do not trigger the guard.
- Pure helper `check_post_create_credentials(content)` — no filesystem/network.

## Tests

`TestPostCreateCredentialGuard` (7 cases): validate-before-deploy passes; deploy-without-validate fails; validate-after-deploy fails; no-deploy n/a; commented deploy n/a; requires `DT_OPERATOR_TOKEN:true`; indented deploy triggers. Full `sync/tests/test_cmd_validate.py` green (14 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)