### PR TITLE
feat(workshops): live-session scheduling, capacity, provision-all, structured pad (EPIC-002)

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -4795,6 +4795,13 @@ class LiveSessionJoinByCode(BaseModel):
 class LiveSessionProvisionAll(BaseModel):
     trainerEmail: str = ""
     tenant: str = ""              # trainer's arena tenant URL
+    # Subset of roster emails to provision this call (empty = whole roster) —
+    # lets the app chunk large rosters under its 120s function cap.
+    emails: list[str] = []
+    # Per-learner app-minted token env (email -> {dtEnv, dtTokenIds}). Orbital
+    # stores no tenant credential, so the app mints and passes values through,
+    # exactly as the single-user /api/arena/provision path does.
+    perUser: dict[str, dict] = {}
 
 
 async def _reserve_join_code(session_id: str) -> str:
@@ -4948,7 +4955,10 @@ async def api_live_session_end(session_id: str, body: LiveSessionTrainerAction):
         raise HTTPException(status_code=404, detail="Session not found or expired")
     if not live_sessions.is_trainer(body.trainerEmail, session):
         raise HTTPException(status_code=403, detail="trainerEmail does not match this session's trainer")
-    new_state, changed = live_sessions.apply_transition(session.get("state", ""), "end")
+    try:
+        new_state, changed = live_sessions.apply_transition(session.get("state", ""), "end")
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
     if changed:
         session["state"] = new_state
         session["endedAt"] = datetime.now(timezone.utc).isoformat()
