### PR TITLE
fix: DynaKube session name capped at 38 chars (webhook limit)

### DIFF
--- a/.devcontainer/test/unit/test_dynakube.bats
+++ b/.devcontainer/test/unit/test_dynakube.bats
@@ -339,7 +339,7 @@ EOF
   [[ "$output" == *"networkZone: test-enablement"$'\n'* ]]
 }
 
-@test "generateDynakube: long repo name truncated to keep session id, max 40 chars" {
+@test "generateDynakube: long repo name truncated to keep session id, max 38 chars" {
   source_functions
   export RepositoryName="enablement-kubernetes-opentelemetry-openpipeline"
   export DT_HOSTGROUP="bob-20260714"
@@ -348,7 +348,7 @@ EOF
 
   name_line=$(grep -m1 '^  name: ' "$FAKE_REPO/.devcontainer/yaml/gen/dynakube.yaml")
   name="${name_line#  name: }"
-  [ "${#name}" -le 40 ]
+  [ "${#name}" -le 38 ]
   [[ "$name" == *"-bob-20260714" ]]
   [[ "$name" != *"--"* ]] || true
   [[ "$name" != *"-" ]]

--- a/.devcontainer/util/functions.sh
+++ b/.devcontainer/util/functions.sh
@@ -1504,14 +1504,15 @@ generateDynakube() {
   local cluster_name="$base_name"
   local session_id="$(getDtSessionId)"
   if [[ -n "$session_id" ]]; then
-    # The operator derives child resource names from the DynaKube name (63-char
-    # k8s limit) — keep it <= 40 chars, sacrificing repo chars before session id.
-    local name_budget=$(( 40 - ${#session_id} - 1 ))
+    # The operator's validating webhook enforces a HARD 38-char DynaKube name
+    # limit (child resources like <name>-activegate-<hash> must fit the 63-char
+    # k8s label limit) — sacrifice repo chars before the session id.
+    local name_budget=$(( 38 - ${#session_id} - 1 ))
     (( name_budget < 1 )) && name_budget=1
     local repo_part="${base_name:0:$name_budget}"
     repo_part="${repo_part%-}"
     cluster_name="${repo_part}-${session_id}"
-    cluster_name="${cluster_name:0:40}"
+    cluster_name="${cluster_name:0:38}"
     cluster_name="${cluster_name%-}"
   fi
   local api_url="${DT_TENANT}/api"


### PR DESCRIPTION
The operator webhook rejects DynaKube names > 38 chars (child resources must fit k8s 63-char label limit). E2e caught it: 40-char name → 'No resources found', ActiveGate never scheduled. Bats updated, 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)