### PR TITLE
fix(dynakube): feature-aware name cap — operator 1.10 rejects 38-char names

### DIFF
--- a/.devcontainer/test/unit/test_dynakube.bats
+++ b/.devcontainer/test/unit/test_dynakube.bats
@@ -354,6 +354,79 @@ EOF
   [[ "$name" != *"-" ]]
 }
 
+# Operator >= 1.10 tightens the DynaKube name limit per enabled feature:
+# telemetryIngest -> 37 (-otel-collector suffix), KSPM -> 35, extensions -> 31.
+
+@test "generateDynakube: telemetry_ingest caps name at 37 (operator 1.10 -otel-collector suffix)" {
+  source_functions
+  export RepositoryName="enablement-kubernetes-101"
+  export DT_HOSTGROUP="training-test-1102-20260731"
+
+  cat > "$FAKE_REPO/.devcontainer/yaml/dynakube-config.yaml" <<'EOF'
+telemetry_ingest: true
+EOF
+
+  generateDynakube apponly
+
+  name_line=$(grep -m1 '^  name: ' "$FAKE_REPO/.devcontainer/yaml/gen/dynakube.yaml")
+  name="${name_line#  name: }"
+  [ "${#name}" -le 37 ]
+  [[ "$name" == *"-training-test-1102-20260731" ]]
+}
+
+@test "generateDynakube: telemetry_ingest off keeps the 38 cap" {
+  source_functions
+  export RepositoryName="enablement-kubernetes-101"
+  export DT_HOSTGROUP="training-test-1102-20260731"
+
+  cat > "$FAKE_REPO/.devcontainer/yaml/dynakube-config.yaml" <<'EOF'
+telemetry_ingest: false
+EOF
+
+  generateDynakube apponly
+
+  name_line=$(grep -m1 '^  name: ' "$FAKE_REPO/.devcontainer/yaml/gen/dynakube.yaml")
+  name="${name_line#  name: }"
+  [ "${#name}" -le 38 ]
+  [ "${#name}" -ge 38 ]
+}
+
+@test "generateDynakube: kspm and extensions tighten the cap further (35 / 31)" {
+  source_functions
+  export RepositoryName="enablement-kubernetes-opentelemetry-openpipeline"
+  export DT_HOSTGROUP="bob-20260714"
+
+  cat > "$FAKE_REPO/.devcontainer/yaml/dynakube-config.yaml" <<'EOF'
+mode: cloudnative
+telemetry_ingest: true
+kspm: true
+extensions: true
+EOF
+
+  generateDynakube cloudnative
+
+  name_line=$(grep -m1 '^  name: ' "$FAKE_REPO/.devcontainer/yaml/gen/dynakube.yaml")
+  name="${name_line#  name: }"
+  [ "${#name}" -le 31 ]
+  [[ "$name" == *"-bob-20260714" ]]
+}
+
+@test "generateDynakube: no session id also respects the feature cap (long repo names)" {
+  source_functions
+  export RepositoryName="enablement-kubernetes-opentelemetry-openpipeline"
+
+  cat > "$FAKE_REPO/.devcontainer/yaml/dynakube-config.yaml" <<'EOF'
+telemetry_ingest: true
+EOF
+
+  generateDynakube apponly
+
+  name_line=$(grep -m1 '^  name: ' "$FAKE_REPO/.devcontainer/yaml/gen/dynakube.yaml")
+  name="${name_line#  name: }"
+  [ "${#name}" -le 37 ]
+  [[ "$name" != *"-" ]]
+}
+
 @test "generateDynakube: no session id keeps pre-1.9 repo-scoped identity" {
   source_functions
 

--- a/.devcontainer/util/functions.sh
+++ b/.devcontainer/util/functions.sh
@@ -1556,16 +1556,25 @@ generateDynakube() {
   local base_name="$(echo "${RepositoryName:-$(hostname)}" | tr '[:upper:]' '[:lower:]')"
   local cluster_name="$base_name"
   local session_id="$(getDtSessionId)"
+  # The operator's validating webhook enforces a HARD DynaKube name limit
+  # (child resources like <name>-activegate-<hash> must fit the 63-char k8s
+  # label limit). Operator >= 1.10 tightens it per enabled feature:
+  # base 38, telemetryIngest 37 (-otel-collector), KSPM 35, extensions 31.
+  local name_cap=38
+  [[ "${DK_TELEMETRY_INGEST:-false}" == "true" && name_cap -gt 37 ]] && name_cap=37
+  [[ "${DK_KSPM:-false}" == "true" && name_cap -gt 35 ]] && name_cap=35
+  [[ "${DK_EXTENSIONS:-false}" == "true" && name_cap -gt 31 ]] && name_cap=31
   if [[ -n "$session_id" ]]; then
-    # The operator's validating webhook enforces a HARD 38-char DynaKube name
-    # limit (child resources like <name>-activegate-<hash> must fit the 63-char
-    # k8s label limit) — sacrifice repo chars before the session id.
-    local name_budget=$(( 38 - ${#session_id} - 1 ))
+    # Sacrifice repo chars before the session id.
+    local name_budget=$(( name_cap - ${#session_id} - 1 ))
     (( name_budget < 1 )) && name_budget=1
     local repo_part="${base_name:0:$name_budget}"
     repo_part="${repo_part%-}"
     cluster_name="${repo_part}-${session_id}"
-    cluster_name="${cluster_name:0:38}"
+    cluster_name="${cluster_name:0:$name_cap}"
+    cluster_name="${cluster_name%-}"
+  else
+    cluster_name="${cluster_name:0:$name_cap}"
     cluster_name="${cluster_name%-}"
   fi
   local api_url="${DT_TENANT}/api"


### PR DESCRIPTION
## Root cause (nightly k8s-101 FAIL on the operator 1.10.2 override)

Operator 1.10 tightens the DynaKube **name limit per enabled feature**:

| Feature enabled | Max name length |
|---|---|
| (base) | 40 |
| `telemetryIngest` | **37** (52 − len(`-otel-collector`)) |
| KSPM | 35 |
| extensions | 31 |

Framework defaults set `telemetry_ingest: true`, and per-user session names (repo + session id) land on exactly **38 chars** — so the 1.10.2 validating webhook denied every DynaKube:

```
The length limit for the name of a DynaKube is 37, because it is the base for the name of
resources related to the DynaKube. ... When using OpenTelemetry collectors, some resources
require the DynaKube name to be shorter than usual.
```

The DynaKube was never created → ActiveGate wait timed out → section 2/3 FAIL (1988s). Operator 1.9.0 enforces a flat 40 and never caught it. **The manifest schema itself is valid on 1.10.2** (v1beta6 still served + storage) — no schema rework needed.

## Fix

`generateDynakube` derives the name cap from the enabled features (38 → 37/35/31) instead of a hard 38, and now also caps session-less names — long repo names (e.g. `enablement-kubernetes-opentelemetry-openpipeline`, 48 chars) were never capped and exceeded even the old 40 limit.

## Verification

- 150/150 unit tests green (4 new: telemetry→37, telemetry-off→38, kspm+extensions→31, session-less cap).
- Live against helm-installed operator 1.10.2 in k3d: 38-char name + telemetryIngest → denied with the exact nightly error; capped 37-char name → accepted.

## Unblocks

Framework release 1.9.3 (AG secret wiring `5fbb0f6` + operator 1.10.2 default `b00eedf` + this) → platform-token path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)