### PR TITLE
feat(ops): app-layer-test job + triage-first fix-issue prompt

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -2404,8 +2404,8 @@ async def api_trigger_build(request: Request):
     requested_by = role["user"]
 
     job_type = body.get("type", "integration-test")
-    if job_type not in ("integration-test", "daemon"):
-        raise HTTPException(400, "type must be integration-test or daemon")
+    if job_type not in ("integration-test", "daemon", "app-layer-test"):
+        raise HTTPException(400, "type must be integration-test, daemon, or app-layer-test")
 
     arches = ["arm64", "amd64"] if arch == "both" else [arch]
     timestamp = datetime.now(timezone.utc).isoformat()

--- a/ops-server/tools/app_layer_driver.py
+++ b/ops-server/tools/app_layer_driver.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""app_layer_driver.py — Orbital app-layer test driver.
+
+Runs INSIDE a provisioned lab container (the `dt` container of an
+`app-layer-test` job). Reproduces the path the Enablement App's UI takes when a
+learner clicks a check or "Run solution", but headless:
+
+  STEP_SETUP / LAB_SOLUTION commands  -> `bash -lc`  (login shell: my_functions.sh
+                                          loaded — same as orbitalService.exec(interactive=true))
+  shell-verification command          -> `bash -c`   (NON-login: my_functions NOT
+                                          loaded — same as exec(interactive=false))
+  then evaluate stdout/exit against `expect` (exit-zero | contains | not-empty | gt)
+
+Drives the full learner loop: STEP_SETUP (user actions) -> LAB_SOLUTION (apply +
+verify the fix) -> shell-verification gates must then PASS. Exit 0 iff every gate
+passes (and every solution verify exits 0).
+
+Usage: python3 app_layer_driver.py <docsDir>
+Mirrors scripts/lab-driver.mjs in dynatrace-app-enablements (kept in sync by intent).
+"""
+import os
+import re
+import subprocess
+import sys
+
+try:
+    import yaml  # type: ignore
+except Exception:
+    subprocess.run([sys.executable, "-m", "pip", "install", "-q", "pyyaml"], check=False)
+    import yaml  # type: ignore
+
+BLOCK_RE = re.compile(r"<!--\s*(LAB_QUESTION|STEP_SETUP|LAB_SOLUTION)\s*(.*?)-->", re.S)
+
+
+def _md_files(docs_dir):
+    return [os.path.join(docs_dir, f) for f in sorted(os.listdir(docs_dir)) if f.endswith(".md")]
+
+
+def extract(docs_dir):
+    """Return (setups, solutions, checks) in nav-ish (filename-sorted) order."""
+    setups, solutions, checks = [], [], []
+    for path in _md_files(docs_dir):
+        fname = os.path.basename(path)
+        with open(path, encoding="utf-8") as fh:
+            text = fh.read()
+        for kind, body in BLOCK_RE.findall(text):
+            try:
+                doc = yaml.safe_load(body)
+            except Exception:
+                continue
+            if not isinstance(doc, dict):
+                continue
+            if kind == "STEP_SETUP":
+                for c in doc.get("commands", []) or []:
+                    setups.append((fname, c))
+            elif kind == "LAB_SOLUTION":
+                cmds = doc.get("commands") or []
+                ver = doc.get("verify") or []
+                if cmds or ver:
+                    solutions.append((fname, list(cmds), list(ver)))
+            elif kind == "LAB_QUESTION" and doc.get("type") == "shell-verification":
+                cmd = doc.get("command")
+                exp = doc.get("expect") or {}
+                if cmd and isinstance(exp, dict):
+                    checks.append((fname, doc.get("buttonText") or doc.get("question") or "", cmd, exp))
+    return setups, solutions, checks
+
+
+def run(cmd, login):
+    """Run a command; login=True -> `bash -lc` (sources .zshrc/my_functions)."""
+    flag = "-lc" if login else "-c"
+    p = subprocess.run(["bash", flag, cmd], capture_output=True, text=True)
+    return p.stdout, p.stderr, p.returncode
+
+
+def evaluate(stdout, exit_code, expect):
+    out = (stdout or "").strip()
+    op = expect.get("operator")
+    val = expect.get("value")
+    if op == "exit-zero":
+        return exit_code == 0
+    if op == "not-empty":
+        return len(out) > 0
+    if op == "contains":
+        return str(val if val is not None else "") in out
+    if op == "gt":
+        try:
+            return int(out.split()[0]) > int(val if val is not None else 0)
+        except (ValueError, IndexError):
+            return False
+    return False
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: app_layer_driver.py <docsDir>", file=sys.stderr)
+        return 2
+    docs_dir = sys.argv[1]
+    setups, solutions, checks = extract(docs_dir)
+
+    print(f"== STEP_SETUP ({len(setups)}) ==")
+    for fname, c in setups:
+        _, _, rc = run(c, login=True)
+        print(f"  [setup {fname}] exit={rc}: {c}")
+
+    print(f"== LAB_SOLUTION ({len(solutions)}) ==")
+    solve_fail = 0
+    for fname, cmds, ver in solutions:
+        for c in cmds:
+            _, _, rc = run(c, login=True)
+            print(f"  [solve {fname}] exit={rc}: {c}")
+        for v in ver:
+            _, _, rc = run(v, login=True)
+            ok = rc == 0
+            solve_fail += 0 if ok else 1
+            print(f"  [verify {fname}] {'OK' if ok else 'FAIL'} exit={rc}: {v}")
+
+    print(f"== shell-verification ({len(checks)}) ==")
+    passed = 0
+    for fname, label, cmd, expect in checks:
+        stdout, stderr, rc = run(cmd, login=False)  # non-interactive — the real app path
+        ok = evaluate(stdout, rc, expect)
+        passed += 1 if ok else 0
+        out1 = (stdout or stderr or "").strip().replace("\n", " ")[:80]
+        print(f"  {'PASS' if ok else 'FAIL'}  [{fname}] {label}")
+        print(f"        $ {cmd}")
+        print(f"        -> exit={rc} out={out1!r} expect={expect.get('operator')} {expect.get('value','')}")
+
+    total = len(checks)
+    print(f"\nRESULT: {passed}/{total} shell-verification checks passed; {solve_fail} solution-verify failures")
+    ok_all = (passed == total) and (solve_fail == 0) and total > 0
+    print("APP_LAYER_TEST: " + ("SUCCESS" if ok_all else "FAILURE"))
+    return 0 if ok_all else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -2060,18 +2060,61 @@ class WorkerManager:
         repo = job["repo"]
 
         if agent_type == "fix-issue":
+            repo_name = repo.split("/")[-1]
+            issue_no  = job["issue_number"]
+            title     = job.get("title", "")
+            body      = job.get("body", "")
+            instructions = job.get("instructions", "")
+            instr_section = (
+                f"\nReporter / operator instructions (highest priority — follow these):\n{instructions}\n"
+                if instructions else ""
+            )
             return (
-                f"You are the enablement ops agent. A bug was reported in {repo}.\n\n"
-                f"Issue #{job['issue_number']}: {job['title']}\n\n"
-                f"{job.get('body', '')}\n\n"
-                "Instructions:\n"
-                "1. Investigate the issue — read the relevant code, check recent changes\n"
-                "2. Query Dynatrace via MCP if the issue relates to observability or monitoring\n"
-                "3. Implement a fix\n"
-                "4. Run tests: make test (if available)\n"
-                "5. Create a new branch, commit, and create a PR referencing the issue\n"
-                "6. Use: gh pr create --title 'Fix: <summary>' "
-                f"--body 'Fixes #{job['issue_number']}'\n"
+                f"You are the Autonomous Enablement Ops agent triaging a GitHub issue in {repo}.\n\n"
+                f"Issue #{issue_no}: {title}\n\n"
+                f"{body}\n"
+                f"{instr_section}\n"
+                f"Your job is to TRIAGE FIRST, then act. Do NOT assume the issue is a real code bug.\n"
+                f"Many issues are false alarms (transient failures, already-fixed problems, or\n"
+                f"misreported state). Acting on a false alarm by opening a code PR is WRONG.\n\n"
+                f"STEP 1 — REPRODUCE / VERIFY THE CLAIM\n"
+                f"  Establish the current ground truth before changing anything.\n"
+                f"  - Read the relevant code / config / workflow in this repo (already cloned in your cwd).\n"
+                f"  - If the claim is about a live URL, GitHub Page, deployment, or endpoint, CHECK IT\n"
+                f"    DIRECTLY before trusting the issue text. For a GitHub Pages claim:\n"
+                f"      gh api repos/{repo}/pages              # is Pages enabled? what is the live url + status?\n"
+                f"      gh run list --repo {repo} --workflow pages-build-deployment --limit 5\n"
+                f"      curl -sS -o /dev/null -w '%{{http_code}}' <the published url>   # 200 == live\n"
+                f"  - Query Dynatrace via MCP only if the claim is about observability/monitoring.\n\n"
+                f"STEP 2 — CLASSIFY\n"
+                f"  Decide exactly one verdict:\n"
+                f"    (A) NOT A BUG — the reported problem does not reproduce / the thing already works\n"
+                f"        (e.g. the Page IS published, the failure was transient, or it was fixed already).\n"
+                f"    (B) REAL BUG  — you reproduced a genuine defect in this repo that needs a code change.\n\n"
+                f"STEP 3A — IF VERDICT IS (A) NOT A BUG  ->  COMMENT AND CLOSE. DO NOT open a PR. DO NOT edit code.\n"
+                f"  1. Post a comment stating what you checked and the evidence it works\n"
+                f"     (include the command output / HTTP status / live URL you verified):\n"
+                f"       gh issue comment {issue_no} --repo {repo} --body \"<your findings + evidence>\"\n"
+                f"  2. Close the issue as not-planned (it was not an actionable defect):\n"
+                f"       gh issue close {issue_no} --repo {repo} --reason 'not planned' \\\n"
+                f"         --comment 'Verified working — see analysis above. Closing.'\n"
+                f"  Then STOP. Do not create branches, commits, or PRs.\n\n"
+                f"STEP 3B — IF VERDICT IS (B) REAL BUG  ->  FIX AND OPEN A PR.\n"
+                f"  1. Be surgical — change only what is needed.\n"
+                f"  2. Run tests if available: make test\n"
+                f"  3. Branch, commit, push:\n"
+                f"       git checkout -b agent/fix-issue-{issue_no}\n"
+                f"       git commit -am 'fix: resolve issue #{issue_no}'\n"
+                f"       git push origin agent/fix-issue-{issue_no}\n"
+                f"  4. Open a PR that auto-closes the issue on merge:\n"
+                f"       gh pr create --repo {repo} \\\n"
+                f"         --title 'Fix: <one-line summary>' \\\n"
+                f"         --body 'Fixes #{issue_no}'\n"
+                f"  Do NOT manually close the issue — the merged PR closes it via 'Fixes #'.\n\n"
+                f"STEP 4 — SUMMARY (end your response with this block)\n"
+                f"  - Verdict: NOT A BUG | REAL BUG\n"
+                f"  - Evidence: (what you checked, key command output)\n"
+                f"  - Action: commented+closed | PR opened (URL)\n"
             )
 
         elif agent_type == "fix-ci":

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -427,7 +427,7 @@ class WorkerManager:
             lock_key = None
             triple = None
             arch = job.get("arch", "arm64")
-            if job.get("type") == "integration-test":
+            if job.get("type") in ("integration-test", "app-layer-test"):
                 triple = _triple_of(job)
                 lock_key = f"running:lock:{triple}"
                 acquired = await self.pool.set(
@@ -459,7 +459,7 @@ class WorkerManager:
                     "ref": _branch_of(job),
                     "started_at": datetime.now(timezone.utc).isoformat(),
                     "worker_id": "master",
-                    "type": "integration-test",
+                    "type": job["type"],
                 })
                 await self.pool.expire(running_key, LOCK_TTL_SECONDS)
             elif job.get("type") == "daemon":
@@ -581,9 +581,9 @@ class WorkerManager:
                             )
                 self.active_jobs.pop(job_id, None)
                 log.info("Finished job: %s → %s", job_id, job["status"])
-                # Telemetry: integration-test results emit test.result with the
-                # full schema. Best-effort — never block on tracker outage.
-                if job.get("type") == "integration-test":
+                # Telemetry: integration-test + app-layer-test results emit test.result
+                # with the full schema. Best-effort — never block on tracker outage.
+                if job.get("type") in ("integration-test", "app-layer-test"):
                     try:
                         result = job.get("result", {}) or {}
                         repo_name = job["repo"].split("/")[-1]
@@ -659,6 +659,11 @@ class WorkerManager:
             return await self._run_sync_command(job)
 
         elif job_type == "integration-test":
+            return await self._run_integration_test(job)
+
+        elif job_type == "app-layer-test":
+            # Same Sysbox provisioning as integration-test; final step is the
+            # app-layer driver (shell-verification + LAB_SOLUTION via the exec path).
             return await self._run_integration_test(job)
 
         elif job_type == "daemon":
@@ -926,6 +931,14 @@ class WorkerManager:
         self._write_env_file(repo_dir / ".devcontainer" / ".env", arch="arm64", job_id=job_id,
                              dt_env=job.get("dt_env"), tenant=job.get("tenant", ""))
 
+        # app-layer-test rides this same provisioning path; it only swaps the final
+        # step (the app-layer driver instead of integration.sh). Copy the driver
+        # into the workspace so it is mounted into the dt container.
+        is_app_layer = job.get("type") == "app-layer-test"
+        if is_app_layer:
+            driver_src = Path(__file__).resolve().parent.parent / "tools" / "app_layer_driver.py"
+            shutil.copy(driver_src, repo_dir / ".app_layer_driver.py")
+
         # Sysbox-isolated nested containers (see executor.py for the same
         # architecture): outer Sysbox container runs docker:25-dind; inner
         # dockerd hosts the dt-enablement container which spins up its own
@@ -1038,8 +1051,13 @@ class WorkerManager:
             steps = [
                 ("postCreateCommand", "./.devcontainer/post-create.sh"),
                 ("postStartCommand",  "./.devcontainer/post-start.sh"),
-                ("integrationTest",   "zsh .devcontainer/test/integration.sh"),
             ]
+            if is_app_layer:
+                # Drive the app-layer path: STEP_SETUP + LAB_SOLUTION + shell-verification
+                # commands from docs, exactly as the Enablement App would via the exec API.
+                steps.append(("appLayerTest", "python3 .app_layer_driver.py docs"))
+            else:
+                steps.append(("integrationTest", "zsh .devcontainer/test/integration.sh"))
             livelog_key = f"job:livelog:{job_id}"
             await self.pool.set(livelog_key, "", ex=3600)
 
@@ -1108,7 +1126,7 @@ class WorkerManager:
         shutil.rmtree(work_dir, ignore_errors=True)
 
         return {
-            "test": "integration",
+            "test": "app-layer" if is_app_layer else "integration",
             "arch": "arm64",
             "ref": ref,
             "exit_code": rc,


### PR DESCRIPTION
Two changes (the second preserves in-progress ops work):

## 1. `app-layer-test` Orbital job
Tests the path the Enablement App's UI takes — `shell-verification → exec → evaluate` and `LAB_SOLUTION → SolutionPanel` — not just `integration.sh`'s shell layer.

- **`ops-server/tools/app_layer_driver.py`** (self-contained, runs inside the lab container): extracts STEP_SETUP / LAB_SOLUTION / shell-verification from `docs/*.md`; runs setup+solution via `bash -lc` (login → my_functions loaded = exec interactive=true) and shell-verification via `bash -c` (non-login = interactive=false — the real app behavior); evaluates `expect` (exit-zero|contains|not-empty|gt). Drives the full learner loop: STEP_SETUP → LAB_SOLUTION apply+verify → gates must PASS.
- **`manager.py`**: routes `app-layer-test` through `_run_integration_test` (same Sysbox provisioning), swapping only the final step; per-triple lock, running-state, and `test.result` telemetry now cover it.
- **dashboard**: `POST /api/builds/trigger {repo, ref, type:"app-layer-test"}`.

Mirrors `dynatrace-app-enablements/scripts/lab-driver.mjs` (kept in sync by intent).

## 2. Triage-first `fix-issue` agent prompt
Preserves in-progress work: the fix-issue agent now TRIAGEs (reproduce/verify → classify NOT-A-BUG vs REAL-BUG → comment+close or fix+PR) instead of assuming every issue is a code bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)