### PR TITLE
feat(orbital): PlatformTokenProvisioner — gen3 platform-token mint (verified live on sprint)

### DIFF
--- a/ops-server/provisioning/dt_token_provisioner.py
+++ b/ops-server/provisioning/dt_token_provisioner.py
@@ -175,3 +175,113 @@ class DTTokenProvisioner:
                         log.warning("Unexpected status revoking token %s: %d", tid, r.status_code)
                 except Exception as exc:
                     log.warning("Could not revoke token %s: %s", tid, exc)
+
+
+# ── Account Management platform-token provisioner (gen3 / migrated tenants) ──────
+#
+# On tenants where classic apiToken creation is disabled (sprint, and prod as it
+# migrates: POST /platform/classic/environment-api/v2/apiTokens → 400 "only available
+# in Account Management"), training tokens must be minted as PLATFORM tokens (dt0s16)
+# via the Account Management API, using an ACCOUNT-level OAuth client.
+#
+# Verified live on sprint (ydi9582h / account ceae4b9d…) 2026-06-19:
+#   bearer:  POST {sso}/sso/oauth2/token  client_credentials
+#            scope="platform-token:tokens:write platform-token:tokens:manage"
+#            resource="urn:dtaccount:{uuid}"
+#   create:  POST {accountApi}/iam/v1/accounts/{uuid}/platform-tokens
+#            {name, scope:[...], resource:["urn:dtenvironment:{envId}"], tags:[...],
+#             expirationDate}  → {tokenId, token}      (userUuid NOT required for the client)
+#   revoke:  DELETE {accountApi}/iam/v1/accounts/{uuid}/platform-tokens/{tokenId}
+
+_PT_SCOPE = "platform-token:tokens:write platform-token:tokens:manage"
+
+
+class PlatformTokenProvisioner:
+    """Mint/revoke training tokens as Account Management platform tokens (gen3 path).
+
+    `env_id` is the tenant subdomain (e.g. 'ydi9582h'); the token is scoped to
+    `urn:dtenvironment:{env_id}`. Mirrors DTTokenProvisioner's ProvisionedTokens output
+    so the rest of the provisioning flow is unchanged.
+    """
+
+    def __init__(self, tenant_url: str, env_id: str, account_uuid: str,
+                 sso_token_url: str, account_api_host: str,
+                 oauth_client_id: str, oauth_client_secret: str):
+        self.tenant_url = tenant_url.rstrip("/")
+        self.env_id = env_id
+        self.account_uuid = account_uuid
+        self.sso_token_url = sso_token_url
+        self.account_api_host = account_api_host.rstrip("/")
+        self._cid = oauth_client_id
+        self._csec = oauth_client_secret
+        if not (env_id and account_uuid and sso_token_url and account_api_host and oauth_client_id and oauth_client_secret):
+            raise ValueError("PlatformTokenProvisioner requires env_id, account_uuid, sso_token_url, account_api_host, oauth_client_id, oauth_client_secret")
+
+    @property
+    def _tokens_url(self) -> str:
+        return f"{self.account_api_host}/iam/v1/accounts/{self.account_uuid}/platform-tokens"
+
+    async def _bearer(self) -> str:
+        async with httpx.AsyncClient(timeout=15) as client:
+            r = await client.post(self.sso_token_url, data={
+                "grant_type": "client_credentials",
+                "client_id": self._cid,
+                "client_secret": self._csec,
+                "scope": _PT_SCOPE,
+                "resource": f"urn:dtaccount:{self.account_uuid}",
+            })
+            r.raise_for_status()
+            return r.json()["access_token"]
+
+    async def create_tokens(self, repo: str, user_id: str, specs: list[TokenSpec],
+                            expires_in_hours: int = 4) -> ProvisionedTokens:
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=expires_in_hours)
+        expires_iso = expires_at.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        repo_short = repo.split("/")[-1][:20].replace("_", "-")
+        user_short = user_id.split("@")[0][:10].replace("_", "-").replace(".", "-")
+        prefix = f"enbl-{repo_short}-{user_short}"
+        resource = [f"urn:dtenvironment:{self.env_id}"]
+
+        bearer = await self._bearer()
+        headers = {"Authorization": f"Bearer {bearer}", "Content-Type": "application/json"}
+        env: dict[str, str] = {}
+        token_ids: list[str] = []
+        errors: list[str] = []
+        async with httpx.AsyncClient(timeout=20) as client:
+            for spec in specs:
+                name = f"{prefix}-{spec.name_suffix}"[:100]
+                payload = {"name": name, "scope": spec.scopes, "resource": resource,
+                           "tags": ["enablement", repo_short], "expirationDate": expires_iso}
+                try:
+                    r = await client.post(self._tokens_url, headers=headers, json=payload)
+                    r.raise_for_status()
+                    data = r.json()
+                    env[spec.env_var] = data["token"]
+                    token_ids.append(data.get("tokenId") or data.get("id"))
+                    log.info("Created platform token '%s' (id=%s)", name, token_ids[-1])
+                except httpx.HTTPStatusError as exc:
+                    errors.append(f"platform token '{name}': HTTP {exc.response.status_code} — {exc.response.text[:200]}")
+        if errors:
+            if token_ids:
+                await self.revoke_tokens(token_ids)
+            raise RuntimeError("Platform-token provisioning failed:\n" + "\n".join(errors))
+        env["DT_ENVIRONMENT"] = self.tenant_url
+        return ProvisionedTokens(env=env, token_ids=token_ids, expires_at=expires_iso, tenant_url=self.tenant_url)
+
+    async def revoke_tokens(self, token_ids: list[str]):
+        if not token_ids:
+            return
+        bearer = await self._bearer()
+        headers = {"Authorization": f"Bearer {bearer}"}
+        async with httpx.AsyncClient(timeout=15) as client:
+            for tid in token_ids:
+                if not tid:
+                    continue
+                try:
+                    r = await client.delete(f"{self._tokens_url}/{tid}", headers=headers)
+                    if r.status_code in (200, 204, 404):
+                        log.info("Revoked platform token %s (status=%d)", tid, r.status_code)
+                    else:
+                        log.warning("Unexpected status revoking platform token %s: %d", tid, r.status_code)
+                except Exception as exc:
+                    log.warning("Could not revoke platform token %s: %s", tid, exc)

