### PR TITLE
Fix: show Sign in button by default to remove auth race (UI)

### DIFF
--- a/ops-server/dashboard/templates/index.html
+++ b/ops-server/dashboard/templates/index.html
@@ -31,8 +31,10 @@
                 <div id="health-status" class="health-badge">checking…</div>
                 <div id="auth-status" class="auth-status">
                     <!-- /oauth2/start redirects straight to GitHub (302); /oauth2/sign_in renders
-                         oauth2-proxy's generic interstitial page, which looks "stuck" to users. -->
-                    <a href="/oauth2/start" class="btn-auth" id="sign-in-btn" hidden>Sign in with GitHub</a>
+                         oauth2-proxy's generic interstitial page, which looks "stuck" to users.
+                         Shown by default — JS hides it after /oauth2/userinfo confirms a session.
+                         Optimistic logged-out state avoids a blank top-right while auth resolves. -->
+                    <a href="/oauth2/start" class="btn-auth" id="sign-in-btn">Sign in with GitHub</a>
                     <span id="user-info" class="user-info" hidden>
                         <span id="user-name" class="user-name"></span>
                         <a href="/oauth2/sign_out?rd=/" class="btn btn-small btn-secondary">Sign out</a>


### PR DESCRIPTION
Fixes #114

## Problem
The Sign in anchor in the dashboard header (`#sign-in-btn` in `ops-server/dashboard/templates/index.html`) started with the `hidden` attribute and was only un-hidden after `loadAuthState()` finished its two sequential `fetch`es to `/oauth2/userinfo` and `/api/auth/role`. Any latency, transient JS error, or deferred init left the top-right blank — users saw no Sign in button until a reload happened to land after auth resolved. The comment at `app.js:110-114` already documents this class of failure ("header stuck on 'checking…', sign-in button never appears").

## Fix
Default the button to visible (optimistic logged-out state). `renderAuthHeader()` still hides it once `/oauth2/userinfo` confirms a session, so signed-in users see the same final state with at most a one-frame flicker. If JS never resolves auth at all, the user can still click Sign in instead of being stuck looking at an empty header.

## Test plan
- [ ] Load the dashboard signed out — Sign in button is visible immediately (no flash of empty header).
- [ ] Load the dashboard signed in — Sign in button briefly visible, then replaced by user info badge.
- [ ] Throttle network to "Slow 3G" in DevTools and reload — Sign in button still visible during the in-flight `/oauth2/userinfo` request.