### PR TITLE
feat(orbital): gen3 token integration — classic→platform scope map + ActiveGate pre-mint

### DIFF
--- a/ops-server/provisioning/dt_token_provisioner.py
+++ b/ops-server/provisioning/dt_token_provisioner.py
@@ -25,7 +25,7 @@ from typing import Optional
 
 import httpx
 
-from .token_specs import TokenSpec
+from .token_specs import TokenSpec, to_platform_scopes
 
 log = logging.getLogger("ops-provisioning")
 
@@ -278,10 +278,19 @@ class PlatformTokenProvisioner:
         env: dict[str, str] = {}
         token_ids: list[str] = []
         errors: list[str] = []
+        needs_ag = False
         async with httpx.AsyncClient(timeout=20) as client:
             for spec in specs:
+                # Classic apiToken scopes are meaningless to the platform-token API — translate
+                # to platform scopes. activeGateTokenManagement.* has no platform equivalent →
+                # flags an ActiveGate-token pre-mint instead.
+                platform_scopes, spec_needs_ag = to_platform_scopes(spec.scopes)
+                needs_ag = needs_ag or spec_needs_ag
+                if not platform_scopes:
+                    log.info("Spec '%s' has no platform scopes after translation — skipping platform token", spec.name_suffix)
+                    continue
                 name = f"{prefix}-{spec.name_suffix}"[:100]
