### PR TITLE
Live training sessions — Orbital registry (P1 backend)

### DIFF
--- a/ops-server/CLAUDE.md
+++ b/ops-server/CLAUDE.md
@@ -353,3 +353,32 @@ sudo cp /home/ubuntu/enablement-framework/codespaces-framework/ops-server/dashbo
         /home/ops/enablement-framework/codespaces-framework/ops-server/dashboard/fleet.py
 sudo systemctl restart ops-dashboard
 ```
+
+## Live sessions
+
+Instructor-led bootcamp cohorts (design: dynatrace-app-enablements/docs/live-training-architecture.md,
+Phase P1 backend). Endpoints in `dashboard/app.py`; pure decision logic in
+`dashboard/live_sessions.py` (no Redis — tested via
+`/home/ops/ops-venv/bin/python -m dashboard.test_live_sessions`). Called through
+the app's `orbital` app function (no X-Auth headers), so trainer actions are
+gated by matching the caller-supplied `trainerEmail` against the stored one —
+same openness as `/api/arena/*`.
+
+| Endpoint | Who | Description |
+|----------|-----|-------------|
+| `POST /api/live/sessions` | trainer | `{title, trainingId, ref?, trainerEmail, roster}` → state `open`; emails lowercased/trimmed, invalid (no `@`) dropped; 400 on missing fields / empty roster |
+| `GET /api/live/sessions?email=` | both | non-ended sessions where the email is trainer or on the roster; items carry joined/roster counts + `isTrainer`/`hasJoined` |
+| `GET /api/live/sessions/{id}?email=` | both | full state; `roster` + `joined` lists only when email == trainerEmail (learners get counts); 404 when missing/expired |
+| `POST /api/live/sessions/{id}/join` | learner | `{email}` — idempotent; 403 not on roster, 409 ended |
+| `POST /api/live/sessions/{id}/start` | trainer | open → running, sets `startedAt`; idempotent when running; 403 mismatch, 409 after ended |
+| `POST /api/live/sessions/{id}/end` | trainer | → ended, sets `endedAt`, applies TTLs; idempotent; 403 mismatch |
+
+Redis keys:
+- `live:session:{id}` — hash: title, trainingId, ref, trainerEmail, state (`open|running|ended`), createdAt, startedAt, endedAt
+- `live:session:{id}:roster` — set of lowercase invited emails
+- `live:session:{id}:joined` — hash email → ISO joinedAt
+- `live:sessions:index` — zset of sessionId scored by epoch createdAt
+
+TTL: on `end` the three `live:session:{id}*` keys get a 7-day TTL (matches
+`job:final` retention). The index entry is kept — the list endpoint skips
+members whose hash has expired.

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -68,6 +68,10 @@ app.include_router(codespace_router)
 # EC2 spot-worker fleet scaling (aws CLI, no boto3) — see dashboard/fleet.py.
 from dashboard import fleet  # noqa: E402
 
+# Live training sessions (bootcamp cohorts) — pure decision logic lives in
+# dashboard/live_sessions.py (tested without Redis); endpoints below stay thin.
+from dashboard import live_sessions  # noqa: E402
+
 _PROFILES_PAGE = """<!doctype html><html><head><meta charset=utf-8>
 <title>Content Profiles</title><style>
 body{font-family:system-ui,sans-serif;margin:0;background:#0d1117;color:#e6edf3}
@@ -4546,6 +4550,177 @@ async def api_arena_terminate(job_id: str):
     await pool.publish("ops:terminate", job_id)
     log.info("Arena termination requested for %s", job_id)
     return {"status": "termination_requested", "job_id": job_id}
+
+
+# ── Live training sessions (bootcamp cohorts) ─────────────────────────────────
+# Registry for instructor-led cohorts: a trainer creates a session with a
+# roster of emails, learners join from any tenant, the trainer starts/ends for
+# everyone at once. Called via the app's `orbital` app function, which sends
+# NO X-Auth headers — trainer actions are gated by matching the caller-supplied
+# trainerEmail against the stored one (same openness as /api/arena/*). All
+# decision logic is in dashboard/live_sessions.py (pure, unit-tested).
+
+
+def _live_keys(session_id: str) -> tuple[str, str, str]:
+    """The three Redis keys of a live session: (hash, roster set, joined hash)."""
+    base = f"live:session:{session_id}"
+    return base, f"{base}:roster", f"{base}:joined"
+
+
+class LiveSessionCreate(BaseModel):
+    title: str = ""
+    trainingId: str = ""
+    ref: str = ""                 # optional content branch
+    trainerEmail: str = ""
+    roster: list[str] = []
+
+
+class LiveSessionJoin(BaseModel):
+    email: str = ""
+
+
+class LiveSessionTrainerAction(BaseModel):
+    trainerEmail: str = ""
+
+
+@app.post("/api/live/sessions")
+async def api_live_session_create(body: LiveSessionCreate):
+    """Create a live session (state=open) with a roster of invited emails.
+
+    Emails are trimmed + lowercased; entries without an '@' are dropped.
+    400 when title/trainingId/trainerEmail is missing or the roster is empty
+    after normalization. Returns the full session JSON (trainer view).
+    """
+    try:
+        fields = live_sessions.validate_create(
+            body.title, body.trainingId, body.trainerEmail, body.roster)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    session_id = _new_job_id()
+    now = datetime.now(timezone.utc)
+    session = {
+        "title":        fields["title"],
+        "trainingId":   fields["trainingId"],
+        "ref":          (body.ref or "").strip(),
+        "trainerEmail": fields["trainerEmail"],
+        "state":        "open",
+        "createdAt":    now.isoformat(),
+        "startedAt":    "",
+        "endedAt":      "",
+    }
+    sess_key, roster_key, _ = _live_keys(session_id)
+    await pool.hset(sess_key, mapping=session)
+    await pool.sadd(roster_key, *fields["roster"])
+    await pool.zadd("live:sessions:index", {session_id: now.timestamp()})
+    log.info("Live session %s created by %s (%s, %d invited)", session_id,
+             fields["trainerEmail"], fields["trainingId"], len(fields["roster"]))
+    return live_sessions.shape_detail(
+        session_id, session, fields["roster"], {}, fields["trainerEmail"])
+
+
+@app.get("/api/live/sessions")
+async def api_live_sessions_list(email: str = ""):
+    """Active (state != ended) sessions visible to an email — as trainer or
+    roster member. Index entries whose keys have TTL-expired are skipped."""
+    email = live_sessions.normalize_email(email)
+    if not live_sessions.is_valid_email(email):
+        raise HTTPException(status_code=400, detail="a valid email query parameter is required")
+    sessions = []
+    for session_id in await pool.zrevrange("live:sessions:index", 0, -1):
+        sess_key, roster_key, joined_key = _live_keys(session_id)
+        session = await pool.hgetall(sess_key)
+        if not session:
+            continue  # expired after `ended` — tolerate the stale index member
+        roster = await pool.smembers(roster_key)
+        if not live_sessions.is_listed(session, roster, email):
+            continue
+        joined = await pool.hgetall(joined_key)
+        sessions.append(live_sessions.shape_summary(
+            session_id, session, roster, joined, email))
+    return {"sessions": sessions, "count": len(sessions)}
+
+
+@app.get("/api/live/sessions/{session_id}")
+async def api_live_session_detail(session_id: str, email: str = ""):
+    """Full session state. The roster and per-learner joined list are only
+    included when the caller email matches trainerEmail; learners get counts."""
+    sess_key, roster_key, joined_key = _live_keys(session_id)
+    session = await pool.hgetall(sess_key)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+    roster = await pool.smembers(roster_key)
+    joined = await pool.hgetall(joined_key)
+    return live_sessions.shape_detail(session_id, session, roster, joined, email)
+
+
+@app.post("/api/live/sessions/{session_id}/join")
+async def api_live_session_join(session_id: str, body: LiveSessionJoin):
+    """Learner joins a session they are invited to. Idempotent — re-joining
+    keeps the original joinedAt. 403 when not on the roster, 409 when ended."""
+    email = live_sessions.normalize_email(body.email)
+    if not live_sessions.is_valid_email(email):
+        raise HTTPException(status_code=400, detail="a valid email is required")
+    sess_key, roster_key, joined_key = _live_keys(session_id)
+    session = await pool.hgetall(sess_key)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+    roster = await pool.smembers(roster_key)
+    err = live_sessions.join_error(session.get("state", ""), email, roster)
+    if err:
+        raise HTTPException(status_code=err[0], detail=err[1])
+    await pool.hsetnx(joined_key, email, datetime.now(timezone.utc).isoformat())
+    return {"state": session.get("state", ""),
+            "joinedCount": await pool.hlen(joined_key)}
+
+
+@app.post("/api/live/sessions/{session_id}/start")
+async def api_live_session_start(session_id: str, body: LiveSessionTrainerAction):
+    """Trainer starts the session: open → running (learners' waiting screens
+    flip). Idempotent when already running; 403 on trainerEmail mismatch."""
+    sess_key, roster_key, joined_key = _live_keys(session_id)
+    session = await pool.hgetall(sess_key)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+    if not live_sessions.is_trainer(body.trainerEmail, session):
+        raise HTTPException(status_code=403, detail="trainerEmail does not match this session's trainer")
+    try:
+        new_state, changed = live_sessions.apply_transition(session.get("state", ""), "start")
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    if changed:
+        session["state"] = new_state
+        session["startedAt"] = datetime.now(timezone.utc).isoformat()
+        await pool.hset(sess_key, mapping={
+            "state": new_state, "startedAt": session["startedAt"]})
+        log.info("Live session %s started by %s", session_id, body.trainerEmail)
+    roster = await pool.smembers(roster_key)
+    joined = await pool.hgetall(joined_key)
+    return live_sessions.shape_detail(session_id, session, roster, joined, body.trainerEmail)
+
+
+@app.post("/api/live/sessions/{session_id}/end")
+async def api_live_session_end(session_id: str, body: LiveSessionTrainerAction):
+    """Trainer ends the session: state → ended, freezes the board, and sets a
+    7-day TTL on the session keys (index entry kept; listing tolerates it)."""
+    sess_key, roster_key, joined_key = _live_keys(session_id)
+    session = await pool.hgetall(sess_key)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+    if not live_sessions.is_trainer(body.trainerEmail, session):
+        raise HTTPException(status_code=403, detail="trainerEmail does not match this session's trainer")
+    new_state, changed = live_sessions.apply_transition(session.get("state", ""), "end")
+    if changed:
+        session["state"] = new_state
+        session["endedAt"] = datetime.now(timezone.utc).isoformat()
+        await pool.hset(sess_key, mapping={
+            "state": new_state, "endedAt": session["endedAt"]})
+        log.info("Live session %s ended by %s", session_id, body.trainerEmail)
+    for key in (sess_key, roster_key, joined_key):
+        await pool.expire(key, live_sessions.SESSION_TTL_SECONDS)
+    roster = await pool.smembers(roster_key)
+    joined = await pool.hgetall(joined_key)
+    return live_sessions.shape_detail(session_id, session, roster, joined, body.trainerEmail)
 
 
 # ── Framework test suites ─────────────────────────────────────────────────────

--- a/ops-server/dashboard/live_sessions.py
+++ b/ops-server/dashboard/live_sessions.py
@@ -1,0 +1,168 @@
+"""Pure decision logic for live training sessions (bootcamp cohorts).
+
+No Redis, no FastAPI — everything here is deterministic and unit-tested in
+dashboard/test_live_sessions.py. The /api/live/* endpoints in app.py stay
+thin: they read/write the Redis keys and delegate every decision here.
+
+Redis model (docs/live-training-architecture.md, ops-server/CLAUDE.md):
+  live:session:{id}         hash  title, trainingId, ref, trainerEmail,
+                                  state (open|running|ended),
+                                  createdAt, startedAt, endedAt
+  live:session:{id}:roster  set   lowercase invited emails
+  live:session:{id}:joined  hash  email -> ISO joinedAt
+  live:sessions:index       zset  sessionId scored by epoch createdAt
+"""
+
+STATES = ("open", "running", "ended")
+
+# TTL applied to the three session keys when a session ends — matches the
+# job:final 7-day retention. The index entry is kept; listing tolerates
+# expired members (hgetall returns {} → skip).
+SESSION_TTL_SECONDS = 7 * 24 * 3600
+
+
+# ── Emails ────────────────────────────────────────────────────────────────────
+
+def normalize_email(email) -> str:
+    """Canonical form used everywhere: trimmed + lowercased."""
+    return (email or "").strip().lower()
+
+
+def is_valid_email(email) -> bool:
+    """Minimal server-side validity: non-empty and contains an '@'."""
+    return bool(email) and "@" in email
+
+
+def normalize_roster(emails) -> list[str]:
+    """Normalize each email, drop invalid ones (no '@'), dedupe keeping order."""
+    seen, out = set(), []
+    for e in emails or []:
+        n = normalize_email(e)
+        if is_valid_email(n) and n not in seen:
+            seen.add(n)
+            out.append(n)
+    return out
+
+
+# ── Create validation ─────────────────────────────────────────────────────────
+
+def validate_create(title, training_id, trainer_email, roster) -> dict:
+    """Validate + normalize a create request.
+
+    Raises ValueError (→ HTTP 400) when title/trainingId/trainerEmail is
+    missing or the roster has no valid email after normalization.
+    """
+    title = (title or "").strip()
+    training_id = (training_id or "").strip()
+    trainer = normalize_email(trainer_email)
+    if not title:
+        raise ValueError("title is required")
+    if not training_id:
+        raise ValueError("trainingId is required")
+    if not is_valid_email(trainer):
+        raise ValueError("a valid trainerEmail is required")
+    members = normalize_roster(roster)
+    if not members:
+        raise ValueError("roster must contain at least one valid email")
+    return {"title": title, "trainingId": training_id,
+            "trainerEmail": trainer, "roster": members}
+
+
+# ── Roster / trainer gating ───────────────────────────────────────────────────
+
+def is_trainer(email, session) -> bool:
+    """True when the caller-supplied email matches the stored trainerEmail.
+
+    The orbital app-function proxy sends no X-Auth headers, so this match is
+    the trainer gate (consistent with the open /api/arena/* endpoints)."""
+    e = normalize_email(email)
+    return bool(e) and e == normalize_email(session.get("trainerEmail"))
+
+
+def on_roster(email, roster) -> bool:
+    """True when the email is on the roster (stored lowercase)."""
+    return normalize_email(email) in set(roster or ())
+
+
+def join_error(state, email, roster):
+    """Return (http_status, detail) blocking a join, or None when allowed."""
+    if not on_roster(email, roster):
+        return 403, "email is not on the session roster"
+    if state == "ended":
+        return 409, "session has ended"
+    return None
+
+
+# ── State transitions ─────────────────────────────────────────────────────────
+
+# action -> {current_state: (new_state, changed)}. Absent = illegal.
+_TRANSITIONS = {
+    "start": {"open": ("running", True), "running": ("running", False)},
+    "end":   {"open": ("ended", True), "running": ("ended", True),
+              "ended": ("ended", False)},
+}
+
+
+def apply_transition(state, action) -> tuple[str, bool]:
+    """Return (new_state, changed) for a trainer action; changed=False means
+    the action is an idempotent no-op. Raises ValueError on an illegal move
+    (e.g. start after ended)."""
+    table = _TRANSITIONS.get(action)
+    if table is None:
+        raise ValueError(f"unknown action '{action}'")
+    if state not in table:
+        raise ValueError(f"cannot {action} a session in state '{state}'")
+    return table[state]
+
+
+# ── Response shaping ──────────────────────────────────────────────────────────
+
+def is_listed(session, roster, email) -> bool:
+    """Listing filter: non-ended sessions where the email is the trainer or
+    on the roster."""
+    if not session or session.get("state") == "ended":
+        return False
+    return is_trainer(email, session) or on_roster(email, roster)
+
+
+def shape_summary(session_id, session, roster, joined, email) -> dict:
+    """One item of GET /api/live/sessions?email= (learner + trainer lists)."""
+    e = normalize_email(email)
+    return {
+        "sessionId":    session_id,
+        "title":        session.get("title", ""),
+        "trainingId":   session.get("trainingId", ""),
+        "state":        session.get("state", ""),
+        "trainerEmail": session.get("trainerEmail", ""),
+        "joinedCount":  len(joined or {}),
+        "rosterCount":  len(roster or ()),
+        "createdAt":    session.get("createdAt", ""),
+        "startedAt":    session.get("startedAt", ""),
+        "isTrainer":    is_trainer(e, session),
+        "hasJoined":    e in (joined or {}),
+    }
+
+
+def shape_detail(session_id, session, roster, joined, email) -> dict:
+    """Full session state (GET /api/live/sessions/{id}).
+
+    Everyone gets the scalar fields + joined/roster counts; the roster and
+    the joined list (who + when) are only included for the trainer."""
+    out = {
+        "sessionId":    session_id,
+        "title":        session.get("title", ""),
+        "trainingId":   session.get("trainingId", ""),
+        "ref":          session.get("ref", ""),
+        "state":        session.get("state", ""),
+        "trainerEmail": session.get("trainerEmail", ""),
+        "createdAt":    session.get("createdAt", ""),
+        "startedAt":    session.get("startedAt", ""),
+        "endedAt":      session.get("endedAt", ""),
+        "joinedCount":  len(joined or {}),
+        "rosterCount":  len(roster or ()),
+    }
+    if is_trainer(email, session):
+        out["roster"] = sorted(roster or ())
+        out["joined"] = [{"email": k, "joinedAt": v}
+                         for k, v in sorted((joined or {}).items())]
+    return out

--- a/ops-server/dashboard/test_live_sessions.py
+++ b/ops-server/dashboard/test_live_sessions.py
@@ -1,0 +1,220 @@
+"""Pure-logic tests for live training sessions (dashboard/live_sessions.py).
+
+No Redis, no FastAPI — exercises only the decision logic the /api/live/*
+endpoints delegate to: email normalization + invalid-drop, create validation,
+legal/illegal state transitions, roster gating, and learner-vs-trainer
+response shaping.
+
+Runnable two ways:
+  - pytest:     python3 -m pytest dashboard/test_live_sessions.py
+  - standalone: /home/ops/ops-venv/bin/python -m dashboard.test_live_sessions
+"""
+
+from dashboard import live_sessions as ls
+
+TRAINER = "trainer@dynatrace.com"
+
+
+def _session(state="open", trainer=TRAINER, **extra) -> dict:
+    """A live:session:{id} hash as stored in Redis (all-string values)."""
+    sess = {
+        "title": "K8s 101 — EMEA Bootcamp", "trainingId": "kubernetes-101",
+        "ref": "", "trainerEmail": trainer, "state": state,
+        "createdAt": "2026-07-14T09:00:00+00:00", "startedAt": "", "endedAt": "",
+    }
+    sess.update(extra)
+    return sess
+
+
+# ── Email normalization ──────────────────────────────────────────────────────
+
+def test_normalize_email_trims_and_lowercases():
+    assert ls.normalize_email("  Alice@Example.COM ") == "alice@example.com"
+    assert ls.normalize_email(None) == ""
+    assert ls.normalize_email("") == ""
+
+
+def test_is_valid_email_requires_at():
+    assert ls.is_valid_email("a@b")
+    assert not ls.is_valid_email("no-at-sign")
+    assert not ls.is_valid_email("")
+
+
+def test_normalize_roster_drops_invalid_and_dedupes():
+    roster = ls.normalize_roster(
+        ["  Bob@X.com", "bob@x.com", "not-an-email", "", None, "carol@y.com "])
+    assert roster == ["bob@x.com", "carol@y.com"]
+
+
+def test_normalize_roster_empty_inputs():
+    assert ls.normalize_roster([]) == []
+    assert ls.normalize_roster(None) == []
+    assert ls.normalize_roster(["nope", "also nope"]) == []
+
+
+# ── Create validation ────────────────────────────────────────────────────────
+
+def test_validate_create_normalizes_everything():
+    fields = ls.validate_create(
+        "  K8s 101 ", " kubernetes-101 ", " Trainer@Dynatrace.COM ",
+        ["Alice@X.com", "bad-entry", "alice@x.com"])
+    assert fields == {"title": "K8s 101", "trainingId": "kubernetes-101",
+                      "trainerEmail": "trainer@dynatrace.com",
+                      "roster": ["alice@x.com"]}
+
+
+def test_validate_create_missing_fields():
+    for kwargs in (
+        dict(title="", training_id="t", trainer_email=TRAINER, roster=["a@b"]),
+        dict(title="T", training_id="", trainer_email=TRAINER, roster=["a@b"]),
+        dict(title="T", training_id="t", trainer_email="", roster=["a@b"]),
+        dict(title="T", training_id="t", trainer_email="no-at", roster=["a@b"]),
+    ):
+        try:
+            ls.validate_create(kwargs["title"], kwargs["training_id"],
+                               kwargs["trainer_email"], kwargs["roster"])
+            raise AssertionError(f"expected ValueError for {kwargs}")
+        except ValueError:
+            pass
+
+
+def test_validate_create_empty_roster_rejected():
+    for roster in ([], None, ["not-an-email"]):
+        try:
+            ls.validate_create("T", "t", TRAINER, roster)
+            raise AssertionError(f"expected ValueError for roster={roster}")
+        except ValueError as exc:
+            assert "roster" in str(exc)
+
+
+# ── State transitions ────────────────────────────────────────────────────────
+
+def test_start_open_to_running():
+    assert ls.apply_transition("open", "start") == ("running", True)
+
+
+def test_start_idempotent_when_running():
+    assert ls.apply_transition("running", "start") == ("running", False)
+
+
+def test_start_after_ended_is_illegal():
+    try:
+        ls.apply_transition("ended", "start")
+        raise AssertionError("expected ValueError")
+    except ValueError as exc:
+        assert "ended" in str(exc)
+
+
+def test_end_from_open_and_running():
+    assert ls.apply_transition("open", "end") == ("ended", True)
+    assert ls.apply_transition("running", "end") == ("ended", True)
+
+
+def test_end_idempotent_when_ended():
+    assert ls.apply_transition("ended", "end") == ("ended", False)
+
+
+def test_unknown_action_and_state_rejected():
+    for state, action in (("open", "pause"), ("bogus", "start"), ("", "end")):
+        try:
+            ls.apply_transition(state, action)
+            raise AssertionError(f"expected ValueError for {state}/{action}")
+        except ValueError:
+            pass
+
+
+# ── Roster / trainer gating ──────────────────────────────────────────────────
+
+def test_is_trainer_case_insensitive():
+    sess = _session()
+    assert ls.is_trainer(" Trainer@DYNATRACE.com ", sess)
+    assert not ls.is_trainer("learner@x.com", sess)
+    assert not ls.is_trainer("", sess)  # empty caller never matches
+
+
+def test_join_error_not_on_roster():
+    assert ls.join_error("open", "stranger@x.com", {"alice@x.com"}) == \
+        (403, "email is not on the session roster")
+
+
+def test_join_error_ended():
+    assert ls.join_error("ended", "alice@x.com", {"alice@x.com"}) == \
+        (409, "session has ended")
+
+
+def test_join_allowed_open_and_running():
+    assert ls.join_error("open", "Alice@X.com ", {"alice@x.com"}) is None
+    assert ls.join_error("running", "alice@x.com", {"alice@x.com"}) is None
+
+
+def test_is_listed_roster_trainer_and_ended():
+    sess = _session(state="open")
+    roster = {"alice@x.com"}
+    assert ls.is_listed(sess, roster, "alice@x.com")
+    assert ls.is_listed(sess, roster, TRAINER)      # trainer sees it too
+    assert not ls.is_listed(sess, roster, "other@x.com")
+    assert not ls.is_listed(_session(state="ended"), roster, "alice@x.com")
+    assert not ls.is_listed({}, roster, "alice@x.com")  # expired hash
+
+
+# ── Response shaping ─────────────────────────────────────────────────────────
+
+def test_shape_summary_learner():
+    joined = {"alice@x.com": "2026-07-14T10:00:00+00:00"}
+    item = ls.shape_summary("sid-1", _session(), {"alice@x.com", "bob@x.com"},
+                            joined, "Alice@X.com")
+    assert item == {
+        "sessionId": "sid-1", "title": "K8s 101 — EMEA Bootcamp",
+        "trainingId": "kubernetes-101", "state": "open",
+        "trainerEmail": TRAINER, "joinedCount": 1, "rosterCount": 2,
+        "createdAt": "2026-07-14T09:00:00+00:00", "startedAt": "",
+        "isTrainer": False, "hasJoined": True,
+    }
+
+
+def test_shape_summary_trainer_not_joined():
+    item = ls.shape_summary("sid-1", _session(), {"alice@x.com"}, {}, TRAINER)
+    assert item["isTrainer"] is True
+    assert item["hasJoined"] is False
+    assert item["joinedCount"] == 0
+
+
+def test_shape_detail_learner_gets_counts_only():
+    joined = {"alice@x.com": "2026-07-14T10:00:00+00:00"}
+    out = ls.shape_detail("sid-1", _session(), {"alice@x.com", "bob@x.com"},
+                          joined, "alice@x.com")
+    assert out["joinedCount"] == 1
+    assert out["rosterCount"] == 2
+    assert "roster" not in out
+    assert "joined" not in out
+
+
+def test_shape_detail_trainer_gets_roster_and_joined():
+    joined = {"bob@x.com": "2026-07-14T10:05:00+00:00",
+              "alice@x.com": "2026-07-14T10:00:00+00:00"}
+    out = ls.shape_detail("sid-1", _session(), {"bob@x.com", "alice@x.com"},
+                          joined, " Trainer@Dynatrace.com ")
+    assert out["roster"] == ["alice@x.com", "bob@x.com"]  # sorted
+    assert out["joined"] == [
+        {"email": "alice@x.com", "joinedAt": "2026-07-14T10:00:00+00:00"},
+        {"email": "bob@x.com", "joinedAt": "2026-07-14T10:05:00+00:00"},
+    ]
+
+
+def test_shape_detail_includes_all_scalar_fields():
+    out = ls.shape_detail("sid-1", _session(state="ended", ref="feat/x"),
+                          set(), {}, "learner@x.com")
+    for field in ("sessionId", "title", "trainingId", "ref", "state",
+                  "trainerEmail", "createdAt", "startedAt", "endedAt",
+                  "joinedCount", "rosterCount"):
+        assert field in out
+    assert out["ref"] == "feat/x"
+    assert out["state"] == "ended"
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok {name}")
+    print("all live-sessions tests passed")


### PR DESCRIPTION
Implements the P1 backend of the live-training epic (design: dynatrace-app-enablements/docs/live-training-architecture.md): tenant-agnostic session registry keyed by email.

- `POST /api/live/sessions` (create: title, trainingId, roster) · `GET /api/live/sessions?email=` (learner/trainer listing) · `GET /api/live/sessions/{id}` (trainer sees roster+joined, learners counts) · `POST .../join` (roster-gated, idempotent) · `POST .../start` / `.../end` (trainer-gated by email match)
- Redis: `live:session:{id}` hash + `:roster` set + `:joined` hash + `live:sessions:index` zset; 7-day TTL after end
- Pure state machine + shaping in `dashboard/live_sessions.py`, 23 unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)