### PR TITLE
fix(orbital): reap job:running orphans when owning worker deregisters

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -3622,6 +3622,13 @@ async def api_arena_provision(body: ArenaProvisionRequest):
                 m = await pool.hgetall(key)
                 if not m or m.get("terminating"):
                     continue
+                # Skip ghosts: a job whose owning worker deregistered (spot
+                # scale-down / crash) is a dead session — don't route a student
+                # to it. The terminate reconciler reaps these, but guard here too.
+                wid = m.get("worker_id", "")
+                if wid and wid != "master" and wid not in ("queued", "") \
+                        and not await pool.exists(f"worker:{wid}"):
+                    continue
                 if (m.get("arena_user") == body.userId
                         and m.get("training_id") == body.trainingId
                         and ((not guard_tenant)

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -431,9 +431,28 @@ class WorkerManager:
                         rec = await self.pool.hgetall(key)
                     except Exception:
                         continue
-                    if rec.get("worker_id") != "master" or rec.get("terminating") != "1":
-                        continue
                     job_id = key.split("job:running:", 1)[1]
+                    worker_id = rec.get("worker_id", "")
+
+                    # Dead-worker orphan adoption: a remote worker (e.g. an
+                    # autoscaled spot instance) that is scaled down, reclaimed, or
+                    # crashes leaves its job:running keys behind — its own agent is
+                    # gone and the master reconciler used to skip all non-master
+                    # jobs, so the record lingered until the expiry reaper (hours).
+                    # Those ghosts break the provision idempotency guard (a student
+                    # re-provisioning would match a dead session) and inflate the
+                    # dashboard. If the owning worker is no longer registered, the
+                    # container is unreachable regardless of flags — reap the record.
+                    if (worker_id and worker_id != "master"
+                            and job_id not in self.active_jobs
+                            and not await self.pool.exists(f"worker:{worker_id}")):
+                        log.info("Reconciler: worker %s gone — reaping orphan %s",
+                                 worker_id, job_id)
+                        await self._force_clean_orphan(job_id)
+                        continue
+
+                    if worker_id != "master" or rec.get("terminating") != "1":
+                        continue
                     if job_id in self.active_jobs:
                         continue  # live task — listener + finally handle it
                     await self._kill_job_container(job_id, rec=rec)


### PR DESCRIPTION
**Found live during the bootcamp QA:** 2 student sessions showed as "running" with no container after their **autoscaled spot worker deregistered** (scaled down / TTL-expired heartbeat).

**Root cause:** a remote worker that dies leaves its `job:running` keys behind — its own agent reconciler is gone, and the master reconciler skipped every non-master job. The records lingered until the expiry reaper (hours). This is now common because the autoscaler churns spot workers.

**Impact:** ghost sessions inflate the dashboard AND break the new provision idempotency guard (#122) — a student re-provisioning would match a dead session and get routed to nothing.

**Fix:**
- Master `_terminate_reconciler` adopts orphans whose `worker:{id}` is no longer registered → `_force_clean_orphan`.
- Provision guard skips matches whose owning worker deregistered (defense in depth).

Verified: hand-reaped the 2 live ghosts (0 daemon jobs remain); this automates it. manager-env tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)