### PR TITLE
chore: drop dynatrace-app tag from app-training-template (stop nightly false-fail)

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -130,7 +130,7 @@ repos:
     status: active
     maintainer: "@shinojosa"
     description: "Trainer-authoring scaffold for building interactive Dynatrace in-app enablement trainings on Orbital. Includes runnable examples for every interactive block type: shell verification, kubectl, DQL, assessments, and custom functions."
-    tags: [devops, orbital, dynatrace-app]
+    tags: [devops, orbital]
     title: "App Training Template"
     primary_tag: devops
     is_template: true


### PR DESCRIPTION
`enablement-app-training-template` is a **block showcase** (documentation of every interactive block type), not a runnable end-to-end lab. The `dynatrace-app` tag enrolled it in the nightly `app-layer-test`, which it has failed **every night by design** — its demo checks and doc-example snippets can't all pass in a dummy-user run, and it has no `LAB_SOLUTION`.

Dropping the tag stops the false-failure so real regressions stand out.

**Scope:** config/data only (`repos.yaml`). The nightly scheduler reads `repos.yaml` at run time, so **no service restart** is needed; the production ops-path `repos.yaml` needs the usual sync to take effect. Golden reference lab remains **Kubernetes 101**; the 1xx labs stay tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)