### PR TITLE
fix(orbital): persist job:log for master (arm64) framework suites — empty logs fix

### DIFF
--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -1572,7 +1572,11 @@ class WorkerManager:
         shutil.rmtree(work_dir, ignore_errors=True)
 
         await self._save_framework_suite_result(suite, job_id, rc, duration, arch, "".join(sections))
-        return {"suite": suite, "exit_code": rc, "passed": rc == 0, "duration_seconds": duration, "arch": arch, "timed_out": timed_out}
+        # Return log_file so _publish_log persists job:log:{id} (read by /api/jobs/{id}/log).
+        # Without this the master (arm64) framework suites streamed to job:livelog during the
+        # run but left job:log empty → the dashboard showed "Initializing isolation container…"
+        # forever for green nightly runs. The amd64 path returns log_file via executor.py.
+        return {"suite": suite, "exit_code": rc, "passed": rc == 0, "duration_seconds": duration, "arch": arch, "timed_out": timed_out, "log_file": str(log_file)}
 
     async def _save_framework_suite_result(self, suite: str, job_id: str, rc: int, duration: int, arch: str, log_text: str):
         """Store last result for a framework suite in Redis."""


### PR DESCRIPTION
## ISSUES-AND-FRS → "# Orbital"
Covers:
- **Logs of Framework test on master are not shown.**
- **Framework runs in ARM (Master) logs are empty.**
- **Logs with empty content** showing "Initializing isolation container…" on green nightly runs.

## Root cause (found live in Redis)
The newest nightly **framework arm64** jobs had `job:livelog` 25k–58k bytes (the live stream worked) but `job:log = 0`; **amd64** had both populated.

`_run_framework_sysbox` (the master path for `engines`/`k3d-apps`/`dt-apponly`/`dt-cnfs`) writes the log file to disk (`log_file.write_text(...)`) but its **result dict omitted `log_file`**. `_publish_log` reads `result["log_file"]` to set `job:log:{id}` → with no path it returns early → `job:log` stays empty → `/api/jobs/{id}/log` serves nothing → the dashboard shows the "Initializing isolation container…" placeholder forever. The amd64 path is unaffected because the worker's `executor.py` returns `log_file`.

(`bats` works too — it sets `job:log` directly.)

## Fix
Return `"log_file"` from `_run_framework_sysbox`, matching the bats + integration + executor paths.

## Verification
Deployed to ops (`cp manager.py` + `systemctl restart ops-worker`); enqueued an arm64 `engines` framework job and confirmed `job:log` populates on completion (was 0 before). Live result appended below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)