### PR TITLE
fix(dynakube): swap unpullable private-ECR ActiveGate image on Sprint tenants

### DIFF
--- a/.devcontainer/test/unit/test_dynakube.bats
+++ b/.devcontainer/test/unit/test_dynakube.bats
@@ -498,3 +498,63 @@ EOF
   [[ "$result" == *"dynatrace-wwse-test-enablement"* ]]
   [[ "$result" == *"framework.version"* ]]
 }
+
+# ============================================================
+# Sprint ActiveGate image workaround
+# ============================================================
+
+@test "isSprintTenant: true for sprint apps + api URLs, false for prod/sro" {
+  source_functions
+
+  run isSprintTenant "https://ydi9582h.sprint.apps.dynatracelabs.com"
+  [ "$status" -eq 0 ]
+  run isSprintTenant "https://ydi9582h.sprint.dynatracelabs.com/api"
+  [ "$status" -eq 0 ]
+
+  run isSprintTenant "https://geu80787.apps.dynatrace.com"
+  [ "$status" -ne 0 ]
+  run isSprintTenant "https://sro97894.apps.dynatrace.com"
+  [ "$status" -ne 0 ]
+}
+
+@test "isSprintTenant: falls back to DT_ENVIRONMENT when no arg" {
+  source_functions
+
+  DT_ENVIRONMENT="https://ydi9582h.sprint.apps.dynatracelabs.com" run isSprintTenant
+  [ "$status" -eq 0 ]
+  DT_ENVIRONMENT="https://geu80787.apps.dynatrace.com" run isSprintTenant
+  [ "$status" -ne 0 ]
+}
+
+@test "_pickLatestActiveGateTag: picks newest clean version, ignores sig/att/fips/raw" {
+  source_functions
+
+  output="$(printf "%s\n" \
+    "1.341.34.20260703-181150" \
+    "1.343.52.20260727-092518" \
+    "1.339.39.20260605-153224" \
+    "1.343.52.20260727-092518-fips" \
+    "sha256-deadbeef.sig" \
+    "1.341.31-raw" \
+    "sha256-cafe.att" | _pickLatestActiveGateTag)"
+  [ "$output" = "1.343.52.20260727-092518" ]
+}
+
+@test "_pickLatestActiveGateTag: empty when no clean version tags" {
+  source_functions
+
+  output="$(printf "%s\n" "latest" "sha256-x.sig" "1.341.31-raw" | _pickLatestActiveGateTag)"
+  [ -z "$output" ]
+}
+
+@test "fixSprintActiveGateImage: no-op (returns 0, no kubectl) on non-sprint tenant" {
+  source_functions
+  # kubectl stub that would fail the test if called
+  kubectl() { echo "KUBECTL_SHOULD_NOT_RUN" >&2; return 1; }
+  export -f kubectl
+
+  DT_ENVIRONMENT="https://geu80787.apps.dynatrace.com" run fixSprintActiveGateImage
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"KUBECTL_SHOULD_NOT_RUN"* ]]
+  [[ "$output" != *"downgrading to the latest available"* ]]
+}

--- a/.devcontainer/util/functions.sh
+++ b/.devcontainer/util/functions.sh
@@ -1304,6 +1304,60 @@ printSecrets(){
     printInfo "Dynatrace Otel Endpoint: $DT_OTEL_ENDPOINT"
 }
 
