### PR TITLE
fix(k3d): gate cluster create on API reachability + retry (bootcamp cold-start race)

### DIFF
--- a/.devcontainer/test/unit/test_cluster_engine.bats
+++ b/.devcontainer/test/unit/test_cluster_engine.bats
@@ -217,3 +217,67 @@ source_functions() {
   deployCloudNative
   [ "$warned" -eq 1 ]
 }
+
+# ============================================================
+# waitK3dApiReady + createK3dCluster reachability gate
+# (regression: under load, k3d cluster listed but API not up →
+#  every downstream kubectl hits localhost:8080 → dead session)
+# ============================================================
+
+@test "waitK3dApiReady: returns 0 when kubectl reaches the API" {
+  source_functions
+  export K3D_CLUSTER_NAME=enablement K3D_API_READY_TIMEOUT=6
+  kubectl() { return 0; }
+  export -f kubectl
+  run waitK3dApiReady
+  [ "$status" -eq 0 ]
+}
+
+@test "waitK3dApiReady: returns non-zero when API never answers" {
+  source_functions
+  export K3D_CLUSTER_NAME=enablement K3D_API_READY_TIMEOUT=6
+  kubectl() { return 1; }
+  export -f kubectl
+  run waitK3dApiReady
+  [ "$status" -ne 0 ]
+}
+
+@test "attachK3dCluster: returns non-zero when nodes unreachable (no silent swallow)" {
+  source_functions
+  export K3D_CLUSTER_NAME=enablement
+  k3d() { return 0; }
+  export -f k3d
+  kubectl() { return 1; }
+  export -f kubectl
+  run attachK3dCluster
+  [ "$status" -ne 0 ]
+}
+
+@test "createK3dCluster: retries create when first cluster is unreachable" {
+  source_functions
+  export K3D_CLUSTER_NAME=enablement K3D_API_READY_TIMEOUT=3
+  export CREATE_CALLS_FILE="$TEST_DIR/create_calls"
+  : > "$CREATE_CALLS_FILE"
+  installK3d() { :; }; export -f installK3d
+  # k3d create records a call; list always shows the cluster present.
+  k3d() {
+    case "$1 $2" in
+      "cluster create") echo x >> "$CREATE_CALLS_FILE" ;;
+      "cluster list")   echo "enablement   1/1" ;;
+      "cluster delete") : ;;
+      "kubeconfig merge") : ;;
+    esac
+    return 0
+  }
+  export -f k3d
+  # API unreachable on first attempt, reachable on second (>=2 create calls).
+  kubectl() {
+    local n; n=$(wc -l < "$CREATE_CALLS_FILE" 2>/dev/null || echo 0)
+    [ "$n" -ge 2 ] && return 0 || return 1
+  }
+  export -f kubectl
+  installIngressController() { :; }; export -f installIngressController
+  run createK3dCluster
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$CREATE_CALLS_FILE")" -eq 2 ]
+}

