### PR TITLE
Orbital fleet autoscaler — EC2 spot workers on the fly

### DIFF
--- a/ops-server/CLAUDE.md
+++ b/ops-server/CLAUDE.md
@@ -319,3 +319,37 @@ Rules:
 - IF graphify-out/wiki/index.md EXISTS, navigate it instead of reading raw files
 - For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
 - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+
+## Fleet autoscaler
+
+EC2 spot-worker scaling for the AMD worker pool. Logic in `dashboard/fleet.py`
+(aws CLI v2 at `/usr/local/bin/aws` via subprocess — **boto3 is not installed**,
+region `eu-west-2`); endpoints in `dashboard/app.py`; pure-logic tests in
+`dashboard/test_fleet.py` (`python3 -m pytest dashboard/test_fleet.py` or
+`/home/ops/ops-venv/bin/python -m dashboard.test_fleet`).
+
+| Endpoint | Auth | Description |
+|----------|------|-------------|
+| `GET /api/fleet` | none | EC2 instances (tag `project=autonomous-enablements` or Name prefix) joined with registered `worker:{id}` hashes (match: `private_ip` == worker `host`) |
+| `POST /api/fleet/scale-up` | writer | `{count, instanceType?}` — launches spot workers from golden AMI `ami-0ed76cf85fa7d2967`; subnet/SGs/key resolved live from worker-1 (`i-02b773319c758fe40`); **hard cap 4 per call** |
+| `POST /api/fleet/scale-down` | writer | `{instanceIds, force?}` — marks matched workers `draining=1`, 409s if a matched worker has `active_jobs > 0` (unless `force`), then terminates. Refuses any id not tagged `orbital-role=worker` / `Name=orbital-worker-spot` |
+| `POST /api/fleet/worker/{id}/start` `/stop` | writer | start/stop pet workers (`autonomous-enablements-worker*`, e.g. stopped worker-3 `i-03689a1374d39cb6a`) |
+
+Spot user-data (built by `_build_user_data()`): IMDSv2-derived unique
+`WORKER_ID=worker-x86_64-spot-<iid tail>` sed-set in `/home/ops/.env`,
+`MASTER_REDIS_URL` host forced to `172.31.36.172`, then
+`systemctl restart ops-worker-agent`.
+
+**Credentials expire:** the service user's `~/.aws/credentials` holds federated
+STS creds. On `ExpiredToken` / `AuthFailure` / missing creds every endpoint
+returns 502 with `"AWS credentials expired or missing — refresh
+~/.aws/credentials"` — refresh the file and retry; nothing to restart.
+
+Deploy:
+```bash
+sudo cp /home/ubuntu/enablement-framework/codespaces-framework/ops-server/dashboard/app.py \
+        /home/ops/enablement-framework/codespaces-framework/ops-server/dashboard/app.py
+sudo cp /home/ubuntu/enablement-framework/codespaces-framework/ops-server/dashboard/fleet.py \
+        /home/ops/enablement-framework/codespaces-framework/ops-server/dashboard/fleet.py
+sudo systemctl restart ops-dashboard
+```

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -65,6 +65,9 @@ app.include_router(github_oauth_router)
 from dashboard.codespace_service import router as codespace_router  # noqa: E402
 app.include_router(codespace_router)
 