--- a/ops-server/provisioning/test_dt_token_provisioner.py
+++ b/ops-server/provisioning/test_dt_token_provisioner.py
@@ -183,3 +183,70 @@ if __name__ == "__main__":
             print(f"FAIL {fn.__name__}: {e}")
     print(f"\n{len(fns) - failed}/{len(fns)} passed")
     sys.exit(1 if failed else 0)
+
+
+# ── PlatformTokenProvisioner (gen3 / Account Management) ────────────────────────
+
+def _pt():
+    from .dt_token_provisioner import PlatformTokenProvisioner
+    return PlatformTokenProvisioner(
+        tenant_url="https://ydi9582h.sprint.apps.dynatracelabs.com", env_id="ydi9582h",
+        account_uuid="ceae4b9d", sso_token_url="https://sso-sprint.dynatracelabs.com/sso/oauth2/token",
+        account_api_host="https://api-hardening.internal.dynatracelabs.com",
+        oauth_client_id="dt0s02.X", oauth_client_secret="dt0s02.X.SEC")
+
+
+def test_platform_token_requires_all_config():
+    from .dt_token_provisioner import PlatformTokenProvisioner
+    try:
+        PlatformTokenProvisioner("https://t", "", "", "", "", "", "")
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError")
+
+
+def _pt_handler():
+    n = {"i": 0}
+    def h(method, url, **kw):
+        if method == "POST" and url.endswith("/sso/oauth2/token"):
+            return _Resp(200, {"access_token": "BEARER", "expires_in": 3600})
+        if method == "POST" and url.endswith("/platform-tokens"):
+            n["i"] += 1
+            return _Resp(200, {"name": "x", "tokenId": f"dt0s16.ID{n['i']}", "token": f"dt0s16.ID{n['i']}.VAL{n['i']}"})
+        if method == "DELETE":
+            return _Resp(200)
+        return _Resp(404, text="unexpected")
+    return h
+
+
+def test_platform_token_create_uses_account_api_and_env_resource():
+    restore, calls = _install_fake(_pt_handler())
+    try:
+        res = asyncio.run(_pt().create_tokens("dynatrace-wwse/enablement-kubernetes-101", "devlove@dynatracelabs.com", SPECS))
+    finally:
+        restore()
+    # tokens minted into env vars
+    assert res.env["DT_OPERATOR_TOKEN"].startswith("dt0s16.")
+    assert res.env["DT_INGEST_TOKEN"].startswith("dt0s16.")
+    assert len(res.token_ids) == 2
+    # create POSTs hit the account platform-tokens endpoint with the env URN as resource
+    creates = [c for c in calls if c[0] == "POST" and c[1].endswith("/platform-tokens")]
+    assert creates and all("/iam/v1/accounts/ceae4b9d/platform-tokens" in c[1] for c in creates)
+    body = creates[0][2]["json"]
+    assert body["resource"] == ["urn:dtenvironment:ydi9582h"]
+    assert "expirationDate" in body and isinstance(body["scope"], list)
+    # bearer fetched with platform-token scope + account resource
+    tok = [c for c in calls if c[1].endswith("/sso/oauth2/token")][0][2]["data"]
+    assert "platform-token:tokens:write" in tok["scope"]
+    assert tok["resource"] == "urn:dtaccount:ceae4b9d"
+
+
+def test_platform_token_revoke_deletes_each():
+    restore, calls = _install_fake(_pt_handler())
+    try:
+        asyncio.run(_pt().revoke_tokens(["dt0s16.A", "dt0s16.B", ""]))
+    finally:
+        restore()
+    dels = [c for c in calls if c[0] == "DELETE"]
+    assert len(dels) == 2  # empty id skipped
+    assert all("/platform-tokens/dt0s16." in c[1] for c in dels)


