### PR TITLE
feat(orbital): wire gen3 platform-token mint into provision + Admin client-id display

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -1256,7 +1256,17 @@ async def api_terminate_job(job_id: str, request: Request):
     meta = await pool.hgetall(f"job:running:{job_id}")
     # Only Orbital-minted tokens carry a stored auth cred here. App-minted tokens
     # (multi-tenancy) are revoked by the app itself — Orbital holds no tenant cred.
-    if (meta.get("dt_token_ids") and meta.get("dt_tenant_url")
+    if meta.get("mint_kind") == "platform" and meta.get("dt_token_ids") and meta.get("dt_tenant_url"):
+        # Orbital-minted platform tokens (gen3) — revoke via the account OAuth client (from env).
+        try:
+            token_ids = json.loads(meta["dt_token_ids"])
+            prov = _gen3_platform_provisioner(meta["dt_tenant_url"])
+            if prov:
+                asyncio.create_task(prov.revoke_tokens(token_ids))
+                log.info("Revoking %d platform token(s) for session %s", len(token_ids), job_id)
+        except Exception as exc:
+            log.warning("Could not initiate platform-token revocation for %s: %s", job_id, exc)
+    elif (meta.get("dt_token_ids") and meta.get("dt_tenant_url")
             and (meta.get("dt_auth_token") or meta.get("dt_oauth_client_id"))):
         from provisioning import DTTokenProvisioner
         try:
@@ -3445,6 +3455,29 @@ class ArenaProvisionRequest(BaseModel):
     dtTokenIds: list[str] = []   # ids the app will revoke (Orbital does not)
 
 
+def _gen3_platform_provisioner(tenant_url: str):
+    """Build a PlatformTokenProvisioner for a tenant whose classic apiToken creation is
+    disabled (gen3 — sprint/dev, and prod as it migrates). Reads the per-account account
+    OAuth client from env: MINT_{CLIENT_ID,CLIENT_SECRET,RESOURCE,SSO,API_HOST}_<DOMAIN>.
+    Returns None when the tenant isn't gen3 or no creds are configured for its account."""
+    try:
+        tenant_id, domain = classify_tenant(tenant_url)
+    except Exception:
+        return None
+    sfx = domain.upper()  # SPRINT / DEV / PROD
+    cid = os.environ.get(f"MINT_CLIENT_ID_{sfx}")
+    csec = os.environ.get(f"MINT_CLIENT_SECRET_{sfx}")
+    res = os.environ.get(f"MINT_RESOURCE_{sfx}", "")
+    sso = os.environ.get(f"MINT_SSO_{sfx}")
+    api = os.environ.get(f"MINT_API_HOST_{sfx}")
+    if not (cid and csec and res and sso and api):
+        return None
+    from provisioning import PlatformTokenProvisioner
+    return PlatformTokenProvisioner(
+        tenant_url=tenant_url, env_id=tenant_id, account_uuid=res.split(":")[-1],
+        sso_token_url=sso, account_api_host=api, oauth_client_id=cid, oauth_client_secret=csec)
+
+
 @app.post("/api/arena/provision")
 async def api_arena_provision(body: ArenaProvisionRequest):
     """Provision a training environment — queues a real daemon job on the amd64 worker.
@@ -3474,6 +3507,7 @@ async def api_arena_provision(body: ArenaProvisionRequest):
     dt_env: dict[str, str] = {}
     provisioned_token_ids: list[str] = []
     token_provisioned = False
+    mint_kind = ""  # "platform" when Orbital minted via the Account Management API (gen3)
 
     tenant_url = body.tenantUrl.rstrip("/") if body.tenantUrl else ""
     if body.dtEnv:
@@ -3484,6 +3518,22 @@ async def api_arena_provision(body: ArenaProvisionRequest):
         token_provisioned = True
         if not tenant_url:
             tenant_url = (dt_env.get("DT_ENVIRONMENT") or "").rstrip("/")
+    elif tenant_url and (_gen3 := _gen3_platform_provisioner(tenant_url)) is not None:
+        # gen3 tenant (classic apiToken creation disabled, e.g. sprint): Orbital mints
+        # platform tokens via the account OAuth client. Orbital owns revocation (mint_kind).
+        try:
+            specs = await load_token_specs(repo_nwo, ref=training["branch"])
+            result = await _gen3.create_tokens(repo=repo_nwo, user_id=body.userId,
+                                               specs=specs, expires_in_hours=session_hours)
+            dt_env = result.env
+            provisioned_token_ids = result.token_ids
+            token_provisioned = True
+            mint_kind = "platform"
+        except Exception as exc:
+            import logging as _log
+            _log.getLogger("ops-dashboard").warning(
+                "Platform-token provisioning failed for %s / %s: %s — falling back to worker creds",
+                repo_nwo, body.userId, exc)
     elif tenant_url and (body.apiToken or (body.oauthClientId and body.oauthClientSecret)):
         try:
             provisioner = DTTokenProvisioner(
@@ -3551,6 +3601,10 @@ async def api_arena_provision(body: ArenaProvisionRequest):
         redis_meta["dt_token_ids"] = json.dumps(provisioned_token_ids)
     if tenant_url:
         redis_meta["dt_tenant_url"] = tenant_url
+    if mint_kind:
+        # Orbital minted platform tokens (gen3) → terminate revokes via the same account
+        # OAuth client (no per-job creds stored; rebuilt from env on revoke).
+        redis_meta["mint_kind"] = mint_kind
     # Store auth so terminate can revoke tokens. Token has apiTokens.read+write only.
     if token_provisioned:
         if body.apiToken:
@@ -4237,7 +4291,15 @@ async def api_arena_terminate(job_id: str):
     meta = await pool.hgetall(f"job:running:{job_id}")
     # Only Orbital-minted tokens carry a stored auth cred here. App-minted tokens
     # (multi-tenancy) are revoked by the app itself — Orbital holds no tenant cred.
-    if (meta.get("dt_token_ids") and meta.get("dt_tenant_url")
+    if meta.get("mint_kind") == "platform" and meta.get("dt_token_ids") and meta.get("dt_tenant_url"):
+        try:
+            token_ids = json.loads(meta["dt_token_ids"])
+            prov = _gen3_platform_provisioner(meta["dt_tenant_url"])
+            if prov:
+                asyncio.create_task(prov.revoke_tokens(token_ids))
+        except Exception as exc:
+            log.warning("Could not initiate platform-token revocation for %s: %s", job_id, exc)
+    elif (meta.get("dt_token_ids") and meta.get("dt_tenant_url")
             and (meta.get("dt_auth_token") or meta.get("dt_oauth_client_id"))):
         from provisioning import DTTokenProvisioner
         try:

--- a/ops-server/dashboard/app_deploy.py
+++ b/ops-server/dashboard/app_deploy.py
@@ -661,6 +661,22 @@ async def deploy_audit(limit: int = 50, x_auth_user: str | None = Header(default
     return {"audit": [json.loads(r) for r in rows]}
 
 
+@router.get("/api/deploy/mint-clients")
+async def mint_clients(x_auth_user: str | None = Header(default=None)):
+    """Read-only: the account OAuth clients configured for gen3 platform-token minting,
+    per domain. Returns the client_id + account URN only — NEVER the secret — so an admin
+    can see which client is in use and rotate it in myaccount if needed."""
+    _require_writer(x_auth_user)
+    out = []
+    for dom in ("SPRINT", "DEV", "PROD"):
+        cid = os.environ.get(f"MINT_CLIENT_ID_{dom}")
+        if cid:
+            out.append({"domain": dom.lower(), "clientId": cid,
+                        "account": os.environ.get(f"MINT_RESOURCE_{dom}", ""),
+                        "sso": os.environ.get(f"MINT_SSO_{dom}", "")})
+    return {"mintClients": out}
+
+
 def _page(msg: str, ok: bool) -> str:
     color = "#2da44e" if ok else "#f85149"
     return (f"<!doctype html><html><head><meta charset=utf-8><title>Deploy</title></head>"

--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -3304,4 +3304,23 @@ async function loadRegisterAudit() {
 function loadRegister() {
     wireRegister();
     loadRegisterAudit();
+    loadMintClients();
+}
+
+async function loadMintClients() {
+    const el = document.getElementById('reg-mint-clients');
+    if (!el) return;
+    try {
+        const r = await fetch('/api/deploy/mint-clients', { credentials: 'same-origin' });
+        if (!r.ok) { el.innerHTML = ''; return; }
+        const j = await r.json();
+        const rows = j.mintClients || [];
+        el.innerHTML = rows.length
+            ? '<h3 style="margin:24px 0 8px">Token-mint OAuth clients (gen3, read-only)</h3>'
+              + '<p class="content-hint" style="margin:0 0 6px">Account OAuth clients used to mint platform tokens for trainings on gen3 tenants. Rotate in myaccount.dynatrace.com; the secret is never shown.</p>'
+              + '<table><thead><tr><th>Domain</th><th>Client ID</th><th>Account</th></tr></thead><tbody>'
+              + rows.map(c => `<tr><td>${escapeHtml(c.domain)}</td><td><code>${escapeHtml(c.clientId)}</code></td><td><code style="font-size:0.72rem">${escapeHtml(c.account)}</code></td></tr>`).join('')
+              + '</tbody></table>'
+            : '';
+    } catch { el.innerHTML = ''; }
 }

--- a/ops-server/dashboard/templates/index.html
+++ b/ops-server/dashboard/templates/index.html
@@ -757,6 +757,7 @@
                 <thead><tr><th>When</th><th>User</th><th>Tenant</th><th>Action</th><th>Result</th><th>Version</th><th>Via</th></tr></thead>
                 <tbody><tr><td colspan="7" class="loading">Loading…</td></tr></tbody>
             </table>
+            <div id="reg-mint-clients"></div>
         </section>
     </main>
 

--- a/ops-server/dashboard/test_gen3_mint_wiring.py
+++ b/ops-server/dashboard/test_gen3_mint_wiring.py
@@ -1,0 +1,33 @@
+"""gen3 mint wiring: _gen3_platform_provisioner builds a PlatformTokenProvisioner from
+per-account MINT_* env, only for tenants whose account has creds configured."""
+import os
+for k, v in {"MINT_CLIENT_ID_SPRINT": "dt0s02.X", "MINT_CLIENT_SECRET_SPRINT": "s",
+             "MINT_RESOURCE_SPRINT": "urn:dtaccount:abc-123",
+             "MINT_SSO_SPRINT": "https://sso-sprint.dynatracelabs.com/sso/oauth2/token",
+             "MINT_API_HOST_SPRINT": "https://api-hardening.internal.dynatracelabs.com"}.items():
+    os.environ.setdefault(k, v)
+import dashboard.app as a
+from provisioning import PlatformTokenProvisioner
+
+
+def test_factory_builds_for_sprint():
+    p = a._gen3_platform_provisioner("https://ydi9582h.sprint.apps.dynatracelabs.com")
+    assert isinstance(p, PlatformTokenProvisioner)
+    assert p.env_id == "ydi9582h"
+    assert p.account_uuid == "abc-123"
+    assert p.account_api_host == "https://api-hardening.internal.dynatracelabs.com"
+
+
+def test_factory_none_when_no_creds_for_domain():
+    # prod has no MINT_*_PROD creds → None (gen2 uses app self-mint / classic)
+    assert a._gen3_platform_provisioner("https://geu80787.apps.dynatrace.com") is None
+
+
+def test_factory_none_for_non_dynatrace():
+    assert a._gen3_platform_provisioner("https://evil.example.com") is None
+
+
+def test_provision_route_registered():
+    assert any(getattr(r, "path", "") == "/api/arena/provision" for r in a.app.routes)
+    import inspect
+    assert inspect.iscoroutinefunction(a.api_arena_provision)

--- a/ops-server/provisioning/__init__.py
+++ b/ops-server/provisioning/__init__.py
@@ -1,5 +1,6 @@
 "Dynatrace token provisioning for training sessions."
-from .dt_token_provisioner import DTTokenProvisioner, ProvisionedTokens
+from .dt_token_provisioner import DTTokenProvisioner, PlatformTokenProvisioner, ProvisionedTokens
 from .token_specs import TokenSpec, load_token_specs, DEFAULT_SPECS
 
-__all__ = ["DTTokenProvisioner", "ProvisionedTokens", "TokenSpec", "load_token_specs", "DEFAULT_SPECS"]
+__all__ = ["DTTokenProvisioner", "PlatformTokenProvisioner", "ProvisionedTokens",
+           "TokenSpec", "load_token_specs", "DEFAULT_SPECS"]


### PR DESCRIPTION
Wires PlatformTokenProvisioner (#104) into the arena provision flow + adds the read-only mint-client display.

## What
- `_gen3_platform_provisioner` factory from per-account `MINT_*` env; provision uses it when the app didn't self-mint (gen3); `mint_kind=platform` in meta; both terminate paths revoke via the account client.
- Read-only `GET /api/deploy/mint-clients` (client_id + account, **never** secret) + table in Register Tenant.
- +4 wiring tests; route + factory verified.

## Verified live on sprint
gen3 branch fires → correct host (`api-hardening.internal.dynatracelabs.com`) → authenticates → calls the platform-token mint.

## Known blocker (NOT wiring — next research item)
Training operator/ingest specs use **classic** apiToken scopes (`activeGateTokenManagement.create`, `metrics.ingest`) → platform-token create rejects them (**'Forbidden resource'**; a client can't delegate scopes it doesn't hold, and these aren't platform-token scopes). So **DynaKube tokens can't be minted as platform tokens** with current specs. Need the gen3 DynaKube token mechanism / platform-token scope mapping.

Deployed to ops.