+# EC2 spot-worker fleet scaling (aws CLI, no boto3) — see dashboard/fleet.py.
+from dashboard import fleet  # noqa: E402
+
 _PROFILES_PAGE = """<!doctype html><html><head><meta charset=utf-8>
 <title>Content Profiles</title><style>
 body{font-family:system-ui,sans-serif;margin:0;background:#0d1117;color:#e6edf3}
@@ -4780,6 +4783,172 @@ async def api_health():
         }, headers=_cors)
     except Exception as e:
         return _JSONResponse(content={"status": "unhealthy", "error": str(e)}, headers=_cors)
+
+
+# ── Fleet autoscaler (EC2 spot workers) ──────────────────────────────────────
+# AWS access via the aws CLI in dashboard/fleet.py — safety rules (4-instance
+# cap, terminate-only-spot-workers, creds-expiry classification) live there
+# as pure functions with tests in dashboard/test_fleet.py.
+
+async def _fleet_workers() -> list[dict]:
+    """Registered worker:{id} hashes (same scan as /api/workers)."""
+    workers = []
+    async for key in pool.scan_iter("worker:*"):
+        # Skip port-pool lists (worker:<id>:app_ports_free) — Redis lists,
+        # not hashes; hgetall would raise WRONGTYPE.
+        if key.endswith(":app_ports_free"):
+            continue
+        try:
+            data = await pool.hgetall(key)
+        except Exception:
+            continue
+        if data:
+            data["worker_id"] = key.replace("worker:", "")
+            workers.append(data)
+    return workers
+
+
+@app.get("/api/fleet")
+async def api_fleet():
+    """EC2 fleet instances joined with registered worker agents.
+
+    Returns ``{instances, workers}``. Each instance carries ``worker_id`` /
+    ``agent_online`` when a registered worker's ``host`` matches the
+    instance's private IP, so the UI can see which boxes have a live agent.
+    """
+    try:
+        instances = await fleet.list_fleet()
+    except fleet.FleetError as e:
+        raise HTTPException(502, str(e))
+
+    workers = await _fleet_workers()
+    by_ip = {w.get("host"): w for w in workers if w.get("host")}
+    for inst in instances:
+        w = by_ip.get(inst.get("private_ip"))
+        inst["worker_id"] = w["worker_id"] if w else None
+        inst["agent_online"] = bool(w)
+    return {"instances": instances, "workers": workers}
+
+
+@app.post("/api/fleet/scale-up")
+async def api_fleet_scale_up(request: Request):
+    """Launch spot workers from the golden AMI.
+
+    Body: ``{count: int, instanceType?: str}`` — hard cap of 4 per call.
+    """
+    role = await _require_writer(request)
+    body = await request.json()
+    try:
+        count = int(body.get("count") or 0)
+    except (TypeError, ValueError):
+        raise HTTPException(400, "count must be an integer")
+    instance_type = (body.get("instanceType")
+                     or fleet.DEFAULT_INSTANCE_TYPE).strip()
+
+    try:
+        launched = await fleet.scale_up(count, instance_type)
+    except ValueError as e:          # bad count / over the safety cap
+        raise HTTPException(400, str(e))
+    except fleet.FleetError as e:    # AWS failure (incl. expired creds)
+        raise HTTPException(502, str(e))
+
+    log.info("fleet scale-up by %s: %d × %s → %s",
+             role["user"], count, instance_type,
+             [i["instance_id"] for i in launched])
+    return {
+        "status": "launched",
+        "count": count,
+        "instance_type": instance_type,
+        "instances": launched,
+        "requested_by": role["user"],
+    }
+
+
+@app.post("/api/fleet/scale-down")
+async def api_fleet_scale_down(request: Request):
+    """Terminate spot workers (tag-verified in fleet.scale_down).
+
+    Body: ``{instanceIds: [...], force?: bool}``. Each matched registered
+    worker (by private_ip == worker ``host``) is marked ``draining=1`` on
+    its ``worker:{id}`` hash first; instances whose matched worker still has
+    ``active_jobs > 0`` are refused unless ``force`` is true.
+    """
+    role = await _require_writer(request)
+    body = await request.json()
+    instance_ids = body.get("instanceIds") or []
+    force = bool(body.get("force"))
+    if not instance_ids or not isinstance(instance_ids, list):
+        raise HTTPException(400, "instanceIds (non-empty list) is required")
+
+    # Map instance → registered worker (best-effort, by private IP).
+    try:
+        instances = await fleet.list_fleet()
+    except fleet.FleetError as e:
+        raise HTTPException(502, str(e))
+    ip_by_id = {i["instance_id"]: i.get("private_ip") for i in instances}
+    workers_by_ip = {w.get("host"): w for w in await _fleet_workers()
+                     if w.get("host")}
+
+    busy, draining = [], []
+    for iid in instance_ids:
+        worker = workers_by_ip.get(ip_by_id.get(iid))
+        if not worker:
+            continue
+        active = int(worker.get("active_jobs") or 0)
+        if active > 0 and not force:
+            busy.append({"instance_id": iid,
+                         "worker_id": worker["worker_id"],
+                         "active_jobs": active})
+            continue
+        await pool.hset(f"worker:{worker['worker_id']}", "draining", "1")
+        draining.append(worker["worker_id"])
+
+    if busy:
+        raise HTTPException(409, detail={
+            "error": "workers_busy",
+            "busy": busy,
+            "hint": "retry with {\"force\": true} to terminate anyway",
+        })
+
+    try:
+        terminated = await fleet.scale_down(instance_ids)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    except fleet.FleetError as e:    # refused ids or AWS failure
+        raise HTTPException(502, str(e))
+
+    log.info("fleet scale-down by %s: %s (draining: %s)",
+             role["user"], instance_ids, draining)
+    return {
+        "status": "terminating",
+        "instances": terminated,
+        "draining_workers": draining,
+        "requested_by": role["user"],
+    }
+
+
+@app.post("/api/fleet/worker/{instance_id}/start")
+async def api_fleet_worker_start(instance_id: str, request: Request):
+    """Start a stopped pet worker (autonomous-enablements-worker*)."""
+    role = await _require_writer(request)
+    try:
+        result = await fleet.start_worker(instance_id)
+    except fleet.FleetError as e:
+        raise HTTPException(502, str(e))
+    log.info("fleet worker start by %s: %s", role["user"], instance_id)
+    return {"status": "starting", **result, "requested_by": role["user"]}
+
+
+@app.post("/api/fleet/worker/{instance_id}/stop")
+async def api_fleet_worker_stop(instance_id: str, request: Request):
+    """Stop a running pet worker (autonomous-enablements-worker*)."""
+    role = await _require_writer(request)
+    try:
+        result = await fleet.stop_worker(instance_id)
+    except fleet.FleetError as e:
+        raise HTTPException(502, str(e))
+    log.info("fleet worker stop by %s: %s", role["user"], instance_id)
+    return {"status": "stopping", **result, "requested_by": role["user"]}
 
 
 def start():

--- a/ops-server/dashboard/fleet.py
+++ b/ops-server/dashboard/fleet.py
@@ -1,0 +1,373 @@
+"""Fleet — EC2 spot-worker autoscaling for the Orbital worker pool.
+
+AWS access goes through the aws CLI v2 (``/usr/local/bin/aws``) via
+``asyncio.create_subprocess_exec`` — boto3 is deliberately NOT a dependency.
+Credentials come from the service user's ``~/.aws/credentials`` (federated
+STS — they EXPIRE). When the CLI fails with an auth/expiry error we surface
+one clear, stable message: :data:`CREDS_ERROR`.
+
+Design: every AWS-touching coroutine delegates its decision logic to small
+pure functions (``_build_user_data``, ``_classify_aws_error``,
+``_verify_terminatable``, ``_validate_scale_count``, ``_start_stop_allowed``,
+``_parse_instances``) so the safety rules are unit-testable without any
+subprocess or network (see ``dashboard/test_fleet.py``).
+"""
+
+import asyncio
+import base64
+import json
+
+AWS_CLI = "/usr/local/bin/aws"
+REGION = "eu-west-2"
+
+# Golden worker AMI (pre-baked Sysbox + ops-worker-agent).
+WORKER_AMI = "ami-0ed76cf85fa7d2967"
+# worker-1 — template instance whose subnet / security groups / key-name are
+# resolved dynamically at scale-up time so networking never drifts from prod.
+TEMPLATE_INSTANCE_ID = "i-02b773319c758fe40"
+# Master's private IP — spot workers must point MASTER_REDIS_URL here.
+MASTER_REDIS_HOST = "172.31.36.172"
+
+PROJECT_TAG = "autonomous-enablements"
+SPOT_WORKER_NAME = "orbital-worker-spot"
+WORKER_ROLE_TAG = "worker"           # value of the orbital-role tag
+WORKER_NAME_PREFIX = "autonomous-enablements-worker"
+
+# Hard safety limit: never launch more than this many instances per call.
+MAX_SCALE_UP = 4
+
+DEFAULT_INSTANCE_TYPE = "c5.2xlarge"
+
+CREDS_ERROR = (
+    "AWS credentials expired or missing — refresh ~/.aws/credentials"
+)
+
+_CRED_ERROR_MARKERS = (
+    "ExpiredToken",
+    "RequestExpired",
+    "AuthFailure",
+    "InvalidClientTokenId",
+    "Unable to locate credentials",
+)
+
+
+class FleetError(RuntimeError):
+    """AWS CLI failure (including expired federated credentials)."""
+
+
+# ── Pure helpers (unit-tested, no subprocess / no AWS) ───────────────────────
+
+def _classify_aws_error(stderr: str) -> str:
+    """Map raw ``aws`` CLI stderr to a user-facing error string.
+
+    Federated STS creds in ~/.aws/credentials expire; the CLI then fails with
+    ExpiredToken / AuthFailure / "Unable to locate credentials". Surface one
+    clear message for all of those; pass anything else through (trimmed).
+    """
+    text = (stderr or "").strip()
+    if any(marker in text for marker in _CRED_ERROR_MARKERS):
+        return CREDS_ERROR
+    return text or "aws CLI failed with no error output"
+
+
+def _validate_scale_count(count: int) -> int:
+    """Enforce the hard scale-up safety cap. Returns the validated count."""
+    if not isinstance(count, int) or isinstance(count, bool):
+        raise ValueError("count must be an integer")
+    if count < 1:
+        raise ValueError("count must be >= 1")
+    if count > MAX_SCALE_UP:
+        raise ValueError(
+            f"count {count} exceeds the hard safety limit of "
+            f"{MAX_SCALE_UP} instances per scale-up"
+        )
+    return count
+
+
+def _build_user_data() -> str:
+    """Cloud-init user-data shell script for a fresh spot worker.
+
+    - Derives a unique WORKER_ID from the instance id (IMDSv2, token-based).
+    - Ensures WORKER_ID= in /home/ops/.env (sed-replace existing line, else
+      append).
+    - Ensures MASTER_REDIS_URL points at the master's private IP
+      (sed-rewrites the host part of an existing redis:// URL — password
+      userinfo preserved — else appends a default URL).
+    - Restarts ops-worker-agent so it registers with the new identity.
+    """
+    return f"""#!/bin/bash
+set -uo pipefail
+ENV_FILE=/home/ops/.env
+
+# IMDSv2: fetch a session token, then the instance id (last 8 chars).
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" \\
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
+INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \\
+  "http://169.254.169.254/latest/meta-data/instance-id" | tail -c 8)
+WORKER_ID="worker-x86_64-spot-${{INSTANCE_ID}}"
+
+touch "$ENV_FILE"
+
+# Set the unique WORKER_ID (replace existing line or append).
+if grep -q '^WORKER_ID=' "$ENV_FILE"; then
+  sed -i "s|^WORKER_ID=.*|WORKER_ID=${{WORKER_ID}}|" "$ENV_FILE"
+else
+  echo "WORKER_ID=${{WORKER_ID}}" >> "$ENV_FILE"
+fi
+
+# Ensure MASTER_REDIS_URL points at the master ({MASTER_REDIS_HOST}),
+# preserving any redis://[:password@] userinfo already present.
+if grep -q '^MASTER_REDIS_URL=' "$ENV_FILE"; then
+  sed -i -E "s|^(MASTER_REDIS_URL=redis://([^@/]*@)?)[^:/@]+|\\1{MASTER_REDIS_HOST}|" "$ENV_FILE"
+else
+  echo "MASTER_REDIS_URL=redis://{MASTER_REDIS_HOST}:6379/0" >> "$ENV_FILE"
+fi
+
+systemctl restart ops-worker-agent
+"""
+
+
+def _encode_user_data(script: str) -> str:
+    """Base64-encode user-data (aws CLI v2 expects blobs pre-encoded)."""
+    return base64.b64encode(script.encode()).decode()
+
+
+def _tags_of(instance: dict) -> dict:
+    """Flatten an EC2 instance's Tags list into a {Key: Value} dict."""
+    return {t.get("Key"): t.get("Value") for t in instance.get("Tags", []) or []}
+
+
+def _parse_instances(reservations: list) -> list[dict]:
+    """Flatten describe-instances Reservations into fleet records."""
+    out = []
+    for res in reservations or []:
+        for inst in res.get("Instances", []) or []:
+            tags = _tags_of(inst)
+            out.append({
+                "instance_id": inst.get("InstanceId", ""),
+                "name": tags.get("Name", ""),
+                "type": inst.get("InstanceType", ""),
+                "state": (inst.get("State") or {}).get("Name", ""),
+                "private_ip": inst.get("PrivateIpAddress", ""),
+                # EC2 only sets InstanceLifecycle for spot/scheduled.
+                "lifecycle": inst.get("InstanceLifecycle") or "on-demand",
+                "launch_time": inst.get("LaunchTime", ""),
+            })
+    return out
+
+
+def _is_spot_worker(instance: dict) -> bool:
+    """True if a raw EC2 instance dict is one of OUR disposable spot workers.
+
+    Terminate is allowed only for instances tagged orbital-role=worker or
+    named orbital-worker-spot — never for the master or pet workers.
+    """
+    tags = _tags_of(instance)
+    return (
+        tags.get("orbital-role") == WORKER_ROLE_TAG
+        or tags.get("Name") == SPOT_WORKER_NAME
+    )
+
+
+def _verify_terminatable(descriptions: list) -> tuple[list[str], list[str]]:
+    """Split raw EC2 instance dicts into (ok_ids, refused_ids).
+
+    An id is terminatable only when the instance carries tag
+    orbital-role=worker or Name=orbital-worker-spot.
+    """
+    ok, refused = [], []
+    for inst in descriptions or []:
+        iid = inst.get("InstanceId", "")
+        (ok if _is_spot_worker(inst) else refused).append(iid)
+    return ok, refused
+
+
+def _start_stop_allowed(instance: dict) -> bool:
+    """True if start/stop is permitted: any autonomous-enablements-worker*
+    instance (e.g. the pre-provisioned stopped worker-3) or one of our
+    tagged spot workers."""
+    name = _tags_of(instance).get("Name", "") or ""
+    return name.startswith(WORKER_NAME_PREFIX) or _is_spot_worker(instance)
+
+
+# ── AWS CLI plumbing ─────────────────────────────────────────────────────────
+
+async def _aws(*args: str):
+    """Run the aws CLI and return parsed JSON stdout.
+
+    Raises :class:`FleetError` with a classified message on non-zero exit
+    (expired federated creds get the stable CREDS_ERROR string).
+    """
+    proc = await asyncio.create_subprocess_exec(
+        AWS_CLI, *args, "--region", REGION, "--output", "json",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    out, err = await proc.communicate()
+    if proc.returncode != 0:
+        raise FleetError(_classify_aws_error(err.decode(errors="replace")))
+    text = out.decode(errors="replace").strip()
+    return json.loads(text) if text else None
+
+
+async def _describe_by_ids(instance_ids: list[str]) -> list[dict]:
+    """describe-instances for explicit ids → flat list of raw instance dicts."""
+    data = await _aws(
+        "ec2", "describe-instances", "--instance-ids", *instance_ids,
+    )
+    return [
+        inst
+        for res in (data or {}).get("Reservations", [])
+        for inst in res.get("Instances", [])
+    ]
+
+
+# ── Public API (all async) ───────────────────────────────────────────────────
+
+async def list_fleet() -> list[dict]:
+    """List all fleet EC2 instances (tag project=autonomous-enablements OR
+    Name prefix autonomous-enablements), merged and de-duplicated.
+
+    Returns [{instance_id, name, type, state, private_ip, lifecycle,
+    launch_time}].
+    """
+    by_tag, by_name = await asyncio.gather(
+        _aws("ec2", "describe-instances", "--filters",
+             f"Name=tag:project,Values={PROJECT_TAG}"),
+        _aws("ec2", "describe-instances", "--filters",
+             f"Name=tag:Name,Values={PROJECT_TAG}*"),
+    )
+    merged: dict[str, dict] = {}
+    for data in (by_tag, by_name):
+        for rec in _parse_instances((data or {}).get("Reservations", [])):
+            if rec["instance_id"]:
+                merged[rec["instance_id"]] = rec
+    return sorted(merged.values(), key=lambda r: (r["name"], r["instance_id"]))
+
+
+async def scale_up(count: int, instance_type: str = DEFAULT_INSTANCE_TYPE) -> list[dict]:
+    """Launch ``count`` spot workers from the golden AMI (hard cap 4).
+
+    Subnet, security groups and key-name are resolved at call time from the
+    live worker-1 instance so launches always match production networking.
+    Raises ValueError on a bad/over-cap count, FleetError on AWS failures.
+    """
+    count = _validate_scale_count(count)
+
+    template = await _describe_by_ids([TEMPLATE_INSTANCE_ID])
+    if not template:
+        raise FleetError(
+            f"template instance {TEMPLATE_INSTANCE_ID} (worker-1) not found — "
+            "cannot resolve subnet/security-groups/key-name"
+        )
+    tmpl = template[0]
+    subnet_id = tmpl.get("SubnetId", "")
+    key_name = tmpl.get("KeyName", "")
+    sg_ids = [g["GroupId"] for g in tmpl.get("SecurityGroups", []) or []]
+    if not (subnet_id and sg_ids):
+        raise FleetError(
+            f"template instance {TEMPLATE_INSTANCE_ID} has no subnet/"
+            "security groups (is it terminated?)"
+        )
+
+    market_options = json.dumps({
+        "MarketType": "spot",
+        "SpotOptions": {"SpotInstanceType": "one-time"},
+    })
+    tag_spec = (
+        "ResourceType=instance,Tags=["
+        f"{{Key=Name,Value={SPOT_WORKER_NAME}}},"
+        f"{{Key=project,Value={PROJECT_TAG}}},"
+        f"{{Key=orbital-role,Value={WORKER_ROLE_TAG}}}]"
+    )
+
+    args = [
+        "ec2", "run-instances",
+        "--image-id", WORKER_AMI,
+        "--count", str(count),
+        "--instance-type", instance_type,
+        "--subnet-id", subnet_id,
+        "--security-group-ids", *sg_ids,
+        "--instance-market-options", market_options,
+        "--tag-specifications", tag_spec,
+        "--user-data", _encode_user_data(_build_user_data()),
+    ]
+    if key_name:
+        args += ["--key-name", key_name]
+
+    data = await _aws(*args)
+    return [
+        {
+            "instance_id": inst.get("InstanceId", ""),
+            "type": inst.get("InstanceType", ""),
+            "state": (inst.get("State") or {}).get("Name", ""),
+            "lifecycle": inst.get("InstanceLifecycle") or "on-demand",
+        }
+        for inst in (data or {}).get("Instances", [])
+    ]
+
+
+async def scale_down(instance_ids: list[str]) -> list[dict]:
+    """Terminate spot workers — refuses unless EVERY id is tagged
+    orbital-role=worker or Name=orbital-worker-spot.
+
+    Raises FleetError listing the refused ids when any id fails the check.
+    """
+    if not instance_ids:
+        raise ValueError("instance_ids is required")
+
+    descriptions = await _describe_by_ids(instance_ids)
+    ok_ids, refused = _verify_terminatable(descriptions)
+    # Ids that describe-instances didn't return at all are refused too.
+    described = {inst.get("InstanceId") for inst in descriptions}
+    refused += [iid for iid in instance_ids if iid not in described]
+    if refused:
+        raise FleetError(
+            "refusing to terminate non-spot-worker instance(s): "
+            + ", ".join(sorted(refused))
+            + " — only instances tagged orbital-role=worker or "
+              "Name=orbital-worker-spot may be terminated"
+        )
+
+    data = await _aws("ec2", "terminate-instances", "--instance-ids", *ok_ids)
+    return [
+        {
+            "instance_id": t.get("InstanceId", ""),
+            "previous_state": (t.get("PreviousState") or {}).get("Name", ""),
+            "current_state": (t.get("CurrentState") or {}).get("Name", ""),
+        }
+        for t in (data or {}).get("TerminatingInstances", [])
+    ]
+
+
+async def _start_stop(instance_id: str, action: str) -> dict:
+    """Shared guard + CLI call for start_worker / stop_worker."""
+    descriptions = await _describe_by_ids([instance_id])
+    if not descriptions:
+        raise FleetError(f"instance {instance_id} not found")
+    if not _start_stop_allowed(descriptions[0]):
+        raise FleetError(
+            f"refusing to {action} {instance_id} — only "
+            f"{WORKER_NAME_PREFIX}* instances or tagged spot workers "
+            "may be started/stopped"
+        )
+    verb = "start-instances" if action == "start" else "stop-instances"
+    key = "StartingInstances" if action == "start" else "StoppingInstances"
+    data = await _aws("ec2", verb, "--instance-ids", instance_id)
+    states = (data or {}).get(key, [])
+    rec = states[0] if states else {}
+    return {
+        "instance_id": instance_id,
+        "previous_state": (rec.get("PreviousState") or {}).get("Name", ""),
+        "current_state": (rec.get("CurrentState") or {}).get("Name", ""),
+    }
+
+
+async def start_worker(instance_id: str) -> dict:
+    """Start a stopped pet worker (e.g. worker-3, i-03689a1374d39cb6a)."""
+    return await _start_stop(instance_id, "start")
+
+
+async def stop_worker(instance_id: str) -> dict:
+    """Stop a running worker (allowed for autonomous-enablements-worker*)."""
+    return await _start_stop(instance_id, "stop")

--- a/ops-server/dashboard/test_fleet.py
+++ b/ops-server/dashboard/test_fleet.py
@@ -1,0 +1,234 @@
+"""Pure-logic tests for the fleet autoscaler (dashboard/fleet.py).
+
+No AWS calls, no subprocess, no Redis — exercises only the pure helper
+functions the async wrappers delegate to: the 4-instance safety cap,
+tag-verification refusal for terminate, user-data generation, and the
+expired-credentials error classification.
+
+Runnable two ways:
+  - pytest:     python3 -m pytest dashboard/test_fleet.py
+                (/home/ops/ops-venv/bin/python -m pytest if pytest installed)
+  - standalone: /home/ops/ops-venv/bin/python -m dashboard.test_fleet
+"""
+
+import base64
+
+from dashboard import fleet
+
+
+def _inst(instance_id="i-abc", **tags) -> dict:
+    """Build a raw EC2 instance dict with the given tags."""
+    return {
+        "InstanceId": instance_id,
+        "Tags": [{"Key": k.replace("_", "-"), "Value": v}
+                 for k, v in tags.items()],
+    }
+
+
+# ── Safety cap ───────────────────────────────────────────────────────────────
+
+def test_scale_count_within_cap_ok():
+    for n in (1, 2, 3, 4):
+        assert fleet._validate_scale_count(n) == n
+
+
+def test_scale_count_over_cap_rejected():
+    for n in (5, 10, 100):
+        try:
+            fleet._validate_scale_count(n)
+        except ValueError as e:
+            assert "safety limit" in str(e)
+            assert str(fleet.MAX_SCALE_UP) in str(e)
+        else:
+            raise AssertionError(f"count={n} should have been rejected")
+
+
+def test_scale_count_zero_negative_and_bool_rejected():
+    for bad in (0, -1, True):
+        try:
+            fleet._validate_scale_count(bad)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"count={bad!r} should have been rejected")
+
+
+def test_cap_is_four():
+    assert fleet.MAX_SCALE_UP == 4
+
+
+# ── Tag-verification refusal (terminate) ─────────────────────────────────────
+
+def test_verify_terminatable_role_tag_ok():
+    ok, refused = fleet._verify_terminatable(
+        [_inst("i-1", orbital_role="worker")])
+    assert ok == ["i-1"] and refused == []
+
+
+def test_verify_terminatable_spot_name_ok():
+    ok, refused = fleet._verify_terminatable(
+        [_inst("i-2", Name="orbital-worker-spot")])
+    assert ok == ["i-2"] and refused == []
+
+
+def test_verify_terminatable_refuses_master_and_untagged():
+    descriptions = [
+        _inst("i-master", Name="autonomous-enablements"),      # the master!
+        _inst("i-pet", Name="autonomous-enablements-worker"),  # pet worker
+        _inst("i-plain"),                                      # no tags
+        _inst("i-wrongrole", orbital_role="master"),
+        _inst("i-spot", Name="orbital-worker-spot"),           # allowed
+    ]
+    ok, refused = fleet._verify_terminatable(descriptions)
+    assert ok == ["i-spot"]
+    assert sorted(refused) == ["i-master", "i-pet", "i-plain", "i-wrongrole"]
+
+
+def test_verify_terminatable_empty():
+    assert fleet._verify_terminatable([]) == ([], [])
+
+
+# ── Start/stop allow-list ────────────────────────────────────────────────────
+
+def test_start_stop_allowed_worker_name_prefix():
+    # worker-3 (i-03689a1374d39cb6a) style pet workers.
+    assert fleet._start_stop_allowed(
+        _inst(Name="autonomous-enablements-worker"))
+    assert fleet._start_stop_allowed(
+        _inst(Name="autonomous-enablements-worker-3"))
+
+
+def test_start_stop_allowed_spot_worker():
+    assert fleet._start_stop_allowed(_inst(Name="orbital-worker-spot"))
+    assert fleet._start_stop_allowed(_inst(orbital_role="worker"))
+
+
+def test_start_stop_refused_for_master_and_others():
+    assert not fleet._start_stop_allowed(_inst(Name="autonomous-enablements"))
+    assert not fleet._start_stop_allowed(_inst(Name="some-other-box"))
+    assert not fleet._start_stop_allowed(_inst())
+
+
+# ── User-data generation ─────────────────────────────────────────────────────
+
+def test_user_data_worker_id_sed_and_append():
+    script = fleet._build_user_data()
+    # sed-replace of an existing WORKER_ID= line…
+    assert "sed -i" in script
+    assert "^WORKER_ID=" in script
+    # …or append when absent.
+    assert 'echo "WORKER_ID=${WORKER_ID}" >>' in script
+    # Unique id derived from the instance id (last 8 chars).
+    assert "worker-x86_64-spot-" in script
+    assert "tail -c 8" in script
+
+
+def test_user_data_uses_imdsv2_token():
+    script = fleet._build_user_data()
+    assert "http://169.254.169.254/latest/api/token" in script
+    assert "X-aws-ec2-metadata-token-ttl-seconds" in script
+    assert "X-aws-ec2-metadata-token:" in script
+    assert "169.254.169.254/latest/meta-data/instance-id" in script
+
+
+def test_user_data_master_redis_and_restart():
+    script = fleet._build_user_data()
+    assert fleet.MASTER_REDIS_HOST in script          # 172.31.36.172
+    assert "MASTER_REDIS_URL" in script
+    assert "systemctl restart ops-worker-agent" in script
+    assert script.startswith("#!/bin/bash")
+
+
+def test_user_data_encodes_to_base64_roundtrip():
+    script = fleet._build_user_data()
+    encoded = fleet._encode_user_data(script)
+    assert base64.b64decode(encoded).decode() == script
+
+
+# ── Expired-credentials classification ───────────────────────────────────────
+
+def test_classify_expired_token():
+    msg = fleet._classify_aws_error(
+        "An error occurred (ExpiredToken) when calling the "
+        "DescribeInstances operation: The security token included in "
+        "the request is expired")
+    assert msg == fleet.CREDS_ERROR
+    assert "refresh ~/.aws/credentials" in msg
+
+
+def test_classify_auth_failure_and_missing_creds():
+    for stderr in (
+        "An error occurred (AuthFailure) when calling the RunInstances "
+        "operation: AWS was not able to validate the provided access "
+        "credentials",
+        "Unable to locate credentials. You can configure credentials by "
+        "running \"aws configure\".",
+        "An error occurred (RequestExpired) ...",
+        "An error occurred (InvalidClientTokenId) ...",
+    ):
+        assert fleet._classify_aws_error(stderr) == fleet.CREDS_ERROR
+
+
+def test_classify_other_errors_pass_through():
+    stderr = ("An error occurred (InvalidInstanceID.NotFound) when calling "
+              "the TerminateInstances operation: The instance ID "
+              "'i-deadbeef' does not exist")
+    msg = fleet._classify_aws_error(stderr)
+    assert msg == stderr.strip()
+    assert msg != fleet.CREDS_ERROR
+
+
+def test_classify_empty_stderr():
+    assert "aws CLI failed" in fleet._classify_aws_error("")
+
+
+# ── Instance parsing (list_fleet shape) ──────────────────────────────────────
+
+def test_parse_instances_shape_and_lifecycle():
+    reservations = [{
+        "Instances": [
+            {
+                "InstanceId": "i-spot1",
+                "InstanceType": "c5.2xlarge",
+                "State": {"Name": "running"},
+                "PrivateIpAddress": "172.31.40.1",
+                "InstanceLifecycle": "spot",
+                "LaunchTime": "2026-07-14T10:00:00+00:00",
+                "Tags": [{"Key": "Name", "Value": "orbital-worker-spot"}],
+            },
+            {
+                "InstanceId": "i-master",
+                "InstanceType": "c5.4xlarge",
+                "State": {"Name": "running"},
+                "PrivateIpAddress": "172.31.36.172",
+                "LaunchTime": "2026-01-01T00:00:00+00:00",
+                "Tags": [{"Key": "Name", "Value": "autonomous-enablements"}],
+            },
+        ],
+    }]
+    recs = fleet._parse_instances(reservations)
+    assert len(recs) == 2
+    spot = next(r for r in recs if r["instance_id"] == "i-spot1")
+    master = next(r for r in recs if r["instance_id"] == "i-master")
+    assert spot["lifecycle"] == "spot"
+    assert master["lifecycle"] == "on-demand"   # no InstanceLifecycle key
+    assert spot["name"] == "orbital-worker-spot"
+    assert spot["private_ip"] == "172.31.40.1"
+    assert master["type"] == "c5.4xlarge"
+    assert set(spot) == {"instance_id", "name", "type", "state",
+                         "private_ip", "lifecycle", "launch_time"}
+
+
+if __name__ == "__main__":
+    failed = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"ok {name}")
+            except AssertionError as e:
+                failed += 1
+                print(f"FAIL {name}: {e}")
+    if failed:
+        raise SystemExit(f"{failed} test(s) failed")
+    print("all fleet tests passed")


### PR DESCRIPTION
`GET /api/fleet` + `POST /api/fleet/scale-up|scale-down` + `POST /api/fleet/worker/{id}/start|stop`. Spot launches from golden AMI ami-0ed76cf85fa7d2967, networking resolved live from worker-1, unique WORKER_ID via IMDSv2 user-data, hard cap 4/call, terminate refuses anything not tagged orbital-role=worker, drain check on scale-down (409 when active_jobs>0 unless force). AWS via aws CLI subprocess (no boto3); federated-creds expiry surfaces a clear 502. 20/20 pure-logic tests. Docs in ops-server/CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)