### PR TITLE
fix(orbital): stage colors (production green / sprint yellow) + short tenant id

### DIFF
--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -1437,8 +1437,7 @@ async function loadRunningDetail() {
                     <td>
                         <span style="font-size:0.75rem;color:var(--text-muted)">${escapeHtml(r.worker_id || '')}</span>
                         ${r.arena_user ? `<br><span style="font-size:0.7rem;color:#4ec9b0" title="Arena session">👤 ${escapeHtml(r.arena_user)}</span>` : ''}
-                        ${r.arena_tenant ? `<br><span style="font-size:0.7rem;color:var(--text-2)" title="Tenant">${escapeHtml(r.arena_tenant.replace(/\.apps\.dynatrace\.com$/, ''))}</span>` : ''}
-                        ${r.stage ? `<span style="font-size:0.62rem;margin-left:4px;padding:0 4px;border-radius:3px;background:${r.stage === 'production' ? '#5a1e1e' : '#3a3a1e'};color:${r.stage === 'production' ? '#ff9a9a' : '#e0d77d'}" title="Tenant stage">${escapeHtml(r.stage)}</span>` : ''}
+                        ${r.arena_tenant ? `<br><span style="font-size:0.7rem;color:var(--text-2)" title="Tenant">${escapeHtml(String(r.arena_tenant).split('.')[0])}${r.stage ? ' ' + stageBadge(r.stage) : ''}</span>` : ''}
                         ${r.provider === 'codespace' ? `<br><span style="font-size:0.7rem;color:#a78bfa" title="Runs in the learner's own GitHub Codespace, proxied by Orbital">☁ codespace</span>` : ''}
                     </td>
                     <td title="${escapeHtml(r.started_at || '')}">${formatTime(r.started_at)}</td>
@@ -3116,8 +3115,9 @@ function stageOf(idOrUrl) {
     return 'production';
 }
 function stageBadge(stage) {
-    const bg = stage === 'production' ? '#5a1e1e' : stage === 'sprint' ? '#3a3a1e' : '#1e3a3a';
-    const fg = stage === 'production' ? '#ff9a9a' : stage === 'sprint' ? '#e0d77d' : '#7dd6e0';
+    // production = green, sprint = yellow, dev = teal.
+    const bg = stage === 'production' ? '#1e3a1e' : stage === 'sprint' ? '#3a3a1e' : '#1e3a3a';
+    const fg = stage === 'production' ? '#7dd67d' : stage === 'sprint' ? '#e0d77d' : '#7dd6e0';
     return `<span style="font-size:0.62rem;margin-left:6px;padding:0 5px;border-radius:3px;background:${bg};color:${fg}" title="Deployment stage">${escapeHtml(stage)}</span>`;
 }
 


### PR DESCRIPTION
Per Sergio note on running-trainings: production stage badge **green** (was red), sprint **yellow**, dev teal. History row now shows just the short tenant id (e.g. `ydi9582h`) + the stage badge, dropping the full tenant domain. Deployed to ops.