### PR TITLE
feat(orbital): tenant deployment stage (production/sprint/dev) badge

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -3512,6 +3512,11 @@ async def api_arena_provision(body: ArenaProvisionRequest):
         "type":         "daemon",
         "arena_user":   body.userId,
         "arena_tenant": body.tenantId or tenant_url,
+        # Stage badge shown next to the tenant id in History (production / sprint / dev),
+        # derived from the tenant domain (*.apps.dynatrace.com=production,
+        # *.sprint.apps.dynatracelabs.com=sprint, *.dev…=dev).
+        "stage":        {"prod": "production", "sprint": "sprint", "dev": "dev"}.get(
+            classify_tenant(tenant_url or body.tenantId or "")[1], "production"),
         "training_id":  body.trainingId,
         "expires_at":   expires_at,
         "token_provisioned": "1" if token_provisioned else "0",

--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -3106,9 +3106,24 @@ function csRenderDelivery() {
     document.getElementById('cs-newtp').innerHTML = csProfileOpts(csState.profiles[0] && csState.profiles[0].profileId);
 }
 
+// Derive the deployment stage from a tenant id/URL: *.apps.dynatrace.com = production,
+// *.sprint.apps.dynatracelabs.com = sprint, *.dev.apps.dynatracelabs.com = dev. A bare
+// id with no domain hint defaults to production (the common case).
+function stageOf(idOrUrl) {
+    const s = String(idOrUrl || '');
+    if (/\.sprint\./.test(s)) return 'sprint';
+    if (/\.dev\./.test(s)) return 'dev';
+    return 'production';
+}
+function stageBadge(stage) {
+    const bg = stage === 'production' ? '#5a1e1e' : stage === 'sprint' ? '#3a3a1e' : '#1e3a3a';
+    const fg = stage === 'production' ? '#ff9a9a' : stage === 'sprint' ? '#e0d77d' : '#7dd6e0';
+    return `<span style="font-size:0.62rem;margin-left:6px;padding:0 5px;border-radius:3px;background:${bg};color:${fg}" title="Deployment stage">${escapeHtml(stage)}</span>`;
+}
+
 function csTenantRow(tid, pid) {
     const tr = document.createElement('tr');
-    tr.innerHTML = `<td><code>${escapeHtml(tid)}</code></td><td><select>${csProfileOpts(pid)}</select></td><td><button class="btn btn-small btn-secondary" type="button">remove</button></td>`;
+    tr.innerHTML = `<td><code>${escapeHtml(tid)}</code>${stageBadge(stageOf(tid))}</td><td><select>${csProfileOpts(pid)}</select></td><td><button class="btn btn-small btn-secondary" type="button">remove</button></td>`;
     tr.dataset.tid = tid;
     tr.querySelector('button').addEventListener('click', () => tr.remove());
     return tr;


### PR DESCRIPTION
Per Sergio: show the deployment stage on registered tenants + next to a running training's tenant id.

- Provision stamps **stage** on the job meta (via classify_tenant on the tenant domain) → History shows the stage badge next to the training tenant id (e.g. `ydi9582h sprint`). The badge was already rendered client-side but the backend never set `stage`.
- Content Service → Tenants table shows a stage badge per tenant (`stageOf`: sprint/dev by domain, else production).
- Stages: `*.apps.dynatrace.com`=production, `*.sprint.apps.dynatracelabs.com`=sprint, `*.dev.apps.dynatracelabs.com`=dev.

Note: History stage is accurate (derived from the full tenant URL at provision). The Tenants-table badge is best-effort — tenant-map keys are bare ids, so a sprint id without a domain hint defaults to 'production'; a follow-up could persist the domain in the tenant map for exactness. Deployed to ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)