### PR TITLE
fix(orbital): keep Agentic History — dedicated agent-job archive (not deleted, rolled off the cap)

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -2244,6 +2244,28 @@ def _infer_started_at(job: dict, result: dict) -> str:
     return finished or ""
 
 
+def _merge_agent_history(completed_raw: list, agent_raw: list) -> list:
+    """Append archived agent-job records that aren't already in jobs:completed
+    (dedupe by job_id). Pure — unit-tested. Bad JSON entries are passed through
+    untouched (the caller's loop skips them)."""
+    if not agent_raw:
+        return completed_raw
+    seen: set = set()
+    for r in completed_raw:
+        try:
+            seen.add(json.loads(r).get("job_id"))
+        except Exception:
+            pass
+    out = list(completed_raw)
+    for r in agent_raw:
+        try:
+            if json.loads(r).get("job_id") not in seen:
+                out.append(r)
+        except Exception:
+            pass
+    return out
+
+
 @app.get("/api/builds/history")
 async def api_builds_history(
     repo: str | None = None,
@@ -2260,6 +2282,10 @@ async def api_builds_history(
     ``repo`` is a substring match (case-insensitive) so the search bar works.
     """
     completed_raw = await pool.lrange("jobs:completed", -500, -1)
+    # Merge the dedicated agent-job archive (agent jobs are rare and otherwise roll off
+    # the 500-cap jobs:completed list, leaving Agentic History empty). Dedupe by job_id.
+    agent_raw = await pool.lrange("agent:jobs:completed", -300, -1)
+    completed_raw = _merge_agent_history(completed_raw, agent_raw)
     rows = []
     distinct_repos: set[str] = set()
     distinct_branches: set[str] = set()

--- a/ops-server/dashboard/test_agentic_history.py
+++ b/ops-server/dashboard/test_agentic_history.py
@@ -1,0 +1,31 @@
+"""Agentic History — agent jobs are archived to a dedicated list so they survive
+the 500-cap jobs:completed rollover; api_builds_history merges them (dedupe by id)."""
+import json
+from dashboard.app import _merge_agent_history
+from workers.manager import AGENT_JOB_TYPES
+
+
+def test_merge_appends_only_new_agent_jobs():
+    completed = [json.dumps({"job_id": "a", "type": "integration-test"}),
+                 json.dumps({"job_id": "b", "type": "fix-issue"})]
+    agent = [json.dumps({"job_id": "b", "type": "fix-issue"}),   # dup of completed → skip
+             json.dumps({"job_id": "c", "type": "fix-ci"})]      # new → appended
+    merged = _merge_agent_history(completed, agent)
+    ids = [json.loads(r)["job_id"] for r in merged]
+    assert ids == ["a", "b", "c"]
+
+
+def test_merge_no_agent_jobs_is_noop():
+    completed = [json.dumps({"job_id": "a"})]
+    assert _merge_agent_history(completed, []) == completed
+
+
+def test_merge_tolerates_bad_json():
+    merged = _merge_agent_history(["{bad", json.dumps({"job_id": "a"})],
+                                  ["alsobad", json.dumps({"job_id": "z"})])
+    assert json.dumps({"job_id": "z"}) in merged  # the valid new one is appended
+
+
+def test_agent_job_types_cover_dashboard_agent_set():
+    for t in ("fix-ci", "fix-issue", "review-pr", "migrate-gen3", "scaffold-lab", "deploy-ghpages"):
+        assert t in AGENT_JOB_TYPES

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -34,6 +34,10 @@ from telemetry.reporter import (
 # 2h: longer than any expected build. If a worker crashes mid-job, the lock
 # auto-expires and the next enqueue for the same triple proceeds.
 LOCK_TTL_SECONDS = 7200
+# Claude-Code agent job types — archived to a dedicated list so Agentic History
+# isn't crowded out of the 500-cap jobs:completed list by integration/framework runs.
+AGENT_JOB_TYPES = {"fix-ci", "fix-issue", "review-pr", "migrate-gen3", "scaffold-lab",
+                   "validate-after-push", "deploy-ghpages"}
 
 # App proxy port pool — master Sysbox containers publish one port in this range
 # so the dashboard can reverse-proxy to k3d LB apps without SSH tunnelling.
@@ -546,8 +550,15 @@ class WorkerManager:
                     self._terminated_jobs.discard(job_id)
                 job["finished_at"] = datetime.now(timezone.utc).isoformat()
                 await self._publish_log(job)
-                await self.pool.rpush("jobs:completed", json.dumps(job))
+                _rec = json.dumps(job)
+                await self.pool.rpush("jobs:completed", _rec)
                 await self.pool.ltrim("jobs:completed", -500, -1)
+                # Agent jobs are rare but get crowded out of the 500-cap jobs:completed
+                # list by integration/framework runs — so Agentic History looked empty.
+                # Keep a dedicated list (cap 300) so it survives.
+                if job.get("type") in AGENT_JOB_TYPES:
+                    await self.pool.rpush("agent:jobs:completed", _rec)
+                    await self.pool.ltrim("agent:jobs:completed", -300, -1)
                 # Terminal-status record that OUTLIVES job:running (deleted below),
                 # so session-status can report a failed creation and point the
                 # student at the retained log (job:log:{id}) instead of a bare


### PR DESCRIPTION
ISSUES-AND-FRS → Orbital → **Agentic History is empty — why?**

**Root cause (live Redis):** agent jobs are NOT deleted — `jobs:completed` is a single **500-cap** list dominated by integration (388) + framework (82) runs, so the rare agent jobs (2 in the window) roll off within days.

**Fix:** `manager.py` archives agent-type jobs to a dedicated `agent:jobs:completed` list (cap 300) on completion; `api_builds_history` merges it with `jobs:completed` (dedupe by job_id, pure `_merge_agent_history`). Agentic History now persists regardless of CI volume.

Tests: +4 (merge dedupe / noop / bad-json / AGENT_JOB_TYPES). Deployed to ops (dashboard + worker).