### PR TITLE
fix(orbital): Synchronizer recent runs empty — dedicated sync:jobs:completed list

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -1736,8 +1736,12 @@ async def api_sync_run(request: Request):
 
 @app.get("/api/sync/history")
 async def api_sync_history(limit: int = 50):
-    """Past sync command runs from jobs:completed."""
+    """Past sync command runs. Sync jobs are rare and roll off the 500-cap jobs:completed
+    list, so merge the dedicated sync:jobs:completed archive (cap 200; dedupe by job_id) —
+    same pattern as Agentic History. Otherwise 'recent runs' looks empty."""
     completed_raw = await pool.lrange("jobs:completed", -500, -1)
+    sync_raw = await pool.lrange("sync:jobs:completed", -200, -1)
+    completed_raw = _merge_agent_history(completed_raw, sync_raw)
     rows = []
     for raw in reversed(completed_raw):
         try:

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -38,6 +38,9 @@ LOCK_TTL_SECONDS = 7200
 # isn't crowded out of the 500-cap jobs:completed list by integration/framework runs.
 AGENT_JOB_TYPES = {"fix-ci", "fix-issue", "review-pr", "migrate-gen3", "scaffold-lab",
                    "validate-after-push", "deploy-ghpages"}
+# Sync-command jobs are likewise rare and roll off the 500-cap jobs:completed list,
+# leaving the Synchronizer "recent runs" empty — keep a dedicated list (cap 200).
+SYNC_JOB_TYPES = {"sync-command"}
 
 # App proxy port pool — master Sysbox containers publish one port in this range
 # so the dashboard can reverse-proxy to k3d LB apps without SSH tunnelling.
@@ -559,6 +562,10 @@ class WorkerManager:
                 if job.get("type") in AGENT_JOB_TYPES:
                     await self.pool.rpush("agent:jobs:completed", _rec)
                     await self.pool.ltrim("agent:jobs:completed", -300, -1)
+                # Same fix for sync-command jobs → Synchronizer "recent runs".
+                if job.get("type") in SYNC_JOB_TYPES:
+                    await self.pool.rpush("sync:jobs:completed", _rec)
+                    await self.pool.ltrim("sync:jobs:completed", -200, -1)
                 # Terminal-status record that OUTLIVES job:running (deleted below),
                 # so session-status can report a failed creation and point the
                 # student at the retained log (job:log:{id}) instead of a bare


### PR DESCRIPTION
Sync-command jobs roll off the shared 500-cap `jobs:completed` (crowded out by integration/framework runs) → Synchronizer 'recent runs' looked empty. Same root cause + fix as Agentic History: archive to a dedicated `sync:jobs:completed` (cap 200) in manager.py; `api_sync_history` merges it (dedupe by job_id via existing `_merge_agent_history`). Verified merge + dedupe. Deployed to ops.