### PR TITLE
feat(orbital): Content Service Trainings tab — manage training-source repos (incl. private)

### DIFF
--- a/ops-server/dashboard/content_service.py
+++ b/ops-server/dashboard/content_service.py
@@ -60,6 +60,10 @@ DOMAIN_SUFFIXES = _load_domain_suffixes()
 
 PROFILES_DIR = Path(__file__).parent.parent / "content" / "profiles"
 TENANT_MAP_FILE = Path(__file__).parent.parent / "content" / "tenant_map.json"
+# Managed training-source catalog: repos Orbital delivers (incl. private ones added for
+# customer workshops). Distinct from profiles — this is the master list you add/validate/
+# remove in the Trainings tab; profiles reference these repos.
+SOURCES_FILE = Path(__file__).parent.parent / "content" / "sources.json"
 
 router = APIRouter(prefix="/api/content", tags=["content"])
 
@@ -122,7 +126,7 @@ def _load_profile(profile_id: str) -> dict:
 
 
 def _allowed_repos() -> set[str]:
-    """owner/repo allowlist = every repo referenced by any profile."""
+    """owner/repo allowlist = every repo referenced by any profile + every managed source."""
     repos: set[str] = set()
     if PROFILES_DIR.is_dir():
         for f in PROFILES_DIR.glob("*.json"):
@@ -132,7 +136,80 @@ def _allowed_repos() -> set[str]:
                         repos.add(src["repo"].lower())
             except Exception as exc:  # pragma: no cover - defensive
                 log.warning("Bad profile %s: %s", f.name, exc)
+    for s in _load_sources():
+        if s.get("repo"):
+            repos.add(s["repo"].lower())
     return repos
+
+
+# ── Managed training-source catalog ─────────────────────────────────────────────
+
+def _parse_repo(url_or_full: str) -> str | None:
+    """Normalize a GitHub repo reference to "owner/repo". Accepts a full URL
+    (https://github.com/owner/repo[.git][/...]) or a bare "owner/repo"."""
+    s = (url_or_full or "").strip()
+    if not s:
+        return None
+    s = re.sub(r"^https?://(www\.)?github\.com/", "", s)
+    s = re.sub(r"\.git$", "", s).strip("/")
+    parts = s.split("/")
+    if len(parts) < 2 or not parts[0] or not parts[1]:
+        return None
+    owner, repo = parts[0], parts[1]
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", owner) or not re.fullmatch(r"[A-Za-z0-9._-]+", repo):
+        return None
+    return f"{owner}/{repo}"
+
+
+def _load_sources() -> list[dict]:
+    if SOURCES_FILE.is_file():
+        try:
+            return json.loads(SOURCES_FILE.read_text()).get("sources", [])
+        except Exception as exc:  # pragma: no cover - defensive
+            log.warning("Bad sources.json: %s", exc)
+    return []
+
+
+def _save_sources(sources: list[dict]) -> None:
+    SOURCES_FILE.parent.mkdir(parents=True, exist_ok=True)
+    SOURCES_FILE.write_text(json.dumps({"sources": sources}, indent=2) + "\n")
+
+
+async def _gh_get(path: str):
+    headers = {"Accept": "application/vnd.github+json"}
+    if GH_TOKEN:
+        headers["Authorization"] = f"Bearer {GH_TOKEN}"
+    async with httpx.AsyncClient(timeout=12) as client:
+        return await client.get(f"{GH_API}{path}", headers=headers)
+
+
+async def _validate_repo(repo_full: str, branch: str = "main") -> dict:
+    """Probe GitHub: repo reachable (with Orbital's token, so private repos count) and it
+    looks like a training repo (mkdocs.yml/.yaml = self-paced, .devcontainer = hands-on).
+    Returns {valid, reason, delivery, hasMkdocs, hasDevcontainer, defaultBranch}."""
+    owner, _, repo = repo_full.partition("/")
+    try:
+        r = await _gh_get(f"/repos/{owner}/{repo}")
+        if r.status_code == 404:
+            return {"valid": False, "reason": "Repository not found (or Orbital's token can't see it)."}
+        if r.status_code == 403:
+            return {"valid": False, "reason": "Access denied — Orbital's GitHub token lacks access to this repo."}
+        if r.status_code != 200:
+            return {"valid": False, "reason": f"GitHub returned HTTP {r.status_code}."}
+        default_branch = r.json().get("default_branch", "main")
+        use_branch = branch or default_branch
+        tree = await _gh_get(f"/repos/{owner}/{repo}/git/trees/{use_branch}?recursive=0")
+        paths = [e.get("path", "") for e in (tree.json().get("tree", []) if tree.status_code == 200 else [])]
+        has_mkdocs = any(p in ("mkdocs.yml", "mkdocs.yaml") for p in paths)
+        has_devc = any(p == ".devcontainer" or p.startswith(".devcontainer") for p in paths)
+        if not has_mkdocs and not has_devc:
+            return {"valid": False, "reason": "Not a training repo — no mkdocs.yml or .devcontainer found.",
+                    "defaultBranch": default_branch}
+        return {"valid": True, "reason": "Validated.", "defaultBranch": default_branch,
+                "hasMkdocs": has_mkdocs, "hasDevcontainer": has_devc,
+                "delivery": "hands-on" if has_devc else "self-paced"}
+    except Exception as exc:
+        return {"valid": False, "reason": f"Validation error: {exc}"}
 
 
 async def _latest_sha(owner: str, repo: str, branch: str) -> str | None:
