### PR TITLE
feat(fleet): dtwiz integration suite triggerable from Orbital + platform-token plumbing

### DIFF
--- a/.devcontainer/test/integration_dtwiz_k3d.sh
+++ b/.devcontainer/test/integration_dtwiz_k3d.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Integration test: dtwiz (dynatrace-oss/dtwiz) + K3d
+#
+# Validates the dtwiz-101 bootcamp training path end-to-end, platform-token-only:
+# installs the dtwiz CLI, points it at a tenant with a PLATFORM token, and runs
+# the same commands a learner runs — status, analyze, install kubernetes — then
+# asserts the operator + DynaKube came up in a fresh K3d cluster and tears down.
+#
+# Why this suite exists: dtwiz uses DT_PLATFORM_TOKEN (dt0s16), NOT the classic
+# DT_OPERATOR_TOKEN/DT_INGEST_TOKEN the other DT suites use, and operator >=1.10
+# accepts the platform token directly in the DynaKube secret. This is the
+# platform-token-native rollout the bootcamp trains on.
+#
+# Credentials: DT_ENVIRONMENT + DT_PLATFORM_TOKEN (platform token with, at least,
+#   installer download + settings read + AG-token create — the profile the
+#   Quickstart "auto discovery" token carries).
+#
+# Run: bash .devcontainer/test/integration_dtwiz_k3d.sh
+source .devcontainer/util/source_framework.sh
+
+printInfoSection "=== dtwiz K3d integration test | arch: $ARCH ==="
+
+_run_env=$(detectRunEnvironment)
+printInfo "Environment: $_run_env | Arch: $ARCH"
+
+# Credentials check — fail fast before any cluster setup.
+assertEnvVariable DT_ENVIRONMENT
+assertEnvVariable DT_PLATFORM_TOKEN
+
+# Pre-test cleanup: remove any clusters left from postCreate so we start clean.
+printInfo "Pre-test cleanup: removing any existing K3d clusters..."
+k3d cluster list -o json 2>/dev/null \
+  | python3 -c "import sys,json; [print(c['name']) for c in json.load(sys.stdin)]" 2>/dev/null \
+  | xargs -r k3d cluster delete 2>/dev/null || true
+
+# 1. Fresh K3d cluster (dtwiz names the cluster from the kube context)
+printInfoSection "1/5  Starting K3d cluster"
+export CLUSTER_ENGINE=k3d
+startK3dCluster
+
+# 2. Install the dtwiz CLI (official installer)
+printInfoSection "2/5  Installing dtwiz CLI"
+source <(curl -sSL https://raw.githubusercontent.com/dynatrace-oss/dtwiz/main/scripts/install.sh)
+export PATH="$HOME/bin:$HOME/.local/bin:$PATH"
+if ! command -v dtwiz >/dev/null 2>&1; then
+  printError "❌ dtwiz not on PATH after install"
+  deleteK3dCluster; exit 1
+fi
+printInfo "dtwiz version: $(dtwiz --version 2>/dev/null || echo unknown)"
+
+# 3. dtwiz connectivity — token must validate against the tenant
+printInfoSection "3/5  dtwiz status (platform-token auth)"
+if dtwiz status 2>&1 | tee /tmp/dtwiz_status.log | grep -qiE "Platform Token:.*valid|valid \("; then
+  printInfo "✅ dtwiz authenticated to $DT_ENVIRONMENT"
+else
+  printError "❌ dtwiz status did not confirm a valid platform token"
+  cat /tmp/dtwiz_status.log
+  deleteK3dCluster; exit 1
+fi
+dtwiz analyze 2>&1 | head -20 || true
+
+# 4. dtwiz install kubernetes — deploys the operator with the platform token
+printInfoSection "4/5  dtwiz install kubernetes"
+if ! dtwiz install kubernetes --yes 2>&1 | tail -40; then
+  printWarn "dtwiz install kubernetes returned non-zero — checking cluster state anyway"
+fi
+
+# 5. Assertions — operator + DynaKube present
+printInfoSection "5/5  Assertions"
+assertRunningPod dynatrace operator
+if kubectl get dynakube -n dynatrace >/dev/null 2>&1; then
+  printInfo "✅ DynaKube created by dtwiz:"
+  kubectl get dynakube -n dynatrace --no-headers
+else
+  printError "❌ No DynaKube after dtwiz install kubernetes"
+  kubectl -n dynatrace get pods
+  deleteK3dCluster; exit 1
+fi
+
+# Cleanup
+printInfoSection "Cleanup: deleting K3d cluster"
+deleteK3dCluster
+
+printInfoSection "✅ dtwiz K3d test PASSED (arch: $ARCH)"

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -4776,6 +4776,7 @@ FRAMEWORK_SUITES = [
     {"id": "dt-apponly","name": "DT Application Monitoring", "description": "Operator + ActiveGate + CSI code injection + todo-app (K3d, AMD64+ARM64)",          "arch": "both", "needs_creds": True,  "test_script": "bash .devcontainer/test/integration_appmon_k3d_todoapp.sh"},
     {"id": "dt-cnfs",   "name": "DT CloudNative FullStack",  "description": "CNFS dynakube + K3d — OneAgent crash expected on container nodes (AMD64+ARM64)", "arch": "both", "needs_creds": True,  "requires_native": True, "test_script": "bash .devcontainer/test/integration_cnfs_k3d_todoapp.sh"},
     {"id": "k3d-aitraveladvisor", "name": "AI Travel Advisor", "description": "Ollama + Weaviate + app on K3d — verifies local-path PVC and ingress (AMD64, needs DT_LLM_TOKEN)", "arch": "amd64", "needs_creds": True, "test_script": "bash .devcontainer/test/integration_k3d_aitraveladvisor.sh"},
+    {"id": "dtwiz",     "name": "dtwiz (platform-token)",     "description": "dtwiz CLI install → status → analyze → install kubernetes on K3d (operator via platform token; the dtwiz-101 bootcamp path). Needs DT_PLATFORM_TOKEN.", "arch": "amd64", "needs_creds": True, "requires_native": True, "test_script": "bash .devcontainer/test/integration_dtwiz_k3d.sh"},
 ]
 
 @app.get("/api/framework/suites")

--- a/ops-server/webhook/config.py
+++ b/ops-server/webhook/config.py
@@ -27,6 +27,8 @@ MAX_PARALLEL_AGENTS = int(os.environ.get("MAX_PARALLEL_AGENTS", "2"))
 DT_ENVIRONMENT = os.environ.get("DT_ENVIRONMENT", "")
 DT_OPERATOR_TOKEN = os.environ.get("DT_OPERATOR_TOKEN", "")
 DT_INGEST_TOKEN = os.environ.get("DT_INGEST_TOKEN", "")
+# Platform token (dt0s16) for the dtwiz suite + platform-token-native trainings.
+DT_PLATFORM_TOKEN = os.environ.get("DT_PLATFORM_TOKEN", "")
 
 # Codespaces tracker
 TRACKER_ENDPOINT = os.environ.get(

--- a/ops-server/worker-agent/config.py
+++ b/ops-server/worker-agent/config.py
@@ -57,6 +57,8 @@ DT_ENVIRONMENT = os.environ.get("DT_ENVIRONMENT", "")
 DT_OPERATOR_TOKEN = os.environ.get("DT_OPERATOR_TOKEN", "")
 DT_INGEST_TOKEN = os.environ.get("DT_INGEST_TOKEN", "")
 DT_LLM_TOKEN = os.environ.get("DT_LLM_TOKEN", "")
+# Platform token (dt0s16) for the dtwiz suite + platform-token-native trainings.
+DT_PLATFORM_TOKEN = os.environ.get("DT_PLATFORM_TOKEN", "")
 
 # Timeouts
 TEST_TIMEOUT = int(os.environ.get("TEST_TIMEOUT", "900"))  # 15 min

--- a/ops-server/worker-agent/executor.py
+++ b/ops-server/worker-agent/executor.py
@@ -45,6 +45,7 @@ from .config import (
     DT_OPERATOR_TOKEN,
     DT_INGEST_TOKEN,
     DT_LLM_TOKEN,
+    DT_PLATFORM_TOKEN,
     TEST_TIMEOUT,
     TEST_IMAGE,
     WORKER_ARCH,
@@ -850,6 +851,10 @@ def _write_env_file(
             "DT_INGEST_TOKEN":   DT_INGEST_TOKEN,
             "DT_LLM_TOKEN":      DT_LLM_TOKEN,
         }
+        # Platform token for the dtwiz suite + platform-token-native trainings
+        # (dtwiz uses DT_PLATFORM_TOKEN, not the classic operator/ingest pair).
+        if DT_PLATFORM_TOKEN:
+            resolved["DT_PLATFORM_TOKEN"] = DT_PLATFORM_TOKEN
     else:
         log.warning(
             "Daemon %s targets non-CoE tenant %s with no per-tenant tokens; writing "

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -24,6 +24,7 @@ from webhook.config import (
     DT_ENVIRONMENT,
     DT_OPERATOR_TOKEN,
     DT_INGEST_TOKEN,
+    DT_PLATFORM_TOKEN,
 )
 from telemetry.reporter import (
     report_test_result,
@@ -2164,6 +2165,10 @@ class WorkerManager:
         )
         if dt_oneagent:
             dt_lines += f"DT_ONEAGENT_TOKEN={dt_oneagent}\n"
+        # Platform token for the dtwiz suite + platform-token-native trainings
+        # (CoE / internal only; never written for a non-CoE tenant).
+        if is_coe and not dt_env and DT_PLATFORM_TOKEN:
+            dt_lines += f"DT_PLATFORM_TOKEN={DT_PLATFORM_TOKEN}\n"
 
         # Provision-time id wins (dashboard already derived + returned it to the
         # app); deriving from the user is the fallback for jobs enqueued elsewhere.


### PR DESCRIPTION
"Add dtwiz to the fleet so we can trigger it." Adds the **dtwiz** suite to the Orbital dashboard's framework triggers — validates the dtwiz-101 bootcamp path e2e: install dtwiz CLI → status/analyze → `install kubernetes` on K3d using a **platform token** (operator ≥1.10 accepts dt0s16 directly).

- New `integration_dtwiz_k3d.sh` + `FRAMEWORK_SUITES` entry (amd64, needs_creds, requires_native)
- `DT_PLATFORM_TOKEN` threaded through config + written into the CoE session `.env` by both env writers (dtwiz uses DT_PLATFORM_TOKEN, not the classic operator/ingest pair). CoE-only — never leaked to a non-CoE tenant.

dtwiz-101 is already a triggerable *training* in the arena catalog; this adds the *CI validation* suite so we can click-to-test it before the bootcamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)