### PR TITLE
fix(worker): fail the Arena session when daemon setup does not provision

### DIFF
--- a/ops-server/worker-agent/agent.py
+++ b/ops-server/worker-agent/agent.py
@@ -94,6 +94,17 @@ def _triple_of(job: dict, default_arch: str) -> str:
     return f"{job['repo']}:{_branch_of(job)}:{job.get('arch', default_arch)}"
 
 
+def daemon_failed(job: dict, result: dict) -> bool:
+    """Whether a daemon job's setup (postCreate/postStart) failed to provision.
+
+    A daemon whose setup exited non-zero never came up, so the Arena session
+    must be reported failed (red banner + retained log) instead of a silent
+    "completed". Integration tests keep their own completed-with-passed-flag
+    semantics, so this is daemon-scoped.
+    """
+    return job.get("type") == "daemon" and bool((result or {}).get("exit_code", 0))
+
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
@@ -655,7 +666,12 @@ class WorkerAgent:
                 else:
                     result = await execute_integration_test(job, redis_pool=self.pool, slot=slot)
                 job["result"] = result
-                job["status"] = "completed"
+                if daemon_failed(job, result):
+                    # Setup exited non-zero — the environment never provisioned.
+                    job["status"] = "failed"
+                    healthy = False
+                else:
+                    job["status"] = "completed"
             except Exception as e:
                 log.error("Job %s failed: %s", job_id, e)
                 job["result"] = {"error": str(e)}
@@ -682,6 +698,17 @@ class WorkerAgent:
                 await self._publish_log(job)
                 await self.pool.rpush("jobs:completed", json.dumps(job))
                 await self.pool.ltrim("jobs:completed", -500, -1)
+                # Terminal record that OUTLIVES job:running so the Arena
+                # session-status endpoint can report failed/terminated/completed
+                # (drives the red banner + retained log). Mirrors workers/manager.py;
+                # without it a finished AMD daemon resolved to a bare "expired".
+                final_rec = {
+                    "status":      job.get("status", "completed"),
+                    "finished_at": job["finished_at"],
+                    "error":       str((job.get("result") or {}).get("error", ""))[:500],
+                }
+                await self.pool.hset(f"job:final:{job_id}", mapping=final_rec)
+                await self.pool.expire(f"job:final:{job_id}", 7 * 24 * 3600)
                 await self.pool.delete(running_key)
                 if lock_key:
                     await self.pool.delete(lock_key)

--- a/ops-server/worker-agent/executor.py
+++ b/ops-server/worker-agent/executor.py
@@ -378,6 +378,19 @@ async def execute_integration_test(
     }
 
 