-                payload = {"name": name, "scope": spec.scopes, "resource": resource,
+                payload = {"name": name, "scope": platform_scopes, "resource": resource,
                            "tags": ["enablement", repo_short], "expirationDate": expires_iso}
                 try:
                     r = await client.post(self._tokens_url, headers=headers, json=payload)
@@ -289,9 +298,22 @@ class PlatformTokenProvisioner:
                     data = r.json()
                     env[spec.env_var] = data["token"]
                     token_ids.append(data.get("tokenId") or data.get("id"))
-                    log.info("Created platform token '%s' (id=%s)", name, token_ids[-1])
+                    log.info("Created platform token '%s' (id=%s, scopes=%s)", name, token_ids[-1], platform_scopes)
                 except httpx.HTTPStatusError as exc:
                     errors.append(f"platform token '{name}': HTTP {exc.response.status_code} — {exc.response.text[:200]}")
+        # An operator spec that needed activeGateTokenManagement → pre-mint an ActiveGate token
+        # (dt0g02), exposed as DT_ACTIVEGATE_TOKEN, since the platform operator token can't carry
+        # that scope. The training wires it into DynaKube (operator no longer self-mints it).
+        if needs_ag and not errors:
+            try:
+                ag = await self.create_activegate_token(f"{prefix}-activegate"[:100], expires_in_hours)
+                if ag.get("token"):
+                    env["DT_ACTIVEGATE_TOKEN"] = ag["token"]
+                    if ag.get("id"):
+                        token_ids.append(ag["id"])
+                    log.info("Pre-minted ActiveGate token (id=%s)", ag.get("id"))
+            except Exception as exc:
+                errors.append(f"ActiveGate token: {exc}")
         if errors:
             if token_ids:
                 await self.revoke_tokens(token_ids)
@@ -307,6 +329,10 @@ class PlatformTokenProvisioner:
         async with httpx.AsyncClient(timeout=15) as client:
             for tid in token_ids:
                 if not tid:
+                    continue
+                if tid.startswith("dt0g02"):
+                    # ActiveGate token — not deletable via the account platform-tokens API
+                    # (different resource); it expires on its short TTL. Skip.
                     continue
                 try:
                     r = await client.delete(f"{self._tokens_url}/{tid}", headers=headers)

--- a/ops-server/provisioning/test_dt_token_provisioner.py
+++ b/ops-server/provisioning/test_dt_token_provisioner.py
@@ -274,3 +274,50 @@ def test_platform_create_activegate_token():
     assert captured["sso"]["scope"] == "environment-api:activegate-tokens:write"
     assert captured["sso"]["resource"] == "urn:dtenvironment:ydi9582h"
     assert any(c[1].endswith("/platform/classic/environment-api/v2/activeGateTokens") for c in calls)
+
+
+def test_platform_create_tokens_translates_scopes_and_premints_ag():
+    """gen3 create_tokens: classic operator/ingest scopes → platform scopes; operator's
+    activeGateTokenManagement → a pre-minted ActiveGate token (DT_ACTIVEGATE_TOKEN)."""
+    from provisioning.token_specs import DEFAULT_SPECS
+    sent = []
+    def h(method, url, **kw):
+        if method == "POST" and url.endswith("/sso/oauth2/token"):
+            return _Resp(200, {"access_token": "B", "expires_in": 3600})
+        if method == "POST" and url.endswith("/platform-tokens"):
+            body = kw.get("json"); sent.append(body)
+            n = len(sent)
+            return _Resp(200, {"tokenId": f"dt0s16.P{n}", "token": f"dt0s16.P{n}.V{n}"})
+        if method == "POST" and url.endswith("/activeGateTokens"):
+            sent.append(kw.get("json"))
+            return _Resp(200, {"id": "dt0g02.AG", "token": "dt0g02.AG.SECRET"})
+        return _Resp(404)
+    restore, calls = _install_fake(h)
+    try:
+        res = asyncio.run(_pt().create_tokens("dynatrace-wwse/enablement-kubernetes-101",
+                                              "devlove@dynatracelabs.com", DEFAULT_SPECS))
+    finally:
+        restore()
+    # operator + ingest platform tokens minted with TRANSLATED (platform) scopes — no classic dotted scope leaks
+    pt_bodies = [b for b in sent if "scope" in b]
+    all_scopes = [s for b in pt_bodies for s in b["scope"]]
+    assert all(":" in s for s in all_scopes), all_scopes
+    assert "storage:metrics:write" in all_scopes and "storage:entities:read" in all_scopes
+    assert "activeGateTokenManagement.write" not in all_scopes and "metrics.ingest" not in all_scopes
+    # operator triggered an ActiveGate-token pre-mint, exposed as DT_ACTIVEGATE_TOKEN
+    assert res.env["DT_ACTIVEGATE_TOKEN"].startswith("dt0g02.")
+    assert res.env["DT_OPERATOR_TOKEN"].startswith("dt0s16.")
+    assert res.env["DT_INGEST_TOKEN"].startswith("dt0s16.")
+    assert any(c[1].endswith("/activeGateTokens") for c in calls)
+    # AG token id present but revoke skips it (dt0g02 not deletable via platform-tokens API)
+    assert "dt0g02.AG" in res.token_ids
+
+
+def test_platform_revoke_skips_activegate_ids():
+    restore, calls = _install_fake(_pt_handler())
+    try:
+        asyncio.run(_pt().revoke_tokens(["dt0s16.A", "dt0g02.AG", "dt0s16.B"]))
+    finally:
+        restore()
+    dels = [c for c in calls if c[0] == "DELETE"]
+    assert len(dels) == 2 and all("dt0g02" not in c[1] for c in dels)

--- a/ops-server/provisioning/token_specs.py
+++ b/ops-server/provisioning/token_specs.py
@@ -61,6 +61,58 @@ DEFAULT_SPECS: list[TokenSpec] = [
 ]
 
 
+# ── gen3 scope translation ──────────────────────────────────────────────────────
+# On tenants where classic apiToken creation is disabled, training tokens are minted as
+# platform tokens (dt0s16). Classic apiToken scopes have no meaning there — map each to its
+# platform-scope equivalent. A value of None = no platform equivalent: the capability is
+# either not needed for applicationMonitoring (DataExport/InstallerDownload) or is covered by
+# a pre-minted ActiveGate token (activeGateTokenManagement.*). Verified mintable live on
+# sprint 2026-06-19 (see docs/gen3-token-research.md in the app repo).
+_CLASSIC_TO_PLATFORM: dict[str, Optional[str]] = {
+    "entities.read":        "storage:entities:read",
+    "settings.read":        "settings:objects:read",
+    "settings.write":       "settings:objects:write",
+    "ReadConfig":           "settings:objects:read",
+    "WriteConfig":          "settings:objects:write",
+    "metrics.read":         "storage:metrics:read",
+    "metrics.ingest":       "storage:metrics:write",
+    "logs.read":            "storage:logs:read",
+    "logs.ingest":          "storage:logs:write",
+    "events.ingest":        "storage:events:write",
+    # No platform-token equivalent → dropped (covered elsewhere / not needed for apponly):
+    "activeGateTokenManagement.write":  None,   # → triggers ActiveGate-token pre-mint
+    "activeGateTokenManagement.create": None,   # → triggers ActiveGate-token pre-mint
+    "DataExport":           None,
+    "InstallerDownload":    None,
+    "openTelemetryTrace.ingest": None,          # platform OTel-ingest scope TBD (storage:spans:write invalid)
+}
+# Classic scopes meaning "this token must manage ActiveGate tokens" → on gen3 we pre-mint an
+# ActiveGate token instead (the platform operator token can't carry it).
+_AG_TRIGGER_SCOPES = {"activeGateTokenManagement.write", "activeGateTokenManagement.create"}
+
+
+def to_platform_scopes(scopes: list[str]) -> tuple[list[str], bool]:
+    """Translate classic apiToken scopes → platform-token scopes for gen3 minting.
+
+    Returns (platform_scopes, needs_activegate_token). Scopes already in platform form
+    (contain ':') pass through unchanged. Unknown classic scopes are dropped (logged)."""
+    out: list[str] = []
+    needs_ag = False
+    for s in scopes:
+        if s in _AG_TRIGGER_SCOPES:
+            needs_ag = True
+        if ":" in s:                      # already a platform scope
+            out.append(s)
+            continue
+        if s in _CLASSIC_TO_PLATFORM:
+            mapped = _CLASSIC_TO_PLATFORM[s]
+            if mapped:
+                out.append(mapped)
+        else:
+            log.warning("No gen3 platform-scope mapping for classic scope %r — dropped", s)
+    return sorted(set(out)), needs_ag
+
+
 def _parse_yaml(content: str) -> list[TokenSpec]:
     data = yaml.safe_load(content)
     specs = []


### PR DESCRIPTION
Completes gen3 minting so existing per-repo `dt-tokens.yaml` (classic scopes) works unchanged where classic apiToken creation is disabled.

- `token_specs.to_platform_scopes()` — classic→platform (entities.read→storage:entities:read, metrics.ingest→storage:metrics:write, settings.read/write→settings:objects:read/write…); activeGateTokenManagement.* → AG pre-mint flag; DataExport/InstallerDownload dropped (not needed for applicationMonitoring).
- `create_tokens` translates scopes per spec; pre-mints an **ActiveGate token** (`DT_ACTIVEGATE_TOKEN`) when an operator spec needed activeGateTokenManagement. `revoke_tokens` skips `dt0g02` (AG tokens expire on TTL).

Net for DEFAULT_SPECS: operator → {settings:objects:read/write, storage:entities:read} + AG token; ingest → {storage:metrics:write, storage:logs:write, storage:events:write}.

+2 tests (suite 11/11). Deployed to ops.

**Next (live validation):** launch k8s-101 on sprint → confirm DynaKube accepts platform tokens + wire DT_ACTIVEGATE_TOKEN into the DynaKube secret (repo `functions.sh`).