+# ── Sprint ActiveGate image workaround ──────────────────────────────────────────
+# Sprint tenants resolve the ActiveGate image to a private build ECR
+# (478983378254.dkr.ecr.us-east-1.amazonaws.com) that a public k3d cluster cannot
+# authenticate to, so the AG pod stays in ImagePullBackOff and the DynaKube never
+# finishes. Prod/gen2 tenants serve the AG from their own tenant registry and are
+# unaffected. On sprint we swap the AG image to the latest PUBLIC ActiveGate build so
+# the many internal/onboarding trainings that run on sprint still work.
+
+isSprintTenant() {
+  # Returns 0 if the tenant URL is a sprint tenant. $1 defaults to $DT_ENVIRONMENT.
+  local url="${1:-$DT_ENVIRONMENT}"
+  case "$url" in
+    *sprint.apps.dynatracelabs.com*|*.sprint.dynatracelabs.com*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+_pickLatestActiveGateTag() {
+  # Read a newline-delimited tag list on stdin; echo the newest clean version tag
+  # (form N.N.N.N-N). Ignores signature/attestation (.sig/.att) and -fips/-raw variants.
+  grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$' | sort -V | tail -1
+}
+
+latestPublicActiveGateImage() {
+  # Echo the newest pullable image ref on public.ecr.aws/dynatrace/dynatrace-activegate,
+  # or return non-zero if it can't be resolved (offline / API change).
+  local repo="public.ecr.aws/dynatrace/dynatrace-activegate" token tag
+  token="$(curl -fsS https://public.ecr.aws/token/ 2>/dev/null | jq -r '.token // empty')" || return 1
+  [ -n "$token" ] || return 1
+  tag="$(curl -fsS -H "Authorization: Bearer $token" \
+        "https://public.ecr.aws/v2/dynatrace/dynatrace-activegate/tags/list" 2>/dev/null \
+        | jq -r '.tags[]?' | _pickLatestActiveGateTag)"
+  [ -n "$tag" ] || return 1
+  echo "${repo}:${tag}"
+}
+
+fixSprintActiveGateImage() {
+  # No-op unless the tenant is sprint. On sprint: warn and patch the deployed DynaKube's
+  # spec.activeGate.image to the latest public build (the operator then recreates the AG
+  # pod with a pullable image). Best-effort — never fails the deploy.
+  isSprintTenant || return 0
+  printWarn "ActiveGate images by default on Sprint won't be found, hence downgrading to the latest available ActiveGate image."
+  local img dk
+  if ! img="$(latestPublicActiveGateImage)"; then
+    printWarn "Could not resolve a public ActiveGate image — leaving the default."
+    return 0
+  fi
+  dk="$(kubectl get dynakube -n dynatrace --no-headers 2>/dev/null | awk '{print $1}' | head -1)"
+  [ -n "$dk" ] || return 0
+  printInfo "Pinning ActiveGate image to $img"
+  kubectl -n dynatrace patch dynakube "$dk" --type=merge \
+    -p "{\"spec\":{\"activeGate\":{\"image\":\"$img\"}}}" >/dev/null 2>&1
+}
+
 deployCloudNative() {
   # Warn if running on k3d — OneAgent DaemonSet will CrashLoopBackOff on container-based nodes
   if [[ "${CLUSTER_ENGINE:-k3d}" != "kind" ]]; then
@@ -1367,6 +1421,10 @@ deployDynatrace() {
   fi
 
   kubectl -n dynatrace apply -f "$gen_file"
+
+  # Sprint tenants ship an unpullable private-ECR ActiveGate image — swap it for the
+  # latest public build so the AG can actually start (no-op on prod/gen2 tenants).
+  fixSprintActiveGateImage
 
   # Wait for ActiveGate to be ready (the critical component for cluster monitoring)
   waitForPod dynatrace activegate


### PR DESCRIPTION
## Problem
Sprint tenants resolve the ActiveGate image to a **private build ECR**
(`478983378254.dkr.ecr.us-east-1.amazonaws.com/dynatrace/dynatrace-activegate`) that a public
k3d cluster cannot authenticate to → AG pod stuck `Init:ErrImagePull`, DynaKube never finishes.
This blocks every K8s-with-ActiveGate training on Sprint (many internal/onboarding trainings run there).
Prod/gen2 tenants serve the AG from their own tenant registry and are unaffected. Confirmed the
operator version is not the lever (1.10.1 and 1.10.2 resolve the identical private-ECR image).

## Fix
`fixSprintActiveGateImage` (called in `deployDynatrace` right after the DynaKube apply):
on **Sprint only**, prints the warning and patches the DynaKube's `spec.activeGate.image` to the
**latest public** ActiveGate build (resolved live from `public.ecr.aws/dynatrace/dynatrace-activegate`).
The operator recreates the AG pod with a pullable image. **No-op on every other tenant.**

Helpers: `isSprintTenant`, `_pickLatestActiveGateTag`, `latestPublicActiveGateImage`.

## Tests
- Unit (`test_dynakube.bats`): sprint detection (sprint vs prod/sro), latest-tag selection
  (ignores `.sig`/`.att`/`-fips`/`-raw`), non-sprint no-op (never calls kubectl).
- **Live on sprint (ydi9582h):** AG image private-ECR `ErrImagePull` → patched to
  `public.ecr.aws/dynatrace/dynatrace-activegate:1.343.52.20260727-092518` → AG pod **1/1 Running**.

Surgical: one new call site in `deployDynatrace`, no change to existing behavior on non-sprint tenants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)