--- a/.devcontainer/util/functions.sh
+++ b/.devcontainer/util/functions.sh
@@ -856,20 +856,59 @@ createK3dCluster() {
 
   installK3d
 
-  k3d cluster create "$K3D_CLUSTER_NAME" \
-    --api-port "$K3D_API_PORT" \
-    -p "${K3D_LB_HTTP_PORT}:80@loadbalancer" \
-    -p "${K3D_LB_HTTPS_PORT}:443@loadbalancer" \
-    --k3s-arg "--disable=traefik@server:0" \
-    --wait
+  # Under heavy concurrent provisioning (many sessions cold-starting k3d on one
+  # host at once) `k3d cluster create --wait` can return with the cluster listed
+  # but the API server not actually reachable / kubeconfig context not attached.
+  # The old code only checked `k3d cluster list | grep`, so a half-started cluster
+  # slipped through and every downstream kubectl hit localhost:8080 → dead session.
+  # Gate on the API actually answering, and retry the whole create once (a fresh
+  # delete+create clears a wedged partial cluster).
+  local attempt
+  for attempt in 1 2; do
+    k3d cluster create "$K3D_CLUSTER_NAME" \
+      --api-port "$K3D_API_PORT" \
+      -p "${K3D_LB_HTTP_PORT}:80@loadbalancer" \
+      -p "${K3D_LB_HTTPS_PORT}:443@loadbalancer" \
+      --k3s-arg "--disable=traefik@server:0" \
+      --wait
 
-  if k3d cluster list 2>/dev/null | grep -q "^${K3D_CLUSTER_NAME} "; then
-    printInfo "K3d cluster '$K3D_CLUSTER_NAME' created — reach ingress at http://localhost:${K3D_LB_HTTP_PORT}/"
-    attachK3dCluster
-  else
-    printError "K3d cluster '$K3D_CLUSTER_NAME' failed to start"
-    return 1
-  fi
+    if k3d cluster list 2>/dev/null | grep -q "^${K3D_CLUSTER_NAME} "; then
+      attachK3dCluster
+      if waitK3dApiReady; then
+        printInfo "K3d cluster '$K3D_CLUSTER_NAME' created — reach ingress at http://localhost:${K3D_LB_HTTP_PORT}/"
+        return 0
+      fi
+    fi
+
+    printWarn "K3d cluster '$K3D_CLUSTER_NAME' not reachable (attempt $attempt/2)"
+    if [[ "$attempt" -lt 2 ]]; then
+      printInfo "Tearing down partial cluster and retrying..."
+      k3d cluster delete "$K3D_CLUSTER_NAME" 2>/dev/null
+      sleep 5
+    fi
+  done
+
+  printError "K3d cluster '$K3D_CLUSTER_NAME' failed to become reachable after 2 attempts"
+  return 1
+}
+
+# Poll until the k3d API server answers (kubectl get nodes) or timeout.
+# Guards against the "cluster listed but API not up / context unattached" race
+# that silently breaks every subsequent kubectl call.
+waitK3dApiReady() {
+  : "${K3D_CLUSTER_NAME:=enablement}"
+  local timeout="${K3D_API_READY_TIMEOUT:-90}"
+  local waited=0
+  while (( waited < timeout )); do
+    if kubectl --context "k3d-${K3D_CLUSTER_NAME}" get nodes &>/dev/null; then
+      # Ensure it is also the CURRENT context so context-less kubectl calls work.
+      kubectl config use-context "k3d-${K3D_CLUSTER_NAME}" &>/dev/null
+      return 0
+    fi
+    sleep 3
+    waited=$(( waited + 3 ))
+  done
+  return 1
 }
 createK3sCluster() { createK3dCluster "$@"; }
 
@@ -884,8 +923,12 @@ attachK3dCluster(){
 
   if kubectl get nodes &>/dev/null; then
     printInfo "Connected to K3d cluster '$K3D_CLUSTER_NAME'"
+    return 0
   else
-    printWarn "Could not connect to K3d cluster '$K3D_CLUSTER_NAME'"
+    # Not fatal on its own — createK3dCluster's waitK3dApiReady gate will retry —
+    # but surface it as a non-zero so callers can react instead of proceeding blind.
+    printWarn "Could not connect to K3d cluster '$K3D_CLUSTER_NAME' yet"
+    return 1
   fi
 }
 attachK3sCluster() { attachK3dCluster "$@"; }


### PR DESCRIPTION
**Found by the 20-student load test** — 1 session (student06) dead-failed with `no current context is set` / `dial tcp [::1]:8080: connection refused`.

**Root cause:** under heavy concurrent cold-starts (6 k3d clusters/worker), `k3d cluster create --wait` returns with the cluster *listed* but the API not reachable / kubeconfig context unattached. Old code checked only `k3d cluster list | grep`; `attachK3dCluster` swallowed the failed context-merge with `printWarn`. Downstream kubectl then hit `localhost:8080` → dead session. ~5% at peak.

**Fix:** `waitK3dApiReady` readiness gate (polls the API, pins current-context) + one create retry (delete+recreate) + `attachK3dCluster` returns non-zero. +4 bats, suite green.

**Deploy note:** needs a framework 1.9.2 release + fleet bump to take effect (sessions pull the pinned version) — deliberately NOT auto-merged; review + release at your discretion. The app already surfaces `failed` with a retry button, so students can self-recover today; this makes the failure rare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)