### PR TITLE
feat(orbital): create_activegate_token — unblock gen3 DynaKube operator path

### DIFF
--- a/ops-server/provisioning/dt_token_provisioner.py
+++ b/ops-server/provisioning/dt_token_provisioner.py
@@ -233,6 +233,37 @@ class PlatformTokenProvisioner:
             r.raise_for_status()
             return r.json()["access_token"]
 
+    async def _env_bearer(self, scope: str) -> str:
+        """Bearer scoped to the ENVIRONMENT (urn:dtenvironment) — for tenant-level APIs
+        such as ActiveGate-token creation (vs the account-scoped _bearer for platform tokens)."""
+        async with httpx.AsyncClient(timeout=15) as client:
+            r = await client.post(self.sso_token_url, data={
+                "grant_type": "client_credentials", "client_id": self._cid,
+                "client_secret": self._csec, "scope": scope,
+                "resource": f"urn:dtenvironment:{self.env_id}"})
+            r.raise_for_status()
+            return r.json()["access_token"]
+
+    async def create_activegate_token(self, name: str, expires_in_hours: int = 4) -> dict:
+        """Create an ENVIRONMENT ActiveGate token (dt0g02) on the tenant — for DynaKube's
+        ActiveGate. The classic apiTokens endpoint is disabled on gen3, but the
+        ActiveGate-token endpoint still works with an OAuth bearer holding
+        `environment-api:activegate-tokens:write`. Returns {id, token}. Verified live on
+        sprint 2026-06-19. This is what unblocks DynaKube provisioning on gen3 (the operator
+        no longer needs to self-mint an AG token — Orbital pre-creates it)."""
+        expires_iso = (datetime.now(timezone.utc) + timedelta(hours=expires_in_hours)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        bearer = await self._env_bearer("environment-api:activegate-tokens:write")
+        url = f"{self.tenant_url}/platform/classic/environment-api/v2/activeGateTokens"
+        async with httpx.AsyncClient(timeout=20) as client:
+            r = await client.post(url, headers={"Authorization": f"Bearer {bearer}",
+                                                "Content-Type": "application/json"},
+                                  json={"name": name[:100], "activeGateType": "ENVIRONMENT",
+                                        "expirationDate": expires_iso})
+            r.raise_for_status()
+            d = r.json()
+            log.info("Created ActiveGate token '%s' (id=%s)", name, d.get("id"))
+            return {"id": d.get("id"), "token": d.get("token")}
+
     async def create_tokens(self, repo: str, user_id: str, specs: list[TokenSpec],
                             expires_in_hours: int = 4) -> ProvisionedTokens:
         expires_at = datetime.now(timezone.utc) + timedelta(hours=expires_in_hours)

--- a/ops-server/provisioning/test_dt_token_provisioner.py
+++ b/ops-server/provisioning/test_dt_token_provisioner.py
@@ -250,3 +250,27 @@ def test_platform_token_revoke_deletes_each():
     dels = [c for c in calls if c[0] == "DELETE"]
     assert len(dels) == 2  # empty id skipped
     assert all("/platform-tokens/dt0s16." in c[1] for c in dels)
+
+
+def test_platform_create_activegate_token():
+    import httpx
+    captured = {}
+    def h(method, url, **kw):
+        if method == "POST" and url.endswith("/sso/oauth2/token"):
+            captured["sso"] = kw.get("data")
+            return _Resp(200, {"access_token": "AGBEARER", "expires_in": 3600})
+        if method == "POST" and url.endswith("/activeGateTokens"):
+            captured["create"] = kw.get("json")
+            return _Resp(200, {"id": "dt0g02.ABC", "token": "dt0g02.ABC.SECRET"})
+        return _Resp(404)
+    restore, calls = _install_fake(h)
+    try:
+        out = asyncio.run(_pt().create_activegate_token("enbl-k8s-ag"))
+    finally:
+        restore()
+    assert out["id"] == "dt0g02.ABC" and out["token"].startswith("dt0g02.")
+    # AG-token endpoint hit with ENVIRONMENT type; bearer scoped to the ENVIRONMENT resource
+    assert captured["create"]["activeGateType"] == "ENVIRONMENT"
+    assert captured["sso"]["scope"] == "environment-api:activegate-tokens:write"
+    assert captured["sso"]["resource"] == "urn:dtenvironment:ydi9582h"
+    assert any(c[1].endswith("/platform/classic/environment-api/v2/activeGateTokens") for c in calls)


### PR DESCRIPTION
**Operator path unblocked.** Captured the ActiveGate-token endpoint that still works on gen3.

## The capture (verified live on sprint)
- `POST {tenant}/platform/classic/environment-api/v2/activeGateTokens` `{name, activeGateType:"ENVIRONMENT", expirationDate}` + OAuth bearer with `environment-api:activegate-tokens:write` (resource `urn:dtenvironment:{id}`) → **`dt0g02` token minted** (id `dt0g02.VUFZBYCH` in the test). This endpoint is **NOT** 400-disabled like the classic apiTokens one.

## Full gen3 DynaKube token set — all mintable by the OAuth client
| Token | How | Verified |
|---|---|---|
| **ActiveGate** (`dt0g02`) | `create_activegate_token` (this PR) | ✅ minted live |
| **operator** (platform `dt0s16`) | `storage:entities:read` + `settings:objects:read/write` + `storage:metrics:read` (no installer/AG-create for applicationMonitoring + a pre-provided AG token) | ✅ minted live |
| **data-ingest** (platform `dt0s16`) | `storage:metrics:write` + `storage:logs:write` (+ otel TBD) | ✅ minted live |

## This PR
`PlatformTokenProvisioner.create_activegate_token` + `_env_bearer` (environment-scoped client_credentials). +1 test (suite 9/9). Deployed to ops.

## Next (integration)
Map each repo's `dt-tokens.yaml` classic scopes → the platform/AG equivalents above, mint AG + operator + ingest in the gen3 provision branch, and wire them into the DynaKube secret keys. Then k8s-101 launches on sprint.