@@ -5065,14 +5075,20 @@ async def api_live_session_provision_all(session_id: str, body: LiveSessionProvi
     if not live_sessions.is_trainer(body.trainerEmail, session):
         raise HTTPException(status_code=403, detail="trainerEmail does not match this session's trainer")
     roster = await pool.smembers(roster_key)
+    wanted = {e.strip().lower() for e in body.emails if e.strip()} if body.emails else None
     results = []
     for email in sorted(roster):
+        if wanted is not None and email.lower() not in wanted:
+            continue
+        per = body.perUser.get(email) or body.perUser.get(email.lower()) or {}
         try:
             provisioned = await api_arena_provision(ArenaProvisionRequest(
                 trainingId=session.get("trainingId", ""),
                 userId=email,
                 tenantUrl=(body.tenant or "").rstrip("/"),
                 ref=session.get("ref", ""),
+                dtEnv=per.get("dtEnv") or {},
+                dtTokenIds=per.get("dtTokenIds") or [],
             ))
             results.append({
                 "email":  email,

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -81,6 +81,10 @@ from dashboard import fleet  # noqa: E402
 # dashboard/live_sessions.py (tested without Redis); endpoints below stay thin.
 from dashboard import live_sessions  # noqa: E402
 
+# Structured workshop pad (EPIC-002) — pure decision logic in
+# dashboard/live_pad.py (tested without Redis); endpoints below stay thin.
+from dashboard import live_pad  # noqa: E402
+
 _PROFILES_PAGE = """<!doctype html><html><head><meta charset=utf-8>
 <title>Content Profiles</title><style>
 body{font-family:system-ui,sans-serif;margin:0;background:#0d1117;color:#e6edf3}
@@ -4766,6 +4770,12 @@ class LiveSessionCreate(BaseModel):
     ref: str = ""                 # optional content branch
     trainerEmail: str = ""
     roster: list[str] = []
+    # Workshop scheduling (EPIC-002) — all optional; absent fields keep the
+    # pre-workshop behavior (immediate state=open, no seat cap).
+    scheduledAt: str = ""         # ISO8601 UTC → initial state "scheduled"
+    timezone: str = ""            # IANA zone name
+    durationMinutes: int = 0
+    maxSeats: int = 0             # 0 = unlimited
 
 
 class LiveSessionJoin(BaseModel):
@@ -4776,6 +4786,28 @@ class LiveSessionTrainerAction(BaseModel):
     trainerEmail: str = ""
 
 
+class LiveSessionJoinByCode(BaseModel):
+    code: str = ""
+    email: str = ""
+    name: str = ""
+
+
+class LiveSessionProvisionAll(BaseModel):
+    trainerEmail: str = ""
+    tenant: str = ""              # trainer's arena tenant URL
+
+
+async def _reserve_join_code(session_id: str) -> str:
+    """Generate a join code and claim it via SET NX on live:joincode:{code}
+    so two sessions can never share one. 31^6 ≈ 887M codes — collisions are
+    vanishingly rare, but retry a few times anyway."""
+    for _ in range(20):
+        code = live_sessions.generate_join_code()
+        if await pool.set(f"live:joincode:{code}", session_id, nx=True):
+            return code
+    raise HTTPException(status_code=500, detail="could not allocate a unique join code")
+
+
 @app.post("/api/live/sessions")
 async def api_live_session_create(body: LiveSessionCreate):
     """Create a live session (state=open) with a roster of invited emails.
@@ -4783,25 +4815,38 @@ async def api_live_session_create(body: LiveSessionCreate):
     Emails are trimmed + lowercased; entries without an '@' are dropped.
     400 when title/trainingId/trainerEmail is missing or the roster is empty
     after normalization. Returns the full session JSON (trainer view).
+
+    Workshops (EPIC-002): scheduledAt/timezone/durationMinutes/maxSeats are
+    optional; creating WITH scheduledAt yields state "scheduled" (open the
+    room later via /open-registration or /start), without it state "open"
+    exactly as before. Every session gets a unique join code (trainer-only
+    in payloads) resolvable via POST /api/live/sessions/join-by-code.
     """
     try:
         fields = live_sessions.validate_create(
             body.title, body.trainingId, body.trainerEmail, body.roster)
+        schedule = live_sessions.validate_schedule(
+            body.scheduledAt, body.timezone, body.durationMinutes, body.maxSeats)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
     session_id = _new_job_id()
+    join_code = await _reserve_join_code(session_id)
     now = datetime.now(timezone.utc)
     session = {
         "title":        fields["title"],
         "trainingId":   fields["trainingId"],
         "ref":          (body.ref or "").strip(),
         "trainerEmail": fields["trainerEmail"],
-        "state":        "open",
+        "state":        live_sessions.initial_state(schedule["scheduledAt"]),
         "createdAt":    now.isoformat(),
         "startedAt":    "",
         "endedAt":      "",
+        "joinCode":     join_code,
     }
+    # Optional workshop fields — only written when present so pre-workshop
+    # sessions (and their payloads) stay byte-identical.
+    session.update({k: v for k, v in schedule.items() if v})
     sess_key, roster_key, _ = _live_keys(session_id)
     await pool.hset(sess_key, mapping=session)
     await pool.sadd(roster_key, *fields["roster"])
@@ -4869,8 +4914,9 @@ async def api_live_session_join(session_id: str, body: LiveSessionJoin):
 
 @app.post("/api/live/sessions/{session_id}/start")
 async def api_live_session_start(session_id: str, body: LiveSessionTrainerAction):
-    """Trainer starts the session: open → running (learners' waiting screens
-    flip). Idempotent when already running; 403 on trainerEmail mismatch."""
+    """Trainer starts the session: scheduled|open → running (learners'
+    waiting screens flip). Idempotent when already running; 403 on
+    trainerEmail mismatch."""
     sess_key, roster_key, joined_key = _live_keys(session_id)
     session = await pool.hgetall(sess_key)
     if not session:
@@ -4908,12 +4954,805 @@ async def api_live_session_end(session_id: str, body: LiveSessionTrainerAction):
         session["endedAt"] = datetime.now(timezone.utc).isoformat()
         await pool.hset(sess_key, mapping={
             "state": new_state, "endedAt": session["endedAt"]})
+        await _store_pad_export(session_id, session)
         log.info("Live session %s ended by %s", session_id, body.trainerEmail)
-    for key in (sess_key, roster_key, joined_key):
-        await pool.expire(key, live_sessions.SESSION_TTL_SECONDS)
+    await _expire_live_session_keys(session_id, session)
     roster = await pool.smembers(roster_key)
     joined = await pool.hgetall(joined_key)
     return live_sessions.shape_detail(session_id, session, roster, joined, body.trainerEmail)
+
+
+@app.post("/api/live/sessions/{session_id}/cancel")
+async def api_live_session_cancel(session_id: str, body: LiveSessionTrainerAction):
+    """Trainer cancels a scheduled/open workshop: state → cancelled, sets
+    cancelledAt, freezes the pad into the export snapshot, and applies the
+    same 7-day TTL as ended (entity + index kept so learners see it was
+    cancelled rather than a vanished session). Idempotent; 409 once running
+    or ended; 403 on trainerEmail mismatch."""
+    sess_key, roster_key, joined_key = _live_keys(session_id)
+    session = await pool.hgetall(sess_key)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+    if not live_sessions.is_trainer(body.trainerEmail, session):
+        raise HTTPException(status_code=403, detail="trainerEmail does not match this session's trainer")
+    try:
+        new_state, changed = live_sessions.apply_transition(session.get("state", ""), "cancel")
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    if changed:
+        session["state"] = new_state
+        session["cancelledAt"] = datetime.now(timezone.utc).isoformat()
+        await pool.hset(sess_key, mapping={
+            "state": new_state, "cancelledAt": session["cancelledAt"]})
+        await _store_pad_export(session_id, session)
+        log.info("Live session %s cancelled by %s", session_id, body.trainerEmail)
+    await _expire_live_session_keys(session_id, session)
+    roster = await pool.smembers(roster_key)
+    joined = await pool.hgetall(joined_key)
+    return live_sessions.shape_detail(session_id, session, roster, joined, body.trainerEmail)
+
+
+@app.post("/api/live/sessions/{session_id}/open-registration")
+async def api_live_session_open_registration(session_id: str, body: LiveSessionTrainerAction):
+    """Trainer opens registration on a scheduled workshop: scheduled → open.
+    Idempotent when already open; 409 once running/ended/cancelled; 403 on
+    trainerEmail mismatch."""
+    sess_key, roster_key, joined_key = _live_keys(session_id)
+    session = await pool.hgetall(sess_key)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+    if not live_sessions.is_trainer(body.trainerEmail, session):
+        raise HTTPException(status_code=403, detail="trainerEmail does not match this session's trainer")
+    try:
+        new_state, changed = live_sessions.apply_transition(session.get("state", ""), "open-registration")
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    if changed:
+        session["state"] = new_state
+        await pool.hset(sess_key, "state", new_state)
+        log.info("Live session %s registration opened by %s", session_id, body.trainerEmail)
+    roster = await pool.smembers(roster_key)
+    joined = await pool.hgetall(joined_key)
+    return live_sessions.shape_detail(session_id, session, roster, joined, body.trainerEmail)
+
+
+@app.post("/api/live/sessions/join-by-code")
+async def api_live_session_join_by_code(body: LiveSessionJoinByCode):
+    """Join a workshop by its 6-char code (case-insensitive) — appends the
+    email to the roster (self-registration), unlike /join which requires an
+    invite. 404 unknown code, 409 when full (maxSeats) or ended/cancelled.
+    Returns the session summary (learner view — no joinCode echo)."""
+    code = live_sessions.normalize_join_code(body.code)
+    if not code:
+        raise HTTPException(status_code=400, detail="a join code is required")
+    email = live_sessions.normalize_email(body.email)
+    if not live_sessions.is_valid_email(email):
+        raise HTTPException(status_code=400, detail="a valid email is required")
+    session_id = await pool.get(f"live:joincode:{code}")
+    if not session_id:
+        raise HTTPException(status_code=404, detail="Unknown join code")
+    sess_key, roster_key, joined_key = _live_keys(session_id)
+    session = await pool.hgetall(sess_key)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+    roster = await pool.smembers(roster_key)
+    err = live_sessions.join_by_code_error(
+        session.get("state", ""), email, roster,
+        int(session.get("maxSeats") or 0))
+    if err:
+        raise HTTPException(status_code=err[0], detail=err[1])
+    await pool.sadd(roster_key, email)
+    await pool.hsetnx(joined_key, email, datetime.now(timezone.utc).isoformat())
+    roster = await pool.smembers(roster_key)
+    joined = await pool.hgetall(joined_key)
+    return {"sessionId": session_id,
+            **live_sessions.shape_summary(session_id, session, roster, joined, email)}
+
+
+@app.post("/api/live/sessions/{session_id}/provision-all")
+async def api_live_session_provision_all(session_id: str, body: LiveSessionProvisionAll):
+    """Trainer pre-provisions a training environment for every roster email.
+
+    Reuses the arena provision path verbatim (including its one-active-
+    session-per-user+tenant+training dedupe): already-active learners are
+    reported as "already-active", everyone else gets a daemon job queued
+    exactly as POST /api/arena/provision would. tenant = the trainer's arena
+    tenant URL; the session's trainingId/ref drive repo + branch."""
+    sess_key, roster_key, _ = _live_keys(session_id)
+    session = await pool.hgetall(sess_key)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+    if not live_sessions.is_trainer(body.trainerEmail, session):
+        raise HTTPException(status_code=403, detail="trainerEmail does not match this session's trainer")
+    roster = await pool.smembers(roster_key)
+    results = []
+    for email in sorted(roster):
+        try:
+            provisioned = await api_arena_provision(ArenaProvisionRequest(
+                trainingId=session.get("trainingId", ""),
+                userId=email,
+                tenantUrl=(body.tenant or "").rstrip("/"),
+                ref=session.get("ref", ""),
+            ))
+            results.append({
+                "email":  email,
+                "status": "already-active" if provisioned.get("deduped") else "queued",
+                "jobId":  provisioned.get("jobId", ""),
+            })
+        except HTTPException as exc:
+            results.append({"email": email, "status": "error",
+                            "error": str(exc.detail)[:200]})
+        except Exception as exc:
+            results.append({"email": email, "status": "error",
+                            "error": str(exc)[:200]})
+    log.info("Live session %s provision-all by %s: %d queued, %d active, %d errors",
+             session_id, body.trainerEmail,
+             sum(1 for r in results if r["status"] == "queued"),
+             sum(1 for r in results if r["status"] == "already-active"),
+             sum(1 for r in results if r["status"] == "error"))
+    return {"results": results}
+
+
+@app.get("/api/live/sessions/{session_id}/readiness")
+async def api_live_session_readiness(session_id: str, trainerEmail: str = ""):
+    """Trainer's per-learner provisioning board: for each roster email the
+    state of their environment for THIS training — none | queued |
+    provisioning | ready | failed. "ready" is the same "Daemon ready"
+    livelog contract as the arena session-status endpoint; "failed" only
+    when a failed terminal record newer than the session exists (be honest
+    — no invented states)."""
+    sess_key, roster_key, _ = _live_keys(session_id)
+    session = await pool.hgetall(sess_key)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+    if not live_sessions.is_trainer(trainerEmail, session):
+        raise HTTPException(status_code=403, detail="trainerEmail does not match this session's trainer")
+    roster = await pool.smembers(roster_key)
+    training_id = session.get("trainingId", "")
+
+    # One scan of the running arena jobs → email -> meta for this training.
+    running_by_email: dict[str, dict] = {}
+    cursor = 0
+    while True:
+        cursor, keys = await pool.scan(cursor, match="job:running:enablement-*", count=200)
+        for key in keys:
+            meta = await pool.hgetall(key)
+            if not meta or meta.get("terminating"):
+                continue
+            user = live_sessions.normalize_email(meta.get("arena_user"))
+            if meta.get("training_id") == training_id and user in roster:
+                running_by_email[user] = meta
+        if cursor == 0:
+            break
+
+    # Failed records: recent jobs:completed entries matched by (email,
+    # training, finished after the session was created).
+    failed_by_email: dict[str, str] = {}
+    for raw in await pool.lrange("jobs:completed", -500, -1):
+        try:
+            record = json.loads(raw)
+        except Exception:
+            continue
+        user = live_sessions.failed_job_email(
+            record, roster, training_id, since=session.get("createdAt", ""))
+        if user and user not in running_by_email:
+            failed_by_email[user] = record.get("job_id", "")
+
+    results = []
+    for email in sorted(roster):
+        meta = running_by_email.get(email)
+        if meta:
+            job_id = meta.get("job_id", "")
+            livelog = await pool.get(f"job:livelog:{job_id}") if job_id else ""
+            results.append({"email": email,
+                            "state": live_sessions.readiness_state(meta, livelog),
+                            "jobId": job_id})
+        elif email in failed_by_email:
+            results.append({"email": email, "state": "failed",
+                            "jobId": failed_by_email[email]})
+        else:
+            results.append({"email": email, "state": "none"})
+    return {"results": results}
+
+
+@app.get("/api/live/capacity")
+async def api_live_capacity(needed: int = 0):
+    """Read-only fleet headroom check for a workshop of `needed` learners —
+    worker heartbeat capacities minus the running-job count per worker. An
+    approximation (heartbeat hashes, no cluster-wide slot ledger) but honest
+    enough for a fail-loud pre-flight."""
+    workers = await _fleet_workers()
+    active_counts: dict[str, int] = {}
+    cursor = 0
+    while True:
+        cursor, keys = await pool.scan(cursor, match="job:running:*", count=200)
+        for key in keys:
+            try:
+                meta = await pool.hgetall(key)
+            except Exception:
+                continue
+            wid = meta.get("worker_id", "")
+            if wid:
+                active_counts[wid] = active_counts.get(wid, 0) + 1
+        if cursor == 0:
+            break
+    return live_sessions.capacity_summary(workers, active_counts, needed)
+
+
+# ── Structured workshop pad (EPIC-002) ────────────────────────────────────────
+# Shared notes (welcome/solutions markdown) + Q&A for a live session, stored
+# in Redis streams (NOT pub/sub) so late joiners and the export replay the
+# full history. Browser access is via /pad/{id} — a self-contained page that
+# claims a single-use pad token (shell-token pattern) for an 8h pad session;
+# live updates are SSE (nginx: proxy_buffering off on /api/live/*stream).
+# All decision logic is in dashboard/live_pad.py (pure, unit-tested).
+
+
+def _pad_keys(session_id: str) -> tuple[str, str, str]:
+    """The three Redis keys of a session pad: (sections hash, qa stream,
+    export string)."""
+    base = f"live:pad:{session_id}"
+    return f"{base}:sections", f"{base}:qa", f"{base}:export"
+
+
+async def _expire_live_session_keys(session_id: str, session: dict):
+    """Apply the ended/cancelled 7-day TTL to every key of a session — the
+    session hash/roster/joined, the join-code pointer, and the raw pad keys
+    (the pad export carries its own 30-day TTL). expire on a missing key is
+    a no-op, so this is safe for sessions without a pad or join code."""
+    sections_key, qa_key, _ = _pad_keys(session_id)
+    keys = [*_live_keys(session_id), sections_key, qa_key]
+    if session.get("joinCode"):
+        keys.append(f"live:joincode:{session['joinCode']}")
+    for key in keys:
+        await pool.expire(key, live_sessions.SESSION_TTL_SECONDS)
+
+
+async def _store_pad_export(session_id: str, session: dict):
+    """Freeze the pad into a standalone HTML snapshot (live:pad:{id}:export,
+    30-day TTL) — called on the end/cancel transition."""
+    sections_key, qa_key, export_key = _pad_keys(session_id)
+    sections = await pool.hgetall(sections_key)
+    entries = await pool.xrange(qa_key)
+    html_doc = live_pad.render_export(
+        session, sections, live_pad.assemble_qa(entries))
+    await pool.set(export_key, html_doc, ex=live_pad.EXPORT_TTL_SECONDS)
+
+
+async def _require_live_session(session_id: str) -> dict:
+    session = await pool.hgetall(f"live:session:{session_id}")
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+    return session
+
+
+def _pad_frozen_guard(session: dict):
+    """Pad writes stop once the session is ended/cancelled — the export
+    snapshot has already been frozen and would silently drop them."""
+    if session.get("state") in ("ended", "cancelled"):
+        raise HTTPException(status_code=409,
+                            detail=f"session is {session.get('state')} — the pad is read-only")
+
+
+async def _pad_add_question(session_id: str, session: dict, email: str,
+                            name: str, text: str) -> dict:
+    _pad_frozen_guard(session)
+    try:
+        text = live_pad.clean_text(text)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    _, qa_key, _ = _pad_keys(session_id)
+    ts = datetime.now(timezone.utc).isoformat()
+    entry_id = await pool.xadd(qa_key, {
+        "type": "question", "qid": "", "email": email, "name": name,
+        "text": text, "ts": ts})
+    return {"qid": entry_id, "ts": ts}
+
+
+async def _pad_add_answer(session_id: str, session: dict, email: str,
+                          name: str, qid: str, text: str) -> dict:
+    _pad_frozen_guard(session)
+    try:
+        text = live_pad.clean_text(text)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    _, qa_key, _ = _pad_keys(session_id)
+    question = await pool.xrange(qa_key, min=qid, max=qid) if qid else []
+    if not question or question[0][1].get("type") != "question":
+        raise HTTPException(status_code=404, detail="question not found")
+    ts = datetime.now(timezone.utc).isoformat()
+    await pool.xadd(qa_key, {
+        "type": "answer", "qid": qid, "email": email, "name": name,
+        "text": text, "ts": ts})
+    return {"qid": qid, "ts": ts}
+
+
+async def _pad_set_section(session_id: str, session: dict, email: str,
+                           key: str, markdown: str) -> dict:
+    _pad_frozen_guard(session)
+    err = live_pad.section_error(key, email, session)
+    if err:
+        raise HTTPException(status_code=err[0], detail=err[1])
+    sections_key, _, _ = _pad_keys(session_id)
+    await pool.hset(sections_key, key, markdown or "")
+    return {"key": key, "saved": True}
+
+
+async def _pad_event_stream(session_id: str):
+    """SSE generator: one full snapshot event, then incremental qa events via
+    blocking XREAD (15 s block, keepalive comment between). Section edits
+    have no stream — change detection piggybacks on each wake (≤15 s lag)."""
+    sections_key, qa_key, _ = _pad_keys(session_id)
+    sections = await pool.hgetall(sections_key)
+    entries = await pool.xrange(qa_key)
+    last_id = entries[-1][0] if entries else "0-0"
+    yield ("event: snapshot\ndata: "
+           + json.dumps(live_pad.shape_pad(sections, entries)) + "\n\n")
+    known = {k: sections.get(k, "") for k in live_pad.SECTION_KEYS}
+    while True:
+        result = await pool.xread({qa_key: last_id}, block=15000, count=100)
+        if result:
+            for _stream, new_entries in result:
+                for entry_id, fields in new_entries:
+                    last_id = entry_id
+                    event = dict(fields)
+                    if event.get("type") == "question":
+                        event["qid"] = entry_id
+                    yield "event: qa\ndata: " + json.dumps(event) + "\n\n"
+        else:
+            yield ": keepalive\n\n"
+        sections = await pool.hgetall(sections_key)
+        current = {k: sections.get(k, "") for k in live_pad.SECTION_KEYS}
+        if current != known:
+            known = current
+            yield "event: sections\ndata: " + json.dumps(current) + "\n\n"
+
+
+def _sse_response(generator) -> StreamingResponse:
+    return StreamingResponse(generator, media_type="text/event-stream",
+                             headers={"Cache-Control": "no-cache",
+                                      "X-Accel-Buffering": "no"})
+
+
+class LivePadSection(BaseModel):
+    trainerEmail: str = ""
+    key: str = ""
+    markdown: str = ""
+
+
+class LivePadQuestion(BaseModel):
+    email: str = ""
+    name: str = ""
+    text: str = ""
+
+
+class LivePadAnswer(BaseModel):
+    trainerEmail: str = ""
+    name: str = ""
+    qid: str = ""
+    text: str = ""
+
+
+class LivePadTokenRequest(BaseModel):
+    email: str = ""
+    name: str = ""
+    role: str = ""                # "trainer" | "learner"
+
+
+class LivePadClaim(BaseModel):
+    token: str = ""
+
+
+class LivePadSessionBody(BaseModel):
+    """padSession-authed writes from the /pad/{id} page — identity comes from
+    the claimed pad-session record server-side, never from client fields."""
+    padSession: str = ""
+    key: str = ""
+    markdown: str = ""
+    qid: str = ""
+    text: str = ""
+
+
+async def _resolve_pad_session(pad_session: str) -> dict:
+    raw = await pool.get(f"live:padsession:{pad_session}") if pad_session else None
+    if not raw:
+        raise HTTPException(status_code=401, detail="invalid or expired pad session")
+    return json.loads(raw)
+
+
+@app.get("/api/live/sessions/{session_id}/pad")
+async def api_live_pad_get(session_id: str):
+    """Full pad state: the two structured sections + Q&A with answers
+    assembled under their questions. Poll-friendly (the in-app tab reads
+    this via the orbital proxy); the popup page uses the SSE stream."""
+    await _require_live_session(session_id)
+    sections_key, qa_key, _ = _pad_keys(session_id)
+    sections = await pool.hgetall(sections_key)
+    entries = await pool.xrange(qa_key)
+    return live_pad.shape_pad(sections, entries)
+
+
+@app.post("/api/live/sessions/{session_id}/pad/section")
+async def api_live_pad_section(session_id: str, body: LivePadSection):
+    """Trainer sets a structured section (welcome|solutions markdown)."""
+    session = await _require_live_session(session_id)
+    return await _pad_set_section(session_id, session,
+                                  body.trainerEmail, body.key, body.markdown)
+
+
+@app.post("/api/live/sessions/{session_id}/pad/question")
+async def api_live_pad_question(session_id: str, body: LivePadQuestion):
+    """Anyone in the session asks a question (max 2000 chars, HTML
+    stripped). The entry's stream id becomes its qid."""
+    session = await _require_live_session(session_id)
+    email = live_sessions.normalize_email(body.email)
+    if not live_sessions.is_valid_email(email):
+        raise HTTPException(status_code=400, detail="a valid email is required")
+    return await _pad_add_question(session_id, session, email,
+                                   (body.name or "").strip(), body.text)
+
+
+@app.post("/api/live/sessions/{session_id}/pad/answer")
+async def api_live_pad_answer(session_id: str, body: LivePadAnswer):
+    """Trainer answers a question (qid = the question's stream id)."""
+    session = await _require_live_session(session_id)
+    if not live_sessions.is_trainer(body.trainerEmail, session):
+        raise HTTPException(status_code=403, detail="only the trainer can answer questions")
+    return await _pad_add_answer(session_id, session,
+                                 live_sessions.normalize_email(body.trainerEmail),
+                                 (body.name or "").strip(), body.qid, body.text)
+
+
+@app.get("/api/live/sessions/{session_id}/pad/stream")
+async def api_live_pad_stream(session_id: str):
+    """SSE pad feed (snapshot + incremental) — session-scoped variant."""
+    await _require_live_session(session_id)
+    return _sse_response(_pad_event_stream(session_id))
+
+
+@app.get("/api/live/sessions/{session_id}/pad/export")
+async def api_live_pad_export(session_id: str, email: str = ""):
+    """The frozen pad snapshot (standalone HTML) — available to the trainer
+    and any roster member once the session ended or was cancelled."""
+    session = await _require_live_session(session_id)
+    roster = await pool.smembers(f"live:session:{session_id}:roster")
+    if not (live_sessions.is_trainer(email, session)
+            or live_sessions.on_roster(email, roster)):
+        raise HTTPException(status_code=403, detail="email is not on the session roster")
+    _, _, export_key = _pad_keys(session_id)
+    html_doc = await pool.get(export_key)
+    if not html_doc:
+        raise HTTPException(status_code=404,
+                            detail="no export snapshot yet (session has not ended or been cancelled)")
+    return HTMLResponse(html_doc)
+
+
+@app.post("/api/live/sessions/{session_id}/pad-token")
+async def api_live_pad_token(session_id: str, body: LivePadTokenRequest):
+    """Issue a single-use 60-second pad handoff token (shell-token pattern).
+
+    Called via the app's authed orbital proxy; the token rides the
+    /pad/{id}?token=… URL and is claimed exactly once by the page, which
+    mints the 8h pad session. Trainer role requires the trainerEmail match;
+    learners must be on the roster."""
+    session = await _require_live_session(session_id)
+    try:
+        role = live_pad.validate_role(body.role)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    email = live_sessions.normalize_email(body.email)
+    if not live_sessions.is_valid_email(email):
+        raise HTTPException(status_code=400, detail="a valid email is required")
+    if role == "trainer":
+        if not live_sessions.is_trainer(email, session):
+            raise HTTPException(status_code=403, detail="trainerEmail does not match this session's trainer")
+    else:
+        roster = await pool.smembers(f"live:session:{session_id}:roster")
+        if not (live_sessions.on_roster(email, roster)
+                or live_sessions.is_trainer(email, session)):
+            raise HTTPException(status_code=403, detail="email is not on the session roster")
+    token = secrets.token_hex(16)
+    await pool.set(f"live:padtoken:{token}", json.dumps({
+        "sessionId": session_id, "email": email,
+        "name": (body.name or "").strip(), "role": role,
+    }), ex=live_pad.PAD_TOKEN_TTL_SECONDS)
+    return {"token": token,
+            "padUrl": f"https://autonomous-enablements.whydevslovedynatrace.com/pad/{session_id}?token={token}"}
+
+
+@app.post("/api/live/pad-claim")
+async def api_live_pad_claim(body: LivePadClaim):
+    """Claim a single-use pad token → mint the multi-use pad session (8h).
+
+    Same atomic GET+DEL as the shell-token WebSocket validation."""
+    pipe = pool.pipeline(transaction=True)
+    pipe.get(f"live:padtoken:{body.token}")
+    pipe.delete(f"live:padtoken:{body.token}")
+    raw, _ = await pipe.execute()
+    if not raw:
+        raise HTTPException(status_code=401, detail="invalid or expired pad token")
+    identity = json.loads(raw)
+    pad_session = secrets.token_hex(16)
+    await pool.set(f"live:padsession:{pad_session}", raw,
+                   ex=live_pad.PAD_SESSION_TTL_SECONDS)
+    session = await pool.hgetall(f"live:session:{identity['sessionId']}") or {}
+    return {"padSession": pad_session, **identity,
+            "title": session.get("title", ""), "state": session.get("state", "")}
+
+
+@app.post("/api/live/pad/section")
+async def api_live_pad_section_ps(body: LivePadSessionBody):
+    """padSession-authed section write (identity from the pad session)."""
+    identity = await _resolve_pad_session(body.padSession)
+    if identity.get("role") != "trainer":
+        raise HTTPException(status_code=403, detail="only the trainer can edit pad sections")
+    session = await _require_live_session(identity["sessionId"])
+    return await _pad_set_section(identity["sessionId"], session,
+                                  identity.get("email", ""), body.key, body.markdown)
+
+
+@app.post("/api/live/pad/question")
+async def api_live_pad_question_ps(body: LivePadSessionBody):
+    """padSession-authed question (identity from the pad session)."""
+    identity = await _resolve_pad_session(body.padSession)
+    session = await _require_live_session(identity["sessionId"])
+    return await _pad_add_question(identity["sessionId"], session,
+                                   identity.get("email", ""),
+                                   identity.get("name", ""), body.text)
+
+
+@app.post("/api/live/pad/answer")
+async def api_live_pad_answer_ps(body: LivePadSessionBody):
+    """padSession-authed answer (trainer pad sessions only)."""
+    identity = await _resolve_pad_session(body.padSession)
+    if identity.get("role") != "trainer":
+        raise HTTPException(status_code=403, detail="only the trainer can answer questions")
+    session = await _require_live_session(identity["sessionId"])
+    return await _pad_add_answer(identity["sessionId"], session,
+                                 identity.get("email", ""),
+                                 identity.get("name", ""), body.qid, body.text)
+
+
+@app.get("/api/live/pad/stream")
+async def api_live_pad_stream_ps(padSession: str = ""):
+    """padSession-authed SSE pad feed (EventSource can't set headers, so the
+    pad session rides the query string)."""
+    identity = await _resolve_pad_session(padSession)
+    await _require_live_session(identity["sessionId"])
+    return _sse_response(_pad_event_stream(identity["sessionId"]))
+
+
+# Self-contained pad page (the /shell/{job_id} pattern: inline CSS/JS, no
+# external deps). Plain string + placeholder substitution — NOT an f-string —
+# so the CSS/JS braces stay readable. __SESSION_ID__/__BASE__ are JSON-encoded
+# on the way in.
+_PAD_PAGE_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Workshop Pad</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html, body { height: 100%; background: #1a1a2e; color: #d4d4d4;
+  font-family: -apple-system, 'Segoe UI', sans-serif; }
+body { display: flex; flex-direction: column; }
+#topbar { background: #16213e; color: #a0aec0; font-size: 12px; line-height: 38px;
+  padding: 0 16px; display: flex; align-items: center; justify-content: space-between;
+  flex-shrink: 0; border-bottom: 1px solid #0d3460; gap: 16px; }
+#brand { display: flex; align-items: center; gap: 8px; }
+#brand-logo { color: #00b4d8; font-size: 18px; }
+#brand-name { color: #e2e8f0; font-weight: 600; font-size: 13px; letter-spacing: .3px; }
+#who { font-size: 11px; color: #718096; white-space: nowrap; }
+#main { flex: 1; overflow-y: auto; padding: 20px; max-width: 860px; width: 100%;
+  margin: 0 auto; }
+.card { background: #16213e; border: 1px solid #0d3460; border-radius: 6px;
+  padding: 14px 16px; margin-bottom: 14px; }
+.card h3 { color: #00b4d8; font-size: 13px; margin-bottom: 10px;
+  text-transform: uppercase; letter-spacing: .5px; }
+.md { font-size: 13px; line-height: 1.55; color: #c9d1d9; word-break: break-word; }
+.md h1, .md h2, .md h3 { color: #e2e8f0; margin: 10px 0 6px; }
+.md h1 { font-size: 16px; } .md h2 { font-size: 14px; } .md h3 { font-size: 13px; }
+.md code { background: #0d1117; border: 1px solid #0d3460; border-radius: 3px;
+  padding: 1px 5px; font: 12px ui-monospace, Menlo, monospace; color: #79c0ff; }
+.md pre { background: #0d1117; border: 1px solid #0d3460; border-radius: 4px;
+  padding: 10px; overflow-x: auto; margin: 8px 0; }
+.md pre code { background: none; border: 0; padding: 0; }
+.md a { color: #58a6ff; }
+.empty { color: #718096; font-size: 12px; font-style: italic; }
+textarea { width: 100%; background: #0d1117; color: #e6edf3;
+  border: 1px solid #0d3460; border-radius: 4px; padding: 8px;
+  font: 12px ui-monospace, Menlo, monospace; resize: vertical; min-height: 70px; }
+textarea:focus, input:focus { outline: 1px solid #00b4d8; }
+button { background: #0e639c; color: #fff; border: 0; border-radius: 4px;
+  padding: 6px 14px; font-size: 12px; cursor: pointer; }
+button:hover { background: #1177bb; }
+button:disabled { opacity: .5; cursor: default; }
+.row { display: flex; gap: 8px; margin-top: 8px; align-items: flex-start; }
+.q { border-top: 1px solid #0d3460; padding: 10px 0; }
+.q:first-child { border-top: 0; }
+.q .who { color: #e2e8f0; font-size: 12px; font-weight: 600; }
+.q .ts { color: #718096; font-size: 10px; font-weight: 400; margin-left: 6px; }
+.q .text { font-size: 13px; margin-top: 4px; white-space: pre-wrap;
+  word-break: break-word; }
+.a { margin: 8px 0 0 18px; padding-left: 10px; border-left: 2px solid #00b4d8; }
+.a .who { color: #00b4d8; }
+#err { display: none; margin: 40px auto; max-width: 480px; text-align: center;
+  color: #fc8181; font-size: 13px; line-height: 1.6; }
+.saved { color: #48bb78; font-size: 11px; margin-left: 8px; }
+</style>
+</head>
+<body>
+<div id="topbar">
+  <div id="brand">
+    <span id="brand-logo">⬡</span>
+    <span id="brand-name">Workshop Pad</span>
+    <span id="title" style="color:#718096"></span>
+  </div>
+  <span id="who">Connecting…</span>
+</div>
+<div id="err"></div>
+<div id="main" style="display:none">
+  <div class="card" id="card-welcome">
+    <h3>Welcome</h3>
+    <div class="md" id="md-welcome"><span class="empty">Nothing here yet.</span></div>
+    <div id="edit-welcome" style="display:none">
+      <div class="row"><textarea id="ta-welcome" placeholder="Markdown…"></textarea></div>
+      <div class="row"><button onclick="saveSection('welcome')">Save</button><span class="saved" id="ok-welcome"></span></div>
+    </div>
+  </div>
+  <div class="card" id="card-solutions">
+    <h3>Solutions</h3>
+    <div class="md" id="md-solutions"><span class="empty">Nothing here yet.</span></div>
+    <div id="edit-solutions" style="display:none">
+      <div class="row"><textarea id="ta-solutions" placeholder="Markdown…"></textarea></div>
+      <div class="row"><button onclick="saveSection('solutions')">Save</button><span class="saved" id="ok-solutions"></span></div>
+    </div>
+  </div>
+  <div class="card">
+    <h3>Questions &amp; Answers</h3>
+    <div id="qa"><span class="empty">No questions yet — ask the first one below.</span></div>
+    <div class="row">
+      <textarea id="compose" maxlength="2000" placeholder="Ask a question…"></textarea>
+      <button onclick="ask()">Ask</button>
+    </div>
+  </div>
+</div>
+<script>
+(async () => {
+  const SESSION_ID = __SESSION_ID__;
+  const BASE = __BASE__;
+  const store = 'padsession-' + SESSION_ID;
+  const esc = s => (s || '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+  // Tiny markdown renderer: escape first, then fences, headings, bold,
+  // inline code, links, line breaks. Deliberately minimal.
+  function md(src) {
+    if (!src) return '<span class="empty">Nothing here yet.</span>';
+    let out = esc(src);
+    out = out.replace(/```([\\s\\S]*?)```/g, (m, c) => '<pre><code>' + c.replace(/^\\n/, '') + '</code></pre>');
+    out = out.replace(/^### (.*)$/gm, '<h3>$1</h3>');
+    out = out.replace(/^## (.*)$/gm, '<h2>$1</h2>');
+    out = out.replace(/^# (.*)$/gm, '<h1>$1</h1>');
+    out = out.replace(/\\*\\*([^*]+)\\*\\*/g, '<b>$1</b>');
+    out = out.replace(/`([^`]+)`/g, '<code>$1</code>');
+    out = out.replace(/\\[([^\\]]+)\\]\\((https?:[^)]+)\\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+    return out.replace(/\\n/g, '<br>');
+  }
+  function fail(msg) {
+    document.getElementById('err').style.display = 'block';
+    document.getElementById('err').textContent = msg;
+    document.getElementById('who').textContent = '';
+  }
+
+  // ── Claim the single-use token → 8h pad session (survives reloads via
+  // sessionStorage; the URL token is dead after first use). ──
+  let me = null;
+  try { me = JSON.parse(sessionStorage.getItem(store) || 'null'); } catch (e) {}
+  const urlToken = new URLSearchParams(location.search).get('token') || '';
+  if (!me && urlToken) {
+    try {
+      const r = await fetch(BASE + '/api/live/pad-claim', {
+        method: 'POST', headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({token: urlToken})});
+      if (r.ok) { me = await r.json(); sessionStorage.setItem(store, JSON.stringify(me)); }
+    } catch (e) {}
+  }
+  if (!me) return fail('This pad link has expired — reopen the pad from the app to get a fresh one.');
+
+  document.getElementById('main').style.display = 'block';
+  document.getElementById('title').textContent = me.title ? '· ' + me.title : '';
+  document.getElementById('who').textContent = (me.name || me.email) + ' (' + me.role + ')';
+  const isTrainer = me.role === 'trainer';
+  if (isTrainer) ['welcome', 'solutions'].forEach(k =>
+    document.getElementById('edit-' + k).style.display = 'block');
+
+  // ── State + rendering (SSE is the single source of truth — own posts
+  // come back through the stream, no local echo). ──
+  let S = {sections: {}, qa: []};
+  function renderSections() {
+    for (const k of ['welcome', 'solutions']) {
+      document.getElementById('md-' + k).innerHTML = md(S.sections[k] || '');
+      const ta = document.getElementById('ta-' + k);
+      if (isTrainer && document.activeElement !== ta) ta.value = S.sections[k] || '';
+    }
+  }
+  function renderQa() {
+    const host = document.getElementById('qa');
+    if (!S.qa.length) { host.innerHTML = '<span class="empty">No questions yet — ask the first one below.</span>'; return; }
+    host.innerHTML = S.qa.map((q, i) => {
+      let h = '<div class="q"><div class="who">' + esc(q.name || q.email) +
+        '<span class="ts">' + esc((q.ts || '').replace('T', ' ').slice(0, 16)) + '</span></div>' +
+        '<div class="text">' + esc(q.text) + '</div>';
+      for (const a of q.answers) h += '<div class="a"><div class="who">' + esc(a.name || 'Trainer') +
+        '<span class="ts">' + esc((a.ts || '').replace('T', ' ').slice(0, 16)) + '</span></div>' +
+        '<div class="text">' + esc(a.text) + '</div></div>';
+      if (isTrainer) h += '<div class="row"><textarea id="ans-' + i + '" style="min-height:40px" placeholder="Answer…"></textarea>' +
+        '<button onclick="answer(' + i + ')">Reply</button></div>';
+      return h + '</div>';
+    }).join('');
+  }
+
+  async function post(path, body) {
+    const r = await fetch(BASE + path, {method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(Object.assign({padSession: me.padSession}, body))});
+    if (!r.ok) alert('Request failed (' + r.status + '): ' + await r.text());
+    return r.ok;
+  }
+  window.ask = async () => {
+    const ta = document.getElementById('compose');
+    if (ta.value.trim() && await post('/api/live/pad/question', {text: ta.value})) ta.value = '';
+  };
+  window.answer = async (i) => {
+    const ta = document.getElementById('ans-' + i);
+    if (ta.value.trim()) await post('/api/live/pad/answer', {qid: S.qa[i].qid, text: ta.value});
+  };
+  window.saveSection = async (k) => {
+    if (await post('/api/live/pad/section', {key: k, markdown: document.getElementById('ta-' + k).value})) {
+      const ok = document.getElementById('ok-' + k);
+      ok.textContent = 'saved'; setTimeout(() => ok.textContent = '', 1500);
+    }
+  };
+
+  // ── Live updates (SSE; EventSource reconnects on its own) ──
+  const es = new EventSource(BASE + '/api/live/pad/stream?padSession=' + encodeURIComponent(me.padSession));
+  es.addEventListener('snapshot', e => {
+    S = JSON.parse(e.data); renderSections(); renderQa();
+  });
+  es.addEventListener('sections', e => {
+    S.sections = JSON.parse(e.data); renderSections();
+  });
+  es.addEventListener('qa', e => {
+    const ev = JSON.parse(e.data);
+    if (ev.type === 'question') {
+      if (!S.qa.some(q => q.qid === ev.qid))
+        S.qa.push({qid: ev.qid, name: ev.name, email: ev.email, text: ev.text, ts: ev.ts, answers: []});
+    } else if (ev.type === 'answer') {
+      const q = S.qa.find(q => q.qid === ev.qid);
+      if (q) q.answers.push({name: ev.name, text: ev.text, ts: ev.ts});
+    }
+    renderQa();
+  });
+  es.onerror = () => { document.getElementById('who').textContent = (me.name || me.email) + ' (reconnecting…)'; };
+  es.onopen = () => { document.getElementById('who').textContent = (me.name || me.email) + ' (' + me.role + ')'; };
+})();
+</script>
+</body>
+</html>"""
+
+
+@app.get("/pad/{session_id}", response_class=HTMLResponse)
+async def live_pad_page(session_id: str, token: str = ""):
+    """Standalone workshop pad page (Welcome/Solutions + Q&A, live via SSE).
+
+    Same handoff as /shell/{job_id}: opened from the app with a single-use
+    ?token= (minted by the authed pad-token endpoint), which the page claims
+    for an 8h pad session. Self-contained — inline CSS/JS, no external deps.
+    """
+    base_url = "https://autonomous-enablements.whydevslovedynatrace.com"
+    return HTMLResponse(_PAD_PAGE_HTML
+                        .replace("__SESSION_ID__", json.dumps(session_id))
+                        .replace("__BASE__", json.dumps(base_url)))
 
 
 # ── Framework test suites ─────────────────────────────────────────────────────

--- a/ops-server/dashboard/live_pad.py
+++ b/ops-server/dashboard/live_pad.py
@@ -1,0 +1,174 @@
+"""Pure decision logic for the structured workshop pad (EPIC-002).
+
+No Redis, no FastAPI — everything here is deterministic and unit-tested in
+dashboard/test_workshops.py. The /api/live/*/pad* endpoints in app.py stay
+thin: they read/write the Redis keys and delegate every decision here.
+
+Redis model (streams, NOT pub/sub):
+  live:pad:{id}:sections  hash    section key -> markdown (keys: welcome,
+                                  solutions)
+  live:pad:{id}:qa        stream  XADD {type: question|answer, qid, email,
+                                  name, text, ts}. A question's qid is its
+                                  own stream entry id; answers carry the qid
+                                  of the question they answer.
+  live:pad:{id}:export    str     standalone HTML snapshot, 30-day TTL,
+                                  written on the end/cancel transition
+  live:padtoken:{token}   str     single-use JSON handoff (60 s TTL) — same
+                                  pattern as shell:token:{token}
+  live:padsession:{tok2}  str     claimed pad identity JSON (8 h TTL):
+                                  sessionId, email, name, role
+"""
+
+import html
+import re
+
+from dashboard import live_sessions
+
+SECTION_KEYS = ("welcome", "solutions")
+ROLES = ("trainer", "learner")
+
+QUESTION_MAX_CHARS = 2000
+
+# TTLs — the single-use handoff token mirrors shell:token (60 s); the claimed
+# pad session outlives a full workshop day; the export matches a month of
+# "can I still get the notes?" follow-ups.
+PAD_TOKEN_TTL_SECONDS = 60
+PAD_SESSION_TTL_SECONDS = 8 * 3600
+EXPORT_TTL_SECONDS = 30 * 24 * 3600
+
+_TAG_RE = re.compile(r"<[^>]*>")
+
+
+def strip_html(text) -> str:
+    """Drop HTML tags and unescape entities — pad text is stored as plain
+    text/markdown and escaped again on render, so markup never round-trips."""
+    return html.unescape(_TAG_RE.sub("", text or ""))
+
+
+def clean_text(text, field="text") -> str:
+    """Normalize a question/answer body: strip HTML + whitespace, enforce the
+    2000-char cap. Raises ValueError (→ HTTP 400) when empty or too long."""
+    cleaned = strip_html(text).strip()
+    if not cleaned:
+        raise ValueError(f"{field} is required")
+    if len(cleaned) > QUESTION_MAX_CHARS:
+        raise ValueError(f"{field} exceeds {QUESTION_MAX_CHARS} characters")
+    return cleaned
+
+
+def validate_role(role) -> str:
+    """'trainer' or 'learner' — anything else is a 400."""
+    role = (role or "").strip().lower()
+    if role not in ROLES:
+        raise ValueError("role must be 'trainer' or 'learner'")
+    return role
+
+
+def section_error(key, email, session):
+    """Return (http_status, detail) blocking a section write, or None.
+
+    Sections are trainer-only and limited to the two structured keys."""
+    if key not in SECTION_KEYS:
+        return 400, f"key must be one of: {', '.join(SECTION_KEYS)}"
+    if not live_sessions.is_trainer(email, session):
+        return 403, "only the trainer can edit pad sections"
+    return None
+
+
+def assemble_qa(entries) -> list[dict]:
+    """[(stream_entry_id, fields)] → questions with their answers nested.
+
+    A question's qid is its stream entry id; answers reference it via their
+    qid field. Answers whose question is unknown are dropped (never shown
+    detached). Questions and answers both keep stream (arrival) order."""
+    questions, by_qid = [], {}
+    for entry_id, fields in entries or []:
+        kind = fields.get("type", "")
+        if kind == "question":
+            question = {
+                "qid":     entry_id,
+                "name":    fields.get("name", ""),
+                "email":   fields.get("email", ""),
+                "text":    fields.get("text", ""),
+                "ts":      fields.get("ts", ""),
+                "answers": [],
+            }
+            questions.append(question)
+            by_qid[entry_id] = question
+        elif kind == "answer":
+            question = by_qid.get(fields.get("qid", ""))
+            if question is not None:
+                question["answers"].append({
+                    "name": fields.get("name", ""),
+                    "text": fields.get("text", ""),
+                    "ts":   fields.get("ts", ""),
+                })
+    return questions
+
+
+def shape_pad(sections, entries) -> dict:
+    """GET /api/live/sessions/{id}/pad payload: the two structured sections
+    (always present, '' when unset) + the assembled Q&A."""
+    return {
+        "sections": {key: (sections or {}).get(key, "")
+                     for key in SECTION_KEYS},
+        "qa": assemble_qa(entries),
+    }
+
+
+# ── Export snapshot ───────────────────────────────────────────────────────────
+
+def _esc(text) -> str:
+    return html.escape(text or "", quote=True)
+
+
+def render_export(session, sections, qa) -> str:
+    """Standalone, print-friendly HTML snapshot of the pad (sections + full
+    Q&A) — stored as live:pad:{id}:export on the end/cancel transition."""
+    title = session.get("title", "") or "Workshop"
+    parts = [f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Workshop Pad · {_esc(title)}</title>
+<style>
+body{{font-family:Georgia,'Times New Roman',serif;max-width:820px;margin:0 auto;
+  padding:32px 24px;color:#1a1a2e;background:#fff;line-height:1.55}}
+h1{{font-size:26px;border-bottom:2px solid #1a1a2e;padding-bottom:8px}}
+h2{{font-size:18px;margin-top:32px;border-bottom:1px solid #ccc;padding-bottom:4px}}
+.meta{{color:#555;font-size:13px;margin-bottom:24px}}
+pre{{white-space:pre-wrap;word-break:break-word;background:#f6f6f4;
+  border:1px solid #ddd;border-radius:4px;padding:12px;font-size:13px;
+  font-family:ui-monospace,Menlo,monospace}}
+.q{{margin:18px 0;page-break-inside:avoid}}
+.q .who{{font-weight:bold;font-size:13px}}
+.q .text{{margin:4px 0 0 0}}
+.a{{margin:8px 0 0 24px;padding-left:12px;border-left:3px solid #888}}
+.ts{{color:#888;font-size:11px;font-weight:normal;margin-left:6px}}
+@media print{{body{{padding:0}}}}
+</style>
+</head>
+<body>
+<h1>{_esc(title)}</h1>
+<div class="meta">Training: {_esc(session.get("trainingId", ""))}
+ · Trainer: {_esc(session.get("trainerEmail", ""))}
+ · State: {_esc(session.get("state", ""))}</div>"""]
+    for key in SECTION_KEYS:
+        markdown = (sections or {}).get(key, "")
+        if markdown:
+            parts.append(f"<h2>{_esc(key.capitalize())}</h2>\n"
+                         f"<pre>{_esc(markdown)}</pre>")
+    parts.append("<h2>Q&amp;A</h2>")
+    if not qa:
+        parts.append("<p>No questions were asked.</p>")
+    for question in qa or []:
+        block = (f'<div class="q"><div class="who">{_esc(question.get("name") or question.get("email", ""))}'
+                 f'<span class="ts">{_esc(question.get("ts", ""))}</span></div>'
+                 f'<p class="text">{_esc(question.get("text", ""))}</p>')
+        for answer in question.get("answers", []):
+            block += (f'<div class="a"><div class="who">{_esc(answer.get("name", ""))}'
+                      f'<span class="ts">{_esc(answer.get("ts", ""))}</span></div>'
+                      f'<p class="text">{_esc(answer.get("text", ""))}</p></div>')
+        parts.append(block + "</div>")
+    parts.append("</body>\n</html>")
+    return "\n".join(parts)

--- a/ops-server/dashboard/live_sessions.py
+++ b/ops-server/dashboard/live_sessions.py
@@ -6,14 +6,22 @@ thin: they read/write the Redis keys and delegate every decision here.
 
 Redis model (docs/live-training-architecture.md, ops-server/CLAUDE.md):
   live:session:{id}         hash  title, trainingId, ref, trainerEmail,
-                                  state (open|running|ended),
+                                  state (scheduled|open|running|ended|cancelled),
                                   createdAt, startedAt, endedAt
+                                  + OPTIONAL workshop fields (EPIC-002):
+                                  scheduledAt, timezone, durationMinutes,
+                                  maxSeats, joinCode, cancelledAt
   live:session:{id}:roster  set   lowercase invited emails
   live:session:{id}:joined  hash  email -> ISO joinedAt
   live:sessions:index       zset  sessionId scored by epoch createdAt
+  live:joincode:{code}      str   sessionId (join-by-code lookup, code UPPER)
 """
 
-STATES = ("open", "running", "ended")
+import secrets
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+STATES = ("scheduled", "open", "running", "ended", "cancelled")
 
 # TTL applied to the three session keys when a session ends — matches the
 # job:final 7-day retention. The index entry is kept; listing tolerates
@@ -68,6 +76,73 @@ def validate_create(title, training_id, trainer_email, roster) -> dict:
             "trainerEmail": trainer, "roster": members}
 
 
+# ── Workshop scheduling (EPIC-002) ────────────────────────────────────────────
+
+def validate_schedule(scheduled_at, timezone_name, duration_minutes,
+                      max_seats) -> dict:
+    """Validate + normalize the OPTIONAL workshop scheduling fields.
+
+    Returns storage-ready strings ('' = absent — the hash field is simply not
+    written, keeping pre-workshop sessions byte-identical). Raises ValueError
+    (→ HTTP 400) on a malformed value.
+    """
+    out = {"scheduledAt": "", "timezone": "", "durationMinutes": "",
+           "maxSeats": ""}
+    when = (scheduled_at or "").strip()
+    if when:
+        try:
+            datetime.fromisoformat(when.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValueError(f"scheduledAt is not a valid ISO8601 timestamp: '{when}'")
+        out["scheduledAt"] = when
+    tz = (timezone_name or "").strip()
+    if tz:
+        try:
+            ZoneInfo(tz)
+        except Exception:
+            raise ValueError(f"timezone is not a valid IANA zone name: '{tz}'")
+        out["timezone"] = tz
+    for field, value in (("durationMinutes", duration_minutes),
+                         ("maxSeats", max_seats)):
+        if value in (None, "", 0):
+            continue
+        try:
+            n = int(value)
+        except (TypeError, ValueError):
+            raise ValueError(f"{field} must be an integer")
+        if n < 0:
+            raise ValueError(f"{field} must be >= 0")
+        if n:
+            out[field] = str(n)
+    return out
+
+
+def initial_state(scheduled_at) -> str:
+    """Create WITH scheduledAt → 'scheduled'; without → 'open' (the
+    pre-workshop behavior, so existing callers are unaffected)."""
+    return "scheduled" if (scheduled_at or "").strip() else "open"
+
+
+# ── Join codes ────────────────────────────────────────────────────────────────
+
+# A-Z/2-9 minus confusables (I, L, O and the digits 0/1 they mimic).
+JOIN_CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"
+JOIN_CODE_LENGTH = 6
+
+
+def generate_join_code(rng=secrets) -> str:
+    """A 6-char join code from the confusable-free alphabet. Uniqueness is
+    enforced by the caller via SET NX on live:joincode:{code}."""
+    return "".join(rng.choice(JOIN_CODE_ALPHABET)
+                   for _ in range(JOIN_CODE_LENGTH))
+
+
+def normalize_join_code(code) -> str:
+    """Canonical join-code form: trimmed + uppercased (codes are
+    case-insensitive on input, stored/looked-up UPPER)."""
+    return (code or "").strip().upper()
+
+
 # ── Roster / trainer gating ───────────────────────────────────────────────────
 
 def is_trainer(email, session) -> bool:
@@ -85,11 +160,35 @@ def on_roster(email, roster) -> bool:
 
 
 def join_error(state, email, roster):
-    """Return (http_status, detail) blocking a join, or None when allowed."""
+    """Return (http_status, detail) blocking a join, or None when allowed.
+
+    Joining is allowed in scheduled/open/running (late joiners OK)."""
     if not on_roster(email, roster):
         return 403, "email is not on the session roster"
     if state == "ended":
         return 409, "session has ended"
+    if state == "cancelled":
+        return 409, "session has been cancelled"
+    return None
+
+
+def join_by_code_error(state, email, roster, max_seats):
+    """Return (http_status, detail) blocking a join-by-code, or None.
+
+    Unlike join_error, the email need NOT be on the roster — joining by code
+    APPENDS it. Already-rostered emails re-join idempotently and are never
+    seat-blocked; new emails are rejected when maxSeats>0 and the roster is
+    full."""
+    if state == "ended":
+        return 409, "session has ended"
+    if state == "cancelled":
+        return 409, "session has been cancelled"
+    if state not in ("scheduled", "open", "running"):
+        return 409, f"session is not joinable in state '{state}'"
+    if on_roster(email, roster):
+        return None
+    if max_seats and len(roster or ()) >= max_seats:
+        return 409, f"session is full ({max_seats} seats taken)"
     return None
 
 
@@ -97,9 +196,14 @@ def join_error(state, email, roster):
 
 # action -> {current_state: (new_state, changed)}. Absent = illegal.
 _TRANSITIONS = {
-    "start": {"open": ("running", True), "running": ("running", False)},
+    "open-registration": {"scheduled": ("open", True),
+                          "open": ("open", False)},
+    "start": {"scheduled": ("running", True), "open": ("running", True),
+              "running": ("running", False)},
     "end":   {"open": ("ended", True), "running": ("ended", True),
               "ended": ("ended", False)},
+    "cancel": {"scheduled": ("cancelled", True), "open": ("cancelled", True),
+               "cancelled": ("cancelled", False)},
 }
 
 
@@ -125,10 +229,32 @@ def is_listed(session, roster, email) -> bool:
     return is_trainer(email, session) or on_roster(email, roster)
 
 
+# Optional workshop fields echoed in payloads only when stored on the hash —
+# absent fields add no keys, keeping pre-workshop payloads byte-identical.
+_WORKSHOP_FIELDS = ("scheduledAt", "timezone", "durationMinutes", "maxSeats",
+                    "cancelledAt")
+
+
+def workshop_fields(session, email) -> dict:
+    """The optional workshop (EPIC-002) fields of a session payload.
+
+    Ints come back as ints; joinCode is included EXCLUSIVELY for the trainer,
+    never for learners."""
+    out = {}
+    for field in _WORKSHOP_FIELDS:
+        value = session.get(field, "")
+        if value:
+            out[field] = (int(value)
+                          if field in ("durationMinutes", "maxSeats") else value)
+    if session.get("joinCode") and is_trainer(email, session):
+        out["joinCode"] = session["joinCode"]
+    return out
+
+
 def shape_summary(session_id, session, roster, joined, email) -> dict:
     """One item of GET /api/live/sessions?email= (learner + trainer lists)."""
     e = normalize_email(email)
-    return {
+    out = {
         "sessionId":    session_id,
         "title":        session.get("title", ""),
         "trainingId":   session.get("trainingId", ""),
@@ -141,6 +267,8 @@ def shape_summary(session_id, session, roster, joined, email) -> dict:
         "isTrainer":    is_trainer(e, session),
         "hasJoined":    e in (joined or {}),
     }
+    out.update(workshop_fields(session, e))
+    return out
 
 
 def shape_detail(session_id, session, roster, joined, email) -> dict:
@@ -161,8 +289,65 @@ def shape_detail(session_id, session, roster, joined, email) -> dict:
         "joinedCount":  len(joined or {}),
         "rosterCount":  len(roster or ()),
     }
+    out.update(workshop_fields(session, email))
     if is_trainer(email, session):
         out["roster"] = sorted(roster or ())
         out["joined"] = [{"email": k, "joinedAt": v}
                          for k, v in sorted((joined or {}).items())]
     return out
+
+
+# ── Provisioning readiness / capacity (EPIC-002) ─────────────────────────────
+
+def readiness_state(meta, livelog) -> str:
+    """Classify a running arena job for the trainer's readiness board — same
+    contract as the session-status endpoint: 'ready' means the executor wrote
+    "Daemon ready" to the livelog; unassigned worker means still 'queued'."""
+    if livelog and "Daemon ready" in livelog:
+        return "ready"
+    if meta.get("worker_id") in ("queued", ""):
+        return "queued"
+    return "provisioning"
+
+
+def failed_job_email(record, roster, training_id, since="") -> str | None:
+    """Map a jobs:completed record to a roster email when it is a FAILED
+    daemon job for this session's training, finished after `since` (the
+    session's createdAt — older failures are unrelated). None otherwise.
+
+    Arena daemon jobs carry the training id in nightly_run_id
+    ("enablement-{trainingId}") and the learner email in requested_by."""
+    if record.get("type") != "daemon" or record.get("status") != "failed":
+        return None
+    if record.get("nightly_run_id") != f"enablement-{training_id}":
+        return None
+    email = normalize_email(record.get("requested_by"))
+    if email not in set(roster or ()):
+        return None
+    if since and record.get("finished_at", "") < since:
+        return None
+    return email
+
+
+def capacity_summary(workers, active_counts, needed) -> dict:
+    """GET /api/live/capacity payload from worker heartbeat hashes + per-worker
+    active-job counts. Pure math — the endpoint only gathers the inputs."""
+    def _int(v):
+        try:
+            return int(v or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    items, total_capacity, total_active = [], 0, 0
+    for worker in sorted(workers or [], key=lambda w: w.get("worker_id", "")):
+        wid = worker.get("worker_id", "")
+        capacity = _int(worker.get("capacity"))
+        active = _int((active_counts or {}).get(wid))
+        total_capacity += capacity
+        total_active += active
+        items.append({"id": wid, "capacity": capacity, "active": active})
+    available = max(total_capacity - total_active, 0)
+    needed = max(_int(needed), 0)
+    return {"capacity": total_capacity, "active": total_active,
+            "available": available, "needed": needed,
+            "sufficient": available >= needed, "workers": items}

--- a/ops-server/dashboard/test_workshops.py
+++ b/ops-server/dashboard/test_workshops.py
@@ -1,0 +1,371 @@
+"""Pure-logic tests for EPIC-002 Workshops (dashboard/live_sessions.py
+extensions + dashboard/live_pad.py).
+
+No Redis, no FastAPI — same approach as test_live_sessions.py: the /api/live/*
+endpoints stay thin and delegate every decision to these functions. Covers
+schedule-create initial state, join codes (happy / normalization / seat caps),
+the cancel transition + learner visibility, joinCode payload gating, capacity
+math from fake worker hashes, pad Q&A assembly, the pad section trainer-gate,
+and the export snapshot rendering.
+
+Runnable two ways:
+  - pytest:     python3 -m pytest dashboard/test_workshops.py
+  - standalone: /home/ops/ops-venv/bin/python -m dashboard.test_workshops
+"""
+
+from dashboard import live_pad as lp
+from dashboard import live_sessions as ls
+
+TRAINER = "trainer@dynatrace.com"
+
+
+def _session(state="open", trainer=TRAINER, **extra) -> dict:
+    """A live:session:{id} hash as stored in Redis (all-string values)."""
+    sess = {
+        "title": "K8s 101 — EMEA Bootcamp", "trainingId": "kubernetes-101",
+        "ref": "", "trainerEmail": trainer, "state": state,
+        "createdAt": "2026-07-14T09:00:00+00:00", "startedAt": "", "endedAt": "",
+    }
+    sess.update(extra)
+    return sess
+
+
+def _raises_value_error(fn, *args, **kwargs) -> str:
+    try:
+        fn(*args, **kwargs)
+    except ValueError as exc:
+        return str(exc)
+    raise AssertionError(f"expected ValueError from {fn.__name__}{args}")
+
+
+# ── Schedule-create: initial state + field validation ────────────────────────
+
+def test_initial_state_scheduled_vs_open():
+    assert ls.initial_state("2026-09-01T09:00:00+00:00") == "scheduled"
+    assert ls.initial_state("") == "open"       # today's behavior preserved
+    assert ls.initial_state(None) == "open"
+    assert ls.initial_state("   ") == "open"
+
+
+def test_validate_schedule_normalizes_and_stringifies():
+    out = ls.validate_schedule(" 2026-09-01T09:00:00Z ", " Europe/Madrid ",
+                               90, 25)
+    assert out == {"scheduledAt": "2026-09-01T09:00:00Z",
+                   "timezone": "Europe/Madrid",
+                   "durationMinutes": "90", "maxSeats": "25"}
+
+
+def test_validate_schedule_all_absent_is_fine():
+    out = ls.validate_schedule("", "", 0, 0)
+    assert out == {"scheduledAt": "", "timezone": "",
+                   "durationMinutes": "", "maxSeats": ""}
+
+
+def test_validate_schedule_rejects_bad_values():
+    assert "scheduledAt" in _raises_value_error(
+        ls.validate_schedule, "next tuesday", "", 0, 0)
+    assert "timezone" in _raises_value_error(
+        ls.validate_schedule, "", "Madrid", 0, 0)   # not an IANA name
+    assert "durationMinutes" in _raises_value_error(
+        ls.validate_schedule, "", "", "ninety", 0)
+    assert "maxSeats" in _raises_value_error(
+        ls.validate_schedule, "", "", 0, -5)
+
+
+# ── Join codes ───────────────────────────────────────────────────────────────
+
+def test_generate_join_code_shape_and_alphabet():
+    for _ in range(50):
+        code = ls.generate_join_code()
+        assert len(code) == 6
+        assert all(c in ls.JOIN_CODE_ALPHABET for c in code)
+    # no confusables in the alphabet: I/L/O and the 0/1 they mimic
+    for confusable in "ILO01":
+        assert confusable not in ls.JOIN_CODE_ALPHABET
+
+
+def test_normalize_join_code_case_insensitive():
+    assert ls.normalize_join_code(" x7km2q ") == "X7KM2Q"
+    assert ls.normalize_join_code("X7KM2Q") == "X7KM2Q"   # same lookup key
+    assert ls.normalize_join_code(None) == ""
+    assert ls.normalize_join_code("") == ""
+
+
+def test_join_by_code_happy_in_all_joinable_states():
+    roster = {"alice@x.com"}
+    for state in ("scheduled", "open", "running"):
+        assert ls.join_by_code_error(state, "bob@x.com", roster, 0) is None
+
+
+def test_join_by_code_rejects_ended_and_cancelled():
+    assert ls.join_by_code_error("ended", "bob@x.com", set(), 0) == \
+        (409, "session has ended")
+    assert ls.join_by_code_error("cancelled", "bob@x.com", set(), 0) == \
+        (409, "session has been cancelled")
+
+
+def test_join_by_code_max_seats_full():
+    roster = {"a@x.com", "b@x.com", "c@x.com"}
+    status, detail = ls.join_by_code_error("open", "new@x.com", roster, 3)
+    assert status == 409
+    assert "full" in detail
+    # one seat still free → allowed
+    assert ls.join_by_code_error("open", "new@x.com", roster, 4) is None
+    # maxSeats 0 = unlimited
+    assert ls.join_by_code_error("open", "new@x.com", roster, 0) is None
+
+
+def test_join_by_code_rejoin_never_seat_blocked():
+    roster = {"a@x.com", "b@x.com"}
+    assert ls.join_by_code_error("open", "A@X.com ", roster, 2) is None
+
+
+def test_invite_join_allows_scheduled_rejects_cancelled():
+    roster = {"alice@x.com"}
+    assert ls.join_error("scheduled", "alice@x.com", roster) is None
+    assert ls.join_error("cancelled", "alice@x.com", roster) == \
+        (409, "session has been cancelled")
+
+
+# ── Cancel / open-registration transitions ───────────────────────────────────
+
+def test_cancel_from_scheduled_and_open():
+    assert ls.apply_transition("scheduled", "cancel") == ("cancelled", True)
+    assert ls.apply_transition("open", "cancel") == ("cancelled", True)
+
+
+def test_cancel_idempotent_and_illegal_states():
+    assert ls.apply_transition("cancelled", "cancel") == ("cancelled", False)
+    for state in ("running", "ended"):
+        try:
+            ls.apply_transition(state, "cancel")
+            raise AssertionError(f"expected ValueError for cancel from {state}")
+        except ValueError:
+            pass
+
+
+def test_open_registration_and_start_from_scheduled():
+    assert ls.apply_transition("scheduled", "open-registration") == ("open", True)
+    assert ls.apply_transition("open", "open-registration") == ("open", False)
+    assert ls.apply_transition("scheduled", "start") == ("running", True)
+    try:
+        ls.apply_transition("cancelled", "start")
+        raise AssertionError("expected ValueError")
+    except ValueError:
+        pass
+
+
+def test_cancelled_session_still_listed_for_learners():
+    """Cancelled keeps entity + index — learners must SEE the cancellation
+    (only ended sessions drop out of the list)."""
+    roster = {"alice@x.com"}
+    cancelled = _session(state="cancelled",
+                         cancelledAt="2026-07-14T11:00:00+00:00")
+    assert ls.is_listed(cancelled, roster, "alice@x.com")
+    item = ls.shape_summary("sid-1", cancelled, roster, {}, "alice@x.com")
+    assert item["state"] == "cancelled"
+    assert item["cancelledAt"] == "2026-07-14T11:00:00+00:00"
+    assert not ls.is_listed(_session(state="ended"), roster, "alice@x.com")
+
+
+# ── joinCode / workshop-field payload gating ─────────────────────────────────
+
+def test_join_code_hidden_from_learners_shown_to_trainer():
+    sess = _session(joinCode="X7KM2Q", maxSeats="20")
+    roster = {"alice@x.com"}
+    for shape in (ls.shape_summary, ls.shape_detail):
+        learner = shape("sid-1", sess, roster, {}, "alice@x.com")
+        trainer = shape("sid-1", sess, roster, {}, TRAINER)
+        assert "joinCode" not in learner
+        assert trainer["joinCode"] == "X7KM2Q"
+        assert learner["maxSeats"] == 20      # seat cap is public (ints)
+        assert trainer["maxSeats"] == 20
+
+
+def test_workshop_fields_absent_keeps_legacy_payload_shape():
+    """Pre-workshop sessions must serialize byte-identically — no new keys."""
+    item = ls.shape_summary("sid-1", _session(), {"alice@x.com"}, {}, "alice@x.com")
+    for field in ("scheduledAt", "timezone", "durationMinutes", "maxSeats",
+                  "cancelledAt", "joinCode"):
+        assert field not in item
+
+
+def test_workshop_fields_present_when_stored():
+    sess = _session(state="scheduled", scheduledAt="2026-09-01T09:00:00Z",
+                    timezone="Europe/Madrid", durationMinutes="90")
+    out = ls.shape_detail("sid-1", sess, {"alice@x.com"}, {}, "alice@x.com")
+    assert out["scheduledAt"] == "2026-09-01T09:00:00Z"
+    assert out["timezone"] == "Europe/Madrid"
+    assert out["durationMinutes"] == 90
+
+
+# ── Capacity math ────────────────────────────────────────────────────────────
+
+def test_capacity_summary_from_worker_hashes():
+    workers = [  # worker:{id} heartbeat hashes (all-string values)
+        {"worker_id": "wamd001", "capacity": "6", "arch": "amd64"},
+        {"worker_id": "wamd002", "capacity": "6", "arch": "amd64"},
+        {"worker_id": "master", "capacity": "4", "arch": "arm64"},
+    ]
+    active = {"wamd001": 5, "wamd002": 2}
+    out = ls.capacity_summary(workers, active, needed=8)
+    assert out["capacity"] == 16
+    assert out["active"] == 7
+    assert out["available"] == 9
+    assert out["needed"] == 8
+    assert out["sufficient"] is True
+    assert out["workers"] == [
+        {"id": "master", "capacity": 4, "active": 0},
+        {"id": "wamd001", "capacity": 6, "active": 5},
+        {"id": "wamd002", "capacity": 6, "active": 2},
+    ]
+
+
+def test_capacity_summary_insufficient_and_garbage_tolerant():
+    workers = [{"worker_id": "w1", "capacity": "2"},
+               {"worker_id": "w2", "capacity": "not-a-number"}]
+    out = ls.capacity_summary(workers, {"w1": 2}, needed=1)
+    assert out == {"capacity": 2, "active": 2, "available": 0, "needed": 1,
+                   "sufficient": False,
+                   "workers": [{"id": "w1", "capacity": 2, "active": 2},
+                               {"id": "w2", "capacity": 0, "active": 0}]}
+    empty = ls.capacity_summary([], {}, needed=0)
+    assert empty["sufficient"] is True and empty["capacity"] == 0
+
+
+# ── Readiness classification ─────────────────────────────────────────────────
+
+def test_readiness_state_matches_arena_status_contract():
+    assert ls.readiness_state({"worker_id": "queued"}, "") == "queued"
+    assert ls.readiness_state({"worker_id": ""}, None) == "queued"
+    assert ls.readiness_state({"worker_id": "wamd001"}, "cloning…") == "provisioning"
+    assert ls.readiness_state({"worker_id": "wamd001"},
+                              "…\nDaemon ready\n") == "ready"
+
+
+def test_failed_job_email_matching():
+    roster = {"alice@x.com"}
+    record = {"type": "daemon", "status": "failed", "job_id": "enablement-ab12",
+              "nightly_run_id": "enablement-kubernetes-101",
+              "requested_by": "Alice@X.com", "finished_at": "2026-07-14T10:00:00+00:00"}
+    since = "2026-07-14T09:00:00+00:00"
+    assert ls.failed_job_email(record, roster, "kubernetes-101", since) == "alice@x.com"
+    # wrong training / not failed / not on roster / stale → no match
+    assert ls.failed_job_email(record, roster, "dtwiz-101", since) is None
+    assert ls.failed_job_email({**record, "status": "completed"}, roster,
+                               "kubernetes-101", since) is None
+    assert ls.failed_job_email(record, {"bob@x.com"}, "kubernetes-101", since) is None
+    assert ls.failed_job_email(record, roster, "kubernetes-101",
+                               "2026-07-14T11:00:00+00:00") is None
+
+
+# ── Pad: question hygiene + section gate ─────────────────────────────────────
+
+def test_clean_text_strips_html_and_caps_length():
+    assert lp.clean_text("  <b>How</b> do I <script>x</script>scale?  ") == \
+        "How do I xscale?"
+    assert lp.clean_text("a" * lp.QUESTION_MAX_CHARS) == "a" * 2000
+    assert "2000" in _raises_value_error(lp.clean_text, "a" * 2001)
+    assert "required" in _raises_value_error(lp.clean_text, "  <p></p>  ")
+
+
+def test_section_error_trainer_gate_and_keys():
+    sess = _session()
+    assert lp.section_error("welcome", TRAINER, sess) is None
+    assert lp.section_error("solutions", " Trainer@Dynatrace.COM ", sess) is None
+    status, detail = lp.section_error("welcome", "learner@x.com", sess)
+    assert status == 403 and "trainer" in detail
+    status, detail = lp.section_error("notes", TRAINER, sess)
+    assert status == 400 and "welcome" in detail
+
+
+def test_validate_role():
+    assert lp.validate_role(" Trainer ") == "trainer"
+    assert lp.validate_role("learner") == "learner"
+    _raises_value_error(lp.validate_role, "admin")
+    _raises_value_error(lp.validate_role, "")
+
+
+# ── Pad: Q&A assembly from stream entries ────────────────────────────────────
+
+def _entries():
+    """live:pad:{id}:qa stream entries as XRANGE returns them."""
+    return [
+        ("1-0", {"type": "question", "qid": "", "email": "alice@x.com",
+                 "name": "Alice", "text": "Why is the pod pending?",
+                 "ts": "2026-07-14T10:00:00+00:00"}),
+        ("2-0", {"type": "question", "qid": "", "email": "bob@x.com",
+                 "name": "Bob", "text": "How do I get the token?",
+                 "ts": "2026-07-14T10:01:00+00:00"}),
+        ("3-0", {"type": "answer", "qid": "1-0", "email": TRAINER,
+                 "name": "Trainer", "text": "No schedulable node yet.",
+                 "ts": "2026-07-14T10:02:00+00:00"}),
+        ("4-0", {"type": "answer", "qid": "1-0", "email": TRAINER,
+                 "name": "Trainer", "text": "Fixed by the taint step.",
+                 "ts": "2026-07-14T10:03:00+00:00"}),
+        # answer to an unknown question → dropped, never shown detached
+        ("5-0", {"type": "answer", "qid": "9-9", "email": TRAINER,
+                 "name": "Trainer", "text": "orphan", "ts": "…"}),
+    ]
+
+
+def test_assemble_qa_nests_answers_under_questions():
+    qa = lp.assemble_qa(_entries())
+    assert [q["qid"] for q in qa] == ["1-0", "2-0"]
+    first = qa[0]
+    assert first["name"] == "Alice"
+    assert first["text"] == "Why is the pod pending?"
+    assert [a["text"] for a in first["answers"]] == \
+        ["No schedulable node yet.", "Fixed by the taint step."]
+    assert first["answers"][0] == {"name": "Trainer",
+                                   "text": "No schedulable node yet.",
+                                   "ts": "2026-07-14T10:02:00+00:00"}
+    assert qa[1]["answers"] == []
+    assert "orphan" not in str(qa)
+
+
+def test_assemble_qa_empty_and_shape_pad_sections_always_present():
+    assert lp.assemble_qa([]) == []
+    assert lp.assemble_qa(None) == []
+    pad = lp.shape_pad({}, [])
+    assert pad == {"sections": {"welcome": "", "solutions": ""}, "qa": []}
+    pad = lp.shape_pad({"welcome": "# Hi"}, _entries())
+    assert pad["sections"]["welcome"] == "# Hi"
+    assert len(pad["qa"]) == 2
+
+
+# ── Pad: export snapshot (rendered on the end/cancel transition) ─────────────
+
+def test_render_export_contains_sections_and_full_qa():
+    sess = _session(state="ended")
+    html_doc = lp.render_export(
+        sess, {"welcome": "# Welcome\n**read this**", "solutions": "kubectl get pods"},
+        lp.assemble_qa(_entries()))
+    for expected in ("K8s 101 — EMEA Bootcamp", "kubernetes-101",
+                     "Welcome", "Solutions", "kubectl get pods",
+                     "Why is the pod pending?", "No schedulable node yet.",
+                     "Alice", "Trainer"):
+        assert expected in html_doc
+    assert html_doc.startswith("<!DOCTYPE html>")
+    assert "orphan" not in html_doc
+
+
+def test_render_export_escapes_html_and_handles_empty_pad():
+    sess = _session(title="<script>alert(1)</script>")
+    html_doc = lp.render_export(
+        sess, {}, lp.assemble_qa([("1-0", {"type": "question", "qid": "",
+                                           "email": "e@x", "name": "<img>",
+                                           "text": "<svg onload=x>", "ts": ""})]))
+    assert "<script>" not in html_doc
+    assert "<svg" not in html_doc
+    assert "&lt;svg onload=x&gt;" in html_doc
+    empty = lp.render_export(_session(), {}, [])
+    assert "No questions were asked." in empty
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok {name}")
+    print("all workshop tests passed")

--- a/ops-server/dashboard/test_workshops.py
+++ b/ops-server/dashboard/test_workshops.py
@@ -369,3 +369,14 @@ if __name__ == "__main__":
             fn()
             print(f"ok {name}")
     print("all workshop tests passed")
+
+
+def test_end_from_scheduled_raises_value_error():
+    """`end` on a scheduled session must raise (endpoint maps it to 409, not 500).
+
+    Regression: the live end endpoint 500'd when a trainer ended a workshop
+    that was never started — caught during the 8-bot herd mini-test.
+    """
+    import pytest as _pytest
+    with _pytest.raises(ValueError):
+        ls.apply_transition("scheduled", "end")

--- a/ops-server/nginx/ops-server.conf
+++ b/ops-server/nginx/ops-server.conf
@@ -390,6 +390,24 @@ server {
         return 401 '{"error":"unauthorized","sign_in":"/oauth2/sign_in"}';
     }
 
+    # ── Workshop pad SSE streams (EPIC-002) ────────────────────────────────
+    # Server-Sent Events must not be buffered (events would sit in nginx's
+    # proxy buffer instead of reaching the browser) and need a read timeout
+    # longer than the pad's 15 s XREAD/keepalive cycle by a wide margin.
+    # HTTP/1.1 + empty Connection header keep the upstream connection open.
+    # Auth is the pad session token validated in FastAPI (query param).
+    location ~ ^/api/live/.*stream {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_read_timeout 3700s;
+    }
+
     # ── Arena API (training sessions, called via the DT app function) ──────
     # Learner-facing checks answer instantly (check* helpers) and never hold
     # this connection. The high ceiling exists for AUTOMATION only: lab-driver


### PR DESCRIPTION
Orbital backend for EPIC-002 Workshops (companion to dynatrace-app-enablements #64).

## What
- live_sessions: scheduled/cancelled states, join codes (NX-reserved), maxSeats, schedule fields — backward compatible, legacy payloads unchanged
- New endpoints: join-by-code, cancel, open-registration, provision-all (in-process arena reuse, per-learner token maps, roster chunking), readiness, capacity (worker-heartbeat math)
- live_pad: trainer sections + attributed Q&A on Redis streams, SSE stream, single-use pad tokens (shell-token pattern), self-contained popup page /pad/{id}, print-friendly export frozen on end/cancel
- nginx: SSE location (proxy_buffering off, 3700s)
- fix: end-transition on scheduled session now 409 (was unhandled 500) + regression test

## Verified
- 53 dashboard tests green (23 pre-existing live-session tests unchanged)
- Live on production Orbital: SRO e2e, sprint e2e (app-minted platform tokens through bulk path), 8-bot herd test 8/8 ready 2m37s

🤖 Generated with [Claude Code](https://claude.com/claude-code)