+def daemon_provisioned(exit_code: int) -> bool:
+    """Whether a daemon's setup brought the environment up.
+
+    A daemon only "comes up" — emits the ``Daemon ready`` marker the Arena
+    session-status keys on, blocks on ``docker wait``, and reports passed — when
+    its postCreate/postStart exited 0. A non-zero exit (e.g. the repo's
+    ``variablesNeeded`` failing closed on a missing DT token) means it never
+    provisioned, so the session must be reported failed (red banner + log)
+    rather than a broken "ready" shell.
+    """
+    return exit_code == 0
+
+
 async def execute_daemon(
     job: dict,
     redis_pool=None,
@@ -438,6 +451,7 @@ async def execute_daemon(
 
     sections = []
     rc = 0
+    failed_step = ""
     livelog_key = f"job:livelog:{job_id}" if redis_pool is not None else None
 
     try:
@@ -536,27 +550,37 @@ async def execute_daemon(
             sections.append(step_out)
             if proc.returncode != 0:
                 rc = proc.returncode
-                msg = f"\n=== {label} failed (rc={rc}) — daemon environment may be incomplete ===\n"
+                failed_step = label
+                msg = f"\n=== {label} failed (rc={rc}) — environment did not provision ===\n"
                 sections.append(msg)
                 if livelog_key:
                     await redis_pool.append(livelog_key, msg)
+                break
 
-        ready_msg = (
-            "\n=== Daemon ready — environment is up ===\n"
-            "=== Connect via the Shell button. Terminate when done. ===\n"
-        )
-        sections.append(ready_msg)
-        if livelog_key:
-            await redis_pool.append(livelog_key, ready_msg)
-            await redis_pool.expire(livelog_key, 86400)
+        # Only a clean setup brings the environment up. On failure do NOT emit the
+        # readiness marker (session-status keys on it) and do NOT block on docker
+        # wait — return immediately so the session is reported failed.
+        if daemon_provisioned(rc):
+            ready_msg = (
+                "\n=== Daemon ready — environment is up ===\n"
+                "=== Connect via the Shell button. Terminate when done. ===\n"
+            )
+            sections.append(ready_msg)
+            if livelog_key:
+                await redis_pool.append(livelog_key, ready_msg)
+                await redis_pool.expire(livelog_key, 86400)
 
-        log.info("Daemon %s ready — waiting for termination", job_id)
-        wait_proc = await asyncio.create_subprocess_exec(
-            "docker", "wait", sb_name,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        await wait_proc.wait()
+            log.info("Daemon %s ready — waiting for termination", job_id)
+            wait_proc = await asyncio.create_subprocess_exec(
+                "docker", "wait", sb_name,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await wait_proc.wait()
+        else:
+            log.warning(
+                "Daemon %s setup failed at %s (rc=%s) — not marking ready",
+                job_id, failed_step, rc)
 
     except Exception as e:
         sections.append(f"\n=== daemon error: {e} ===\n")
@@ -593,9 +617,10 @@ async def execute_daemon(
         "ref": ref,
         "exit_code": rc,
         "duration_seconds": duration,
-        "passed": True,
+        "passed": daemon_provisioned(rc),
         "timed_out": False,
-        "failed_step": "",
+        "failed_step": failed_step,
+        "error": "" if daemon_provisioned(rc) else f"{failed_step or 'setup'} failed (rc={rc}) — environment did not provision",
         "log_file": str(log_file),
     }
 

--- a/ops-server/worker-agent/test_daemon_status.py
+++ b/ops-server/worker-agent/test_daemon_status.py
@@ -1,0 +1,56 @@
+"""Tests for the daemon provisioning-failure → session status mapping.
+
+Pure logic — no Redis/Docker — so it runs anywhere.
+
+Runnable two ways (mirrors test_scheduler.py):
+  - pytest:     /home/ops/ops-venv/bin/python -m pytest worker-agent/test_daemon_status.py
+  - standalone: cd ops-server && /home/ops/ops-venv/bin/python -m worker-agent.test_daemon_status
+
+Covers the provisioning red-banner contract: a daemon whose postCreate/postStart
+exits non-zero (e.g. the repo's variablesNeeded failing closed on a missing DT
+token) must NOT report "Daemon ready" and must surface as a failed session.
+"""
+
+from .executor import daemon_provisioned
+from .agent import daemon_failed
+
+
+def test_provisioned_only_on_zero_exit():
+    assert daemon_provisioned(0) is True
+    assert daemon_provisioned(1) is False
+    assert daemon_provisioned(124) is False   # setup timeout
+
+
+def test_daemon_failed_on_nonzero_exit():
+    job = {"type": "daemon"}
+    assert daemon_failed(job, {"exit_code": 1}) is True
+    assert daemon_failed(job, {"exit_code": 124}) is True
+
+
+def test_daemon_ok_on_zero_or_missing_exit():
+    job = {"type": "daemon"}
+    assert daemon_failed(job, {"exit_code": 0}) is False
+    assert daemon_failed(job, {}) is False          # healthy / terminated daemon
+    assert daemon_failed(job, None) is False
+
+
+def test_non_daemon_never_flagged():
+    # Integration tests keep their completed-with-passed-flag semantics.
+    assert daemon_failed({"type": "integration-test"}, {"exit_code": 1}) is False
+    assert daemon_failed({"type": "fix-issue"}, {"exit_code": 2}) is False
+
+
+if __name__ == "__main__":
+    import sys
+    fns = [v for k, v in sorted(globals().items())
+           if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"ok   {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {fn.__name__}: {e}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Problem

On the AMD worker the daemon path (`worker-agent/executor.py`) wrote the `Daemon ready` marker **unconditionally** — even when `postCreate`/`postStart` exited non-zero — and `agent.py` recorded the job as `completed` while **never writing `job:final`**.

Result for a failed provision (e.g. the repo's `variablesNeeded` failing closed on a missing `DT_OPERATOR_TOKEN`):
- session-status saw `Daemon ready` in the livelog → reported **ready** → student got a broken shell, **no banner**; or
- once `job:running` expired, with no `job:final`, session-status returned a bare **`expired`**.

The app's `TrainingSession` red banner only fires on session-status `failed`.

## Fix (AMD worker path only)

- **executor.py** — emit the readiness marker + block on `docker wait` **only** when setup exited 0 (`daemon_provisioned`); `break` out of the setup loop on the first failing step; return `passed=False` + an `error` on a failed provision.
- **agent.py** — mark a daemon **failed** when its setup exited non-zero (`daemon_failed`), and write **`job:final`** (status / finished_at / error, 7-day TTL) so session-status can report `failed`/`terminated`/`completed`. This mirrors `workers/manager.py`, which already wrote `job:final`.

`workers/manager.py` (master) is intentionally untouched — Arena daemons enqueue to `queue:test:amd64` and run on the AMD worker-agent.

## Tests

`worker-agent/test_daemon_status.py` (pure helpers, 4 cases): `daemon_provisioned` true only on exit 0; `daemon_failed` true on non-zero daemon exit; false on 0/missing/None; non-daemon jobs never flagged. `4/4` + scheduler `17/17` green.

## Deploy

AMD worker: `git pull` on `/home/ops/enablement-framework/codespaces-framework` + `systemctl restart ops-worker-agent`.

## Follow-up (not in this PR)

`workers/manager.py` writes the readiness marker as `environment ready — daemon is running`, which session-status (`Daemon ready`) never matches — latent for master-run daemons only. Left for a separate change (file has unrelated in-flight edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)