### PR DESCRIPTION
The sprint mint fix, core implemented + **verified live**.

## Root cause (final)
Classic apiToken creation is disabled on sprint for **all** callers — the dt0s16 platform token AND an OAuth client with `environment-api:api-tokens:write` both get `400 "Creation only available in Account Management"`. (The earlier 403 was just a pre-scope check.) So gen3 trainings must mint **platform tokens** via the Account Management API.

## What this adds
`PlatformTokenProvisioner` (mirrors `DTTokenProvisioner`):
- bearer: `client_credentials` on the account SSO, `scope="platform-token:tokens:write platform-token:tokens:manage"`, `resource="urn:dtaccount:{uuid}"`.
- create: `POST {accountApi}/iam/v1/accounts/{uuid}/platform-tokens` `{name, scope[], resource:["urn:dtenvironment:{envId}"], tags[], expirationDate}` → `{tokenId, token}`.
- revoke: `DELETE .../platform-tokens/{tokenId}`.

## Verified LIVE on sprint (ydi9582h / account ceae4b9d)
- Token **create + revoke** succeeded (2 test tokens minted then deleted, DELETE→200).
- `settings:objects:write` on the **same** OAuth client also confirmed (200) → **one account OAuth client covers deploy + settings + mint** = one implementation.
- `userUuid` not required for the service client.

Config per account in `/home/ops/.env` (secret-safe): `MINT_CLIENT_ID_*`, `MINT_CLIENT_SECRET_*`, `MINT_RESOURCE_*`, `MINT_SSO_*`, `MINT_API_HOST_*`. +3 unit tests (8/8 suite).

## Next (wiring)
Arena provision flow: detect gen3 (classic disabled / domain) → use `PlatformTokenProvisioner` with the per-account `MINT_*` creds instead of `DTTokenProvisioner`; surface the client_id read-only in Admin.