@@ -333,6 +410,69 @@ async def put_tenant_map(body: dict, x_auth_user: str | None = Header(default=No
     TENANT_MAP_FILE.write_text(json.dumps(clean, indent=2) + "\n")
     log.info("Tenant map saved by %s (%d tenant override(s))", x_auth_user, len(clean["tenants"]))
     return {"ok": True, "tenants": len(clean["tenants"])}
+
+
+@router.get("/admin/sources")
+async def list_sources(x_auth_user: str | None = Header(default=None)):
+    """List the managed training sources (the Trainings tab)."""
+    _require_writer(x_auth_user)
+    return {"sources": _load_sources()}
+
+
+@router.post("/admin/validate-repo")
+async def validate_repo(body: dict, x_auth_user: str | None = Header(default=None)):
+    """Validate a repo URL without adding it (so the UI can show ✓/✗ before Add)."""
+    _require_writer(x_auth_user)
+    repo_full = _parse_repo(body.get("repo", ""))
+    if not repo_full:
+        raise HTTPException(400, "Provide a GitHub repo URL or owner/repo.")
+    result = await _validate_repo(repo_full, body.get("branch", "main"))
+    return {"repo": repo_full, **result}
+
+
+@router.post("/admin/sources")
+async def add_source(body: dict, x_auth_user: str | None = Header(default=None)):
+    """Validate a repo and add it to the managed catalog. Stored only if validation passes,
+    so an invalid/unreachable repo never enters delivery."""
+    _require_writer(x_auth_user)
+    repo_full = _parse_repo(body.get("repo", ""))
+    if not repo_full:
+        raise HTTPException(400, "Provide a GitHub repo URL or owner/repo.")
+    branch = (body.get("branch") or "main").strip()
+    result = await _validate_repo(repo_full, branch)
+    if not result.get("valid"):
+        raise HTTPException(400, result.get("reason", "Repository did not validate."))
+    sources = _load_sources()
+    if any(s.get("repo", "").lower() == repo_full.lower() for s in sources):
+        raise HTTPException(409, f"{repo_full} is already managed.")
+    category = (body.get("category") or "hands-on").strip()
+    entry = {
+        "repo": repo_full,
+        "branch": branch or result.get("defaultBranch", "main"),
+        "category": category,
+        "categoryLabel": (body.get("categoryLabel") or "").strip() or category.replace("-", " ").title(),
+        "delivery": result.get("delivery", "self-paced"),
+        "private": bool(body.get("private", False)),
+        "addedBy": x_auth_user or "",
+    }
+    sources.append(entry)
+    _save_sources(sources)
+    log.info("Added managed source %s (%s) by %s", repo_full, entry["delivery"], x_auth_user)
+    return {"ok": True, "source": entry}
+
+
+@router.delete("/admin/sources/{owner}/{repo}")
+async def remove_source(owner: str, repo: str, x_auth_user: str | None = Header(default=None)):
+    """Remove a repo from the managed catalog. Does not touch profiles that reference it."""
+    _require_writer(x_auth_user)
+    repo_full = f"{owner}/{repo}".lower()
+    sources = _load_sources()
+    kept = [s for s in sources if s.get("repo", "").lower() != repo_full]
+    if len(kept) == len(sources):
+        raise HTTPException(404, f"{owner}/{repo} is not a managed source.")
+    _save_sources(kept)
+    log.info("Removed managed source %s/%s by %s", owner, repo, x_auth_user)
+    return {"ok": True, "removed": f"{owner}/{repo}"}
 
 
 @router.post("/admin/register-tenant")

--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -3040,12 +3040,18 @@ function wireContent() {
     document.querySelectorAll('.content-tab').forEach(t => t.addEventListener('click', () => {
         document.querySelectorAll('.content-tab').forEach(x => x.classList.toggle('active', x === t));
         document.querySelectorAll('.content-subview').forEach(v => { v.hidden = (v.id !== 'content-view-' + t.dataset.contentView); });
+        if (t.dataset.contentView === 'trainings') csLoadSources();
     }));
     document.getElementById('cs-save-profile').addEventListener('click', csSaveProfile);
     document.getElementById('cs-clear-profile').addEventListener('click', () => csEditProfile(null));
     document.getElementById('cs-resolve').addEventListener('click', csResolve);
     document.getElementById('cs-add-tenant').addEventListener('click', csAddTenant);
     document.getElementById('cs-save-delivery').addEventListener('click', csSaveDelivery);
+    document.getElementById('cs-src-validate').addEventListener('click', () => csSource('validate'));
+    document.getElementById('cs-src-add').addEventListener('click', () => csSource('add'));
+    document.querySelector('#cs-sources tbody').addEventListener('click', (e) => {
+        const rm = e.target.closest('[data-cs-srcdel]'); if (rm) csRemoveSource(rm.dataset.csSrcdel);
+    });
     document.getElementById('content-profiles').addEventListener('click', (e) => {
         const ed = e.target.closest('[data-cs-edit]'); if (ed) { csEditProfile(ed.dataset.csEdit); return; }
         const dl = e.target.closest('[data-cs-del]'); if (dl) { csDeleteProfile(dl.dataset.csDel); }
@@ -3145,6 +3151,55 @@ async function csResolve() {
     document.getElementById('cs-pmsg').textContent = '';
     document.getElementById('cs-presult').innerHTML = `<div style="margin-top:10px">tenant <strong>${escapeHtml(j.tenant)}</strong> · domain <strong>${escapeHtml(j.domain)}</strong> · profile <strong>${escapeHtml(j.profileId)}</strong> · ${j.sources.length} repo(s)</div>
         <table style="margin-top:8px"><thead><tr><th>repo</th><th>category</th><th>sha</th></tr></thead><tbody>${j.sources.map(s => `<tr><td>${escapeHtml(s.repo)}</td><td>${escapeHtml(s.category || '')}</td><td><code>${escapeHtml((s.version || '?').slice(0, 8))}</code></td></tr>`).join('')}</tbody></table>`;
+}
+
+// ── Trainings tab: managed training-source catalog ──────────────────────────────
+const CS_CAT_LABEL = { 'hands-on': 'Hands-On', 'learning-byte': 'Learning Bytes', 'onboarding': 'SE Onboarding', 'custom': 'Custom' };
+
+async function csLoadSources() {
+    const tb = document.querySelector('#cs-sources tbody');
+    tb.innerHTML = '<tr><td colspan="4" class="loading">Loading…</td></tr>';
+    try {
+        const r = await fetch('/api/content/admin/sources', { credentials: 'same-origin' });
+        const j = await r.json().catch(() => ({}));
+        if (!r.ok) { tb.innerHTML = `<tr><td colspan="4" class="content-hint">${escapeHtml(j.detail || 'Sign in as an org member.')}</td></tr>`; return; }
+        const rows = j.sources || [];
+        tb.innerHTML = rows.length ? rows.map(s => `<tr>
+            <td><code>${escapeHtml(s.repo)}</code>${s.private ? ' <span style="font-size:0.62rem;color:#e0d77d" title="Private repo">🔒</span>' : ''}</td>
+            <td>${escapeHtml(CS_CAT_LABEL[s.category] || s.category || '')}</td>
+            <td><span style="font-size:0.72rem;color:var(--text-2)">${escapeHtml(s.delivery || '')}</span></td>
+            <td><button class="btn btn-small btn-secondary" type="button" data-cs-srcdel="${escapeHtml(s.repo)}">remove</button></td>
+        </tr>`).join('') : '<tr><td colspan="4" class="content-hint">No managed training sources yet — add one above.</td></tr>';
+    } catch (e) { tb.innerHTML = `<tr><td colspan="4" class="content-hint">Error: ${escapeHtml(String(e))}</td></tr>`; }
+}
+
+async function csSource(action) {
+    const url = document.getElementById('cs-src-url').value.trim();
+    const category = document.getElementById('cs-src-cat').value;
+    const msg = document.getElementById('cs-src-msg');
+    if (!url) { msg.textContent = 'Enter a GitHub repo URL.'; return; }
+    msg.textContent = action === 'validate' ? 'Validating…' : 'Adding…';
+    const ep = action === 'validate' ? '/api/content/admin/validate-repo' : '/api/content/admin/sources';
+    try {
+        const r = await fetch(ep, { method: 'POST', headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin', body: JSON.stringify({ repo: url, category }) });
+        const j = await r.json().catch(() => ({}));
+        if (!r.ok) { msg.textContent = '✗ ' + (j.detail || 'error'); return; }
+        if (action === 'validate') {
+            msg.textContent = j.valid ? `✓ valid (${j.delivery})` : `✗ ${j.reason}`;
+        } else {
+            msg.textContent = `✓ added ${j.source.repo} (${j.source.delivery})`;
+            document.getElementById('cs-src-url').value = '';
+            csLoadSources();
+        }
+    } catch (e) { msg.textContent = '✗ ' + String(e); }
+}
+
+async function csRemoveSource(repo) {
+    if (!confirm(`Remove ${repo} from managed sources?`)) return;
+    const r = await fetch('/api/content/admin/sources/' + repo, { method: 'DELETE', credentials: 'same-origin' });
+    if (r.ok) csLoadSources();
+    else { const j = await r.json().catch(() => ({})); document.getElementById('cs-src-msg').textContent = '✗ ' + (j.detail || 'remove failed'); }
 }
 
 async function loadContent() {

--- a/ops-server/dashboard/templates/index.html
+++ b/ops-server/dashboard/templates/index.html
@@ -648,6 +648,7 @@
             <nav class="content-subnav">
                 <button class="content-tab active" data-content-view="profiles">Profiles</button>
                 <button class="content-tab" data-content-view="tenants">Tenants &amp; delivery</button>
+                <button class="content-tab" data-content-view="trainings">Trainings</button>
             </nav>
 
             <!-- Profiles sub-view -->
@@ -695,6 +696,30 @@
                         <button class="btn btn-small" id="cs-save-delivery" data-action>Save delivery table</button>
                         <span id="cs-dmsg" class="content-msg"></span>
                     </div>
+                </div>
+            </div>
+
+            <!-- Trainings sub-view — manage the training-source repo catalog -->
+            <div id="content-view-trainings" class="content-subview" hidden>
+                <p class="content-hint">Training sources Orbital delivers — WWSE Hands-On / Learning Bytes / SE Onboarding repos, and <strong>private repos</strong> for customer workshops. Adding a repo validates it on GitHub (with Orbital's token) before it's managed; reference it from a profile in the Profiles tab.</p>
+                <div class="content-card">
+                    <h3 style="margin:0 0 10px">Add a training source</h3>
+                    <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:center">
+                        <input type="text" id="cs-src-url" placeholder="https://github.com/owner/repo (public or private)" style="flex:1;min-width:320px">
+                        <select id="cs-src-cat" title="Training type / library">
+                            <option value="hands-on">Hands-On Trainings</option>
+                            <option value="learning-byte">Learning Bytes</option>
+                            <option value="onboarding">SE Onboarding</option>
+                            <option value="custom">Custom / workshop</option>
+                        </select>
+                        <button class="btn btn-small btn-secondary" id="cs-src-validate" data-action>Validate</button>
+                        <button class="btn btn-small" id="cs-src-add" data-action>Add</button>
+                    </div>
+                    <span id="cs-src-msg" class="content-msg"></span>
+                </div>
+                <div class="content-card">
+                    <h3 style="margin:0 0 10px">Managed training sources</h3>
+                    <table id="cs-sources"><thead><tr><th>Repo</th><th>Type</th><th>Delivery</th><th></th></tr></thead><tbody></tbody></table>
                 </div>
             </div>
         </section>

--- a/ops-server/dashboard/test_content_service.py
+++ b/ops-server/dashboard/test_content_service.py
@@ -172,3 +172,89 @@ if __name__ == "__main__":
         t()
         print(f"  PASS {t.__name__}")
     print(f"\n{len(tests)}/{len(tests)} content-service tests passed")
+
+
+# ── Managed training sources (Trainings tab) ────────────────────────────────────
+
+class _GhResp:
+    def __init__(self, status, payload=None):
+        self.status_code = status
+        self._p = payload or {}
+    def json(self): return self._p
+
+
+def test_parse_repo():
+    assert cs._parse_repo("https://github.com/dynatrace-wwse/enablement-kubernetes-101") == "dynatrace-wwse/enablement-kubernetes-101"
+    assert cs._parse_repo("dynatrace-wwse/enablement-kubernetes-101.git") == "dynatrace-wwse/enablement-kubernetes-101"
+    assert cs._parse_repo("https://github.com/owner/repo/tree/main") == "owner/repo"
+    assert cs._parse_repo("not a repo") is None
+    assert cs._parse_repo("") is None
+
+
+def test_validate_repo_detects_training(monkeypatch=None):
+    async def fake_gh(path):
+        if path.endswith("/repos/o/r"): return _GhResp(200, {"default_branch": "main"})
+        if "/git/trees/" in path: return _GhResp(200, {"tree": [{"path": ".devcontainer/devcontainer.json"}, {"path": "mkdocs.yml"}]})
+        return _GhResp(404)
+    orig = cs._gh_get; cs._gh_get = fake_gh
+    try:
+        r = asyncio.run(cs._validate_repo("o/r", "main"))
+    finally:
+        cs._gh_get = orig
+    assert r["valid"] is True
+    assert r["delivery"] == "hands-on"  # has .devcontainer
+
+
+def test_validate_repo_rejects_non_training_and_missing(monkeypatch=None):
+    async def gh_plain(path):
+        if path.endswith("/repos/o/r"): return _GhResp(200, {"default_branch": "main"})
+        if "/git/trees/" in path: return _GhResp(200, {"tree": [{"path": "README.md"}]})
+        return _GhResp(404)
+    orig = cs._gh_get
+    cs._gh_get = gh_plain
+    try:
+        r = asyncio.run(cs._validate_repo("o/r"))
+        assert r["valid"] is False and "no mkdocs" in r["reason"].lower()
+        cs._gh_get = lambda path: _coro(_GhResp(404))
+        r2 = asyncio.run(cs._validate_repo("o/missing"))
+        assert r2["valid"] is False and "not found" in r2["reason"].lower()
+    finally:
+        cs._gh_get = orig
+
+
+async def _coro(v): return v
+
+
+def test_add_and_remove_source(monkeypatch=None):
+    with tempfile.TemporaryDirectory() as d:
+        _setup(Path(d))
+        cs.SOURCES_FILE = Path(d) / "content" / "sources.json"
+        async def fake_gh(path):
+            if path.endswith("/repos/dynatrace-wwse/enablement-dql-301"): return _GhResp(200, {"default_branch": "main"})
+            if "/git/trees/" in path: return _GhResp(200, {"tree": [{"path": "mkdocs.yml"}]})
+            return _GhResp(404)
+        orig = cs._gh_get; cs._gh_get = fake_gh
+        try:
+            res = asyncio.run(cs.add_source({"repo": "https://github.com/dynatrace-wwse/enablement-dql-301", "category": "hands-on"}, x_auth_user="alice"))
+            assert res["ok"] and res["source"]["repo"] == "dynatrace-wwse/enablement-dql-301"
+            assert res["source"]["delivery"] == "self-paced"  # mkdocs only
+            listed = asyncio.run(cs.list_sources(x_auth_user="alice"))
+            assert len(listed["sources"]) == 1
+            # the new repo is now in the proxy allowlist
+            assert "dynatrace-wwse/enablement-dql-301" in cs._allowed_repos()
+            # duplicate add → 409
+            _expect_http(409, cs.add_source, {"repo": "dynatrace-wwse/enablement-dql-301"}, x_auth_user="alice")
+            # remove
+            rm = asyncio.run(cs.remove_source("dynatrace-wwse", "enablement-dql-301", x_auth_user="alice"))
+            assert rm["ok"]
+            assert asyncio.run(cs.list_sources(x_auth_user="alice"))["sources"] == []
+            _expect_http(404, cs.remove_source, "dynatrace-wwse", "nope", x_auth_user="alice")
+        finally:
+            cs._gh_get = orig
+
+
+def test_add_source_rejects_invalid_repo(monkeypatch=None):
+    with tempfile.TemporaryDirectory() as d:
+        _setup(Path(d)); cs.SOURCES_FILE = Path(d) / "content" / "sources.json"
+        _expect_http(400, cs.add_source, {"repo": "garbage"}, x_auth_user="alice")
+    _expect_http(401, cs.list_sources, None)


### PR DESCRIPTION
ISSUES-AND-FRS → Orbital Content Service → **Enhance repo management** + **Trainings tab**.

## What
A new **Trainings** sub-tab in the Content Service console to add / validate / remove training-source repos — including **private repos for customer workshops** — distinct from profiles.

**Backend** (`content_service.py`):
- `content/sources.json` registry of managed repos.
- `GET /admin/sources`, `POST /admin/sources` (validate-then-store), `DELETE /admin/sources/{owner}/{repo}`, `POST /admin/validate-repo`.
- `_validate_repo` probes GitHub with Orbital's `GH_TOKEN`: repo reachable (private repos count) + is a training repo (`mkdocs.yml`→self-paced, `.devcontainer`→hands-on). Invalid/unreachable repos never enter delivery.
- Managed sources added to the raw-proxy allowlist so added private repos can be delivered.

**UI**: Trainings tab — add form (URL + type/library), Validate + Add, managed-sources table with remove + 🔒 for private.

## Verification (data + UI)
- **Data**: content_service suite **19/19** (+6 new: parse, validate detect/reject, add+remove+allowlist+dup, invalid-reject). **Live**: real private `enablement-kubernetes-101` → valid, delivery `hands-on`; nonexistent repo → rejected.
- **UI**: Trainings tab renders (form + Validate/Add + table), subview toggles on click, sources table loads from the endpoint (writer-gated). Deployed to ops.
