### PR TITLE
fix(orbital): classic settings:objects scopes for deploy + surface scope-skip warnings

### DIFF
--- a/ops-server/dashboard/app_deploy.py
+++ b/ops-server/dashboard/app_deploy.py
@@ -52,7 +52,12 @@ DEPLOY_REDIRECT_URI = os.environ.get(
 )
 DEPLOY_SCOPES = os.environ.get(
     "DEPLOY_SCOPES",
-    "app-engine:apps:install app-engine:apps:run app-engine:apps:delete app-settings:objects:write",
+    # apps:* to install/run/delete; app-settings + CLASSIC settings:objects:* so the
+    # post-install steps can write the outbound-allowlist and remote-grail settings via
+    # the classic settings API. Without classic settings:objects:write those steps 403
+    # and silently skip (cross-tenant forwarding wouldn't get configured).
+    "app-engine:apps:install app-engine:apps:run app-engine:apps:delete "
+    "app-settings:objects:write settings:objects:read settings:objects:write",
 )
 APP_ID = "my.dynatrace.enablements"
 DEFAULT_SSO = "https://sso.dynatrace.com"
@@ -145,6 +150,23 @@ def _client_for(domain: str) -> tuple[str, str]:
 def _missing_scopes(action: str, granted: str | None) -> list[str]:
     """Required IAM scopes for the action minus what the user's token actually granted."""
     return sorted(REQUIRED_SCOPES.get(action, set()) - set((granted or "").split()))
+
+
+def _scope_warnings(allowlist: str, remote_grail: str) -> list[str]:
+    """Surface post-install steps that were SKIPPED because the deploy token lacked
+    settings:objects:write. The deploy itself still succeeds (those steps are best-effort),
+    but the operator must know cross-tenant forwarding wasn't configured — otherwise it
+    fails silently. Returned in the deploy response + audit so it's visible, not buried."""
+    warnings: list[str] = []
+    if "token lacks settings" in (remote_grail or ""):
+        warnings.append(
+            "remote-grail NOT configured: the deploy token is missing settings:objects:write, "
+            "so cross-tenant forwarding to wwse was not enabled. Re-deploy with a token that has "
+            "settings:objects:read+write, or set the remote-grail setting by hand.")
+    if "token lacks settings" in (allowlist or ""):
+        warnings.append(
+            "outbound allowlist NOT updated: the deploy token is missing settings:objects:write.")
+    return warnings
 
 
 def _app_url(tenant_url: str) -> str:
@@ -623,12 +645,13 @@ async def deploy_with_token(body: dict, x_auth_user: str | None = Header(default
     reg = await _register_in_content_service(user, tenant)
     profile = (reg or {}).get("profile")
     url = _app_url(tenant)
+    warnings = _scope_warnings(allowlist, remote_grail)
     await _audit(user, tenant_id, "deploy", res["status"], via=via,
                  **{k: res[k] for k in ("from", "to") if res.get(k)}, url=url, profile=profile,
-                 allowlist=allowlist, remote_grail=remote_grail)
+                 allowlist=allowlist, remote_grail=remote_grail, warnings=warnings)
     return {"ok": True, "tenant": tenant_id, "status": res["status"], "from": res.get("from"),
             "version": res.get("to"), "url": url, "profile": profile, "allowlist": allowlist,
-            "remote_grail": remote_grail}
+            "remote_grail": remote_grail, "warnings": warnings}
 
 
 @router.get("/api/deploy/audit")

--- a/ops-server/dashboard/test_app_deploy.py
+++ b/ops-server/dashboard/test_app_deploy.py
@@ -338,3 +338,13 @@ def test_ensure_remote_grail_updates_existing_setting():
     assert msg == "updated → wwse"
     assert captured["put_url"].endswith("/obj-1")
     assert captured["put"]["value"]["apiToken"] == "COE-SECRET"
+
+
+def test_scope_warnings_flags_missing_settings_scope():
+    w = dep._scope_warnings("skipped (token lacks settings:objects:read/write)",
+                            "skipped (token lacks settings:objects:read/write)")
+    assert len(w) == 2
+    assert any("remote-grail NOT configured" in x for x in w)
+    # clean results → no warnings
+    assert dep._scope_warnings("added 1 host(s)", "enabled → wwse") == []
+    assert dep._scope_warnings("", "skipped (central tenant — stores locally)") == []


### PR DESCRIPTION
Answers + fixes the scope-verification gap.

## Behavior today (the answer)
- **Register Tenant**: validates nothing — only adds the tenant to the content map; no token stored.
- **Deploy scopes (apps:install/run)**: SSO path **pre-verifies** (rejects upfront via `_missing_scopes`); token path **fails at runtime (502)** if missing.
- **Settings scope (settings:objects:write — remote-grail + allowlist)**: **neither path pre-verified**, and the steps are best-effort → **an app could deploy fine while remote-grail was silently skipped.** Also the SSO flow requested `app-settings:objects:write`, not the **classic** `settings:objects:write` those writes actually need.

## Fix
1. `DEPLOY_SCOPES` now also requests `settings:objects:read settings:objects:write` (classic) so SSO-delegated tokens can write the remote-grail + allowlist settings.
2. `_scope_warnings()` — the deploy response + audit now include an explicit **`warnings`** list when remote-grail/allowlist were skipped for missing scope, so it's visible instead of silent.

The deploy is still **not** hard-blocked on the settings scope (those steps are optional by design), but the operator is now told. +1 unit test. Deployed to ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)