### PR TITLE
Arena: nginx timeout ceiling for automation execs; validator waits via LAB_WAIT=1

### DIFF
--- a/ops-server/nginx/ops-server.conf
+++ b/ops-server/nginx/ops-server.conf
@@ -379,6 +379,23 @@ server {
         return 401 '{"error":"unauthorized","sign_in":"/oauth2/sign_in"}';
     }
 
+    # ── Arena API (training sessions, called via the DT app function) ──────
+    # Learner-facing checks answer instantly (check* helpers) and never hold
+    # this connection. The high ceiling exists for AUTOMATION only: lab-driver
+    # and the agentic validator run the same commands with LAB_WAIT=1 (bounded
+    # rollout waits) and timeoutSeconds up to Orbital's 900 s exec clamp. The
+    # proxy must outlive that cap so the client always receives Orbital's clean
+    # JSON result/timeout — never an nginx 504 HTML page.
+    location ~ ^/api/arena/ {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 910s;
+        proxy_send_timeout 910s;
+    }
+
     # ── GitHub webhook (public — HMAC-signed by GitHub) ────────────────────
     location /webhook {
         proxy_pass http://127.0.0.1:8443;

--- a/ops-server/tools/agentic_validator.py
+++ b/ops-server/tools/agentic_validator.py
@@ -61,7 +61,7 @@ DOCS_BASE_URL = "https://dynatrace-wwse.github.io"
 
 PROVISION_TIMEOUT_S = 900   # 15 min max for cluster setup
 POLL_INTERVAL_S = 20
-EXEC_TIMEOUT_S = 120        # mirrors server-side timeout
+EXEC_TIMEOUT_S = 660        # covers the longest LAB_WAIT check budget (framework waitForPod: 60×10s)
 
 # trainingId → repo name mapping (mirrors _ARENA_REPOS in app.py)
 TRAINING_REPO_MAP: dict[str, str] = {
@@ -150,11 +150,18 @@ def wait_ready(session: requests.Session, job_id: str, timeout_s: int = PROVISIO
 
 
 def exec_command(session: requests.Session, job_id: str, command: str) -> dict[str, Any]:
-    """Run a non-interactive command inside the training container."""
+    """Run a non-interactive command inside the training container.
+
+    LAB_WAIT=1 switches the labs' check* verification helpers into their
+    bounded-retry mode: automation waits for the expected state (rollouts are
+    asynchronous), while learner clicks in the app — which never set LAB_WAIT —
+    get an instant answer.
+    """
     try:
         r = session.post(
             f"{ORBITAL_API}/api/arena/sessions/{job_id}/exec",
-            json={"command": command},
+            json={"command": f"export LAB_WAIT=1; {command}",
+                  "timeoutSeconds": EXEC_TIMEOUT_S},
             timeout=EXEC_TIMEOUT_S + 10,
         )
         if not r.ok:


### PR DESCRIPTION
## Context

Learner-facing verification checks are now instant (dynatrace-wwse/enablement-kubernetes-101#31). Automation (lab-driver, agentic validator, solution runs) is the only caller that legitimately holds an arena exec connection while a check waits for a rollout — this PR gives it the transport headroom and the wait switch.

## Changes

- **`ops-server/nginx/ops-server.conf`** — dedicated `location ~ ^/api/arena/` with `proxy_read_timeout`/`proxy_send_timeout 910s`. Previously `/api/arena/*` fell into the catch-all `location /` (60 s default), so any exec outliving 60 s returned an nginx 504 HTML page instead of Orbital's clean JSON — the root cause of the "Orbital returned 504: `<html>…`" error in the training app. The ceiling must outlive Orbital's 900 s exec clamp; learner checks answer in milliseconds and never touch it.
- **`ops-server/tools/agentic_validator.py`** — `exec_command` prepends `export LAB_WAIT=1;` (switches the labs' `check*` helpers into bounded-wait mode) and passes `timeoutSeconds`; `EXEC_TIMEOUT_S` 120 → 660 to cover the longest framework wait budget (`waitForPod`: 60×10 s).

## Verification (live, COE session)

- `sleep 200` through nginx → clean JSON at 200.7 s (old config died at 60 s).
- `sleep 15` with a 10 s cap → Orbital's JSON `"Command timed out after 10 seconds"` at 10.1 s — no 504.
- All six k8s-101 `check*` helpers: 0.4–0.5 s round-trip, correct exit codes and messages.

**Note:** the nginx config is already deployed and live on the ops server (`/etc/nginx/sites-available/ops-server`, both repo checkouts synced) — merging makes the repo match production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)