### PR TITLE
fix(security): mask PII on public Orbital reads + auth-tighten live-session writes

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -1,6 +1,7 @@
 """Dashboard — web UI and API for the multi-arch ops platform."""
 
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -84,6 +85,10 @@ from dashboard import live_sessions  # noqa: E402
 # Structured workshop pad (EPIC-002) — pure decision logic in
 # dashboard/live_pad.py (tested without Redis); endpoints below stay thin.
 from dashboard import live_pad  # noqa: E402
+
+# PII masking for anonymous (public) reads — pure transforms in
+# dashboard/masking.py (tested without Redis).
+from dashboard import masking  # noqa: E402
 
 _PROFILES_PAGE = """<!doctype html><html><head><meta charset=utf-8>
 <title>Content Profiles</title><style>
@@ -478,6 +483,57 @@ async def _require_writer(request: Request) -> dict:
             },
         )
     return role
+
+
+# ── Service bearer + PII masking (public reads) ──────────────────────────────
+# The Dynatrace app's `orbital` app function sends `Authorization: Bearer
+# <token>` (from the tenant's orbital-config app-settings secret). ORBITAL_TOKEN
+# in /home/ops/.env holds the accepted value(s) (comma-separated to allow
+# rotation). Callers presenting it are "service" callers and get FULL payloads;
+# signed-in org members (nginx-verified X-Auth-User) also get full payloads;
+# everyone else is anonymous and gets emails/tenants masked (dashboard is
+# public — see dashboard/masking.py).
+#
+# X-Auth-User is only trustworthy on nginx locations that either hard-gate
+# (auth_request) or opportunistically set AND clear it — the catch-all and
+# arena locations clear it explicitly so it cannot be spoofed by clients.
+
+ORBITAL_TOKENS = tuple(
+    t.strip() for t in os.environ.get("ORBITAL_TOKEN", "").split(",") if t.strip())
+
+
+def _is_service_caller(request: Request) -> bool:
+    """True when the request carries a bearer matching a configured
+    ORBITAL_TOKEN. Always False when no token is configured (fail closed:
+    an empty config must not turn every caller into a service caller)."""
+    auth = request.headers.get("authorization", "")
+    if not auth.lower().startswith("bearer "):
+        return False
+    presented = auth[7:].strip()
+    return any(hmac.compare_digest(presented, t) for t in ORBITAL_TOKENS)
+
+
+def _has_full_access(request: Request) -> bool:
+    """Masking decision for public reads: service bearer OR a signed-in org
+    member (X-Auth-User is set by nginx only after oauth2-proxy validated
+    the session, and cleared on anonymous fallbacks)."""
+    return bool(request.headers.get("x-auth-user", "")) or _is_service_caller(request)
+
+
+async def _require_service_or_writer(request: Request) -> None:
+    """Auth gate for live-session write endpoints: the app's service bearer
+    OR a signed-in writer. 401 otherwise (403 for a signed-in non-member)."""
+    if _is_service_caller(request):
+        return
+    if request.headers.get("x-auth-user", ""):
+        await _require_writer(request)
+        return
+    raise HTTPException(
+        status_code=401,
+        detail={"error": "unauthorized",
+                "reason": "this endpoint requires the Orbital service bearer "
+                          "or a signed-in org member session"},
+    )
 
 
 @app.get("/api/auth/role")
@@ -1097,14 +1153,19 @@ async def api_agent_fix_issue(request: Request):
 
 
 @app.get("/api/builds/running")
-async def api_builds_running():
+async def api_builds_running(request: Request):
     """Currently executing tests, plus pending queue depths.
 
     Workers write a ``job:running:<run_id>`` HASH when they pick up a job and
     delete it when done. Concurrency per (repo, branch, arch) is enforced via
     ``running:lock:<triple>`` STRING keys (see workers/manager.py and
     worker-agent/agent.py).
+
+    Public endpoint — anonymous callers get arena_user/arena_tenant masked
+    (learner emails + tenant URLs are PII); signed-in org members and the
+    app's service bearer get full values.
     """
+    full = _has_full_access(request)
     queues = {}
     for arch in ("arm64", "amd64"):
         queues[arch] = await pool.llen(f"queue:test:{arch}")
@@ -1130,8 +1191,10 @@ async def api_builds_running():
                 "started_at": meta.get("started_at"),
                 "worker_id": meta.get("worker_id"),
                 "type": meta.get("type", "integration-test"),
-                "arena_user": meta.get("arena_user"),
-                "arena_tenant": meta.get("arena_tenant"),
+                "arena_user": meta.get("arena_user") if full
+                              else masking.mask_email(meta.get("arena_user")),
+                "arena_tenant": meta.get("arena_tenant") if full
+                                else masking.mask_tenant(meta.get("arena_tenant")),
                 "provider": meta.get("provider", "sysbox"),
                 "stage": meta.get("stage"),
             })
@@ -1278,8 +1341,12 @@ async def api_terminate_job(job_id: str, request: Request):
 
 
 @app.get("/api/queue/list")
-async def api_queue_list():
-    """Contents of the pending test queues (arm64 + amd64), unordered."""
+async def api_queue_list(request: Request):
+    """Contents of the pending test queues (arm64 + amd64), unordered.
+
+    Public — requested_by (a learner email for queued arena jobs) is masked
+    for anonymous callers."""
+    full = _has_full_access(request)
     result = []
     for arch in ("arm64", "amd64"):
         items = await pool.lrange(f"queue:test:{arch}", 0, -1)
@@ -1297,7 +1364,8 @@ async def api_queue_list():
                 "ref":          j.get("ref") or j.get("branch") or j.get("head_branch") or "main",
                 "type":         j.get("type", "integration-test"),
                 "queued_at":    j.get("timestamp") or j.get("queued_at"),
-                "requested_by": j.get("requested_by", ""),
+                "requested_by": j.get("requested_by", "") if full
+                                else masking.mask_email(j.get("requested_by", "")),
             })
     return {"items": result, "total": len(result)}
 
@@ -3951,7 +4019,7 @@ async def api_arena_provision(body: ArenaProvisionRequest):
 
 
 @app.get("/api/arena/sessions/{job_id}")
-async def api_arena_session_status(job_id: str):
+async def api_arena_session_status(job_id: str, request: Request):
     """Return current session status.
 
     Status transitions:
@@ -3993,19 +4061,25 @@ async def api_arena_session_status(job_id: str):
     else:
         status = "provisioning"
 
+    # Anonymous callers get the learner identity masked (the app's bearer /
+    # signed-in members get full values — the app needs them for the UI + DQL
+    # session-id substitution).
+    full = _has_full_access(request)
     return {
         "jobId":      job_id,
         "status":     status,
         "wsUrl":      f"wss://autonomous-enablements.whydevslovedynatrace.com/ws/jobs/{job_id}/shell",
         "trainingId": meta.get("training_id", ""),
-        "userId":     meta.get("arena_user", ""),
+        "userId":     meta.get("arena_user", "") if full
+                      else masking.mask_email(meta.get("arena_user", "")),
         "expiresAt":  meta.get("expires_at", ""),
-        "dtSessionId": meta.get("dt_hostgroup", ""),
+        "dtSessionId": meta.get("dt_hostgroup", "") if full
+                       else masking.mask_email(meta.get("dt_hostgroup", "")),
     }
 
 
 @app.get("/api/arena/user-session")
-async def api_arena_user_session(userId: str, trainingId: str, tenant: str = ""):
+async def api_arena_user_session(userId: str, trainingId: str, request: Request, tenant: str = ""):
     """Find an existing running session for a given user + training + tenant.
 
     Session uniqueness is (user, tenant, training): the SAME user may have a
@@ -4034,14 +4108,17 @@ async def api_arena_user_session(userId: str, trainingId: str, tenant: str = "")
                     status = "queued"
                 else:
                     status = "provisioning"
+                full = _has_full_access(request)
                 return {
                     "jobId":      job_id,
                     "status":     status,
                     "wsUrl":      f"wss://autonomous-enablements.whydevslovedynatrace.com/ws/jobs/{job_id}/shell",
                     "trainingId": meta.get("training_id", ""),
-                    "userId":     meta.get("arena_user", ""),
+                    "userId":     meta.get("arena_user", "") if full
+                                  else masking.mask_email(meta.get("arena_user", "")),
                     "expiresAt":  meta.get("expires_at", ""),
-                    "dtSessionId": meta.get("dt_hostgroup", ""),
+                    "dtSessionId": meta.get("dt_hostgroup", "") if full
+                                   else masking.mask_email(meta.get("dt_hostgroup", "")),
                 }
         if cursor == 0:
             break
@@ -4049,7 +4126,7 @@ async def api_arena_user_session(userId: str, trainingId: str, tenant: str = "")
 
 
 @app.get("/api/arena/active-sessions")
-async def api_arena_active_sessions(userId: str, tenant: str = ""):
+async def api_arena_active_sessions(userId: str, request: Request, tenant: str = ""):
     """Every running session for a user+tenant, ACROSS all trainings.
 
     Server-side resource guard: only one live environment per user+tenant is
@@ -4058,6 +4135,7 @@ async def api_arena_active_sessions(userId: str, tenant: str = ""):
     the learner switches browser/device (localStorage can't see those). Mirrors
     user-session but drops the training filter and returns a list.
     """
+    full = _has_full_access(request)
     sessions = []
     cursor = 0
     while True:
@@ -4081,7 +4159,8 @@ async def api_arena_active_sessions(userId: str, tenant: str = ""):
                     "jobId":      job_id,
                     "status":     status,
                     "trainingId": meta.get("training_id", ""),
-                    "userId":     meta.get("arena_user", ""),
+                    "userId":     meta.get("arena_user", "") if full
+                                  else masking.mask_email(meta.get("arena_user", "")),
                     "expiresAt":  meta.get("expires_at", ""),
                 })
         if cursor == 0:
@@ -4816,7 +4895,7 @@ async def _reserve_join_code(session_id: str) -> str:
 
 
 @app.post("/api/live/sessions")
-async def api_live_session_create(body: LiveSessionCreate):
+async def api_live_session_create(body: LiveSessionCreate, request: Request):
     """Create a live session (state=open) with a roster of invited emails.
 
     Emails are trimmed + lowercased; entries without an '@' are dropped.
@@ -4828,7 +4907,10 @@ async def api_live_session_create(body: LiveSessionCreate):
     room later via /open-registration or /start), without it state "open"
     exactly as before. Every session gets a unique join code (trainer-only
     in payloads) resolvable via POST /api/live/sessions/join-by-code.
+
+    Auth: service bearer (the app's orbital function) or a signed-in writer.
     """
+    await _require_service_or_writer(request)
     try:
         fields = live_sessions.validate_create(
             body.title, body.trainingId, body.trainerEmail, body.roster)
@@ -4865,12 +4947,17 @@ async def api_live_session_create(body: LiveSessionCreate):
 
 
 @app.get("/api/live/sessions")
-async def api_live_sessions_list(email: str = ""):
+async def api_live_sessions_list(request: Request, email: str = ""):
     """Active (state != ended) sessions visible to an email — as trainer or
-    roster member. Index entries whose keys have TTL-expired are skipped."""
+    roster member. Index entries whose keys have TTL-expired are skipped.
+
+    The email is caller-supplied (the app proxy authenticates with the
+    service bearer, not per-user) — anonymous callers therefore get masked
+    trainer emails and never a joinCode."""
     email = live_sessions.normalize_email(email)
     if not live_sessions.is_valid_email(email):
         raise HTTPException(status_code=400, detail="a valid email query parameter is required")
+    full = _has_full_access(request)
     sessions = []
     for session_id in await pool.zrevrange("live:sessions:index", 0, -1):
         sess_key, roster_key, joined_key = _live_keys(session_id)
@@ -4881,22 +4968,28 @@ async def api_live_sessions_list(email: str = ""):
         if not live_sessions.is_listed(session, roster, email):
             continue
         joined = await pool.hgetall(joined_key)
-        sessions.append(live_sessions.shape_summary(
-            session_id, session, roster, joined, email))
+        item = live_sessions.shape_summary(
+            session_id, session, roster, joined, email)
+        sessions.append(item if full else masking.mask_live_summary(item))
     return {"sessions": sessions, "count": len(sessions)}
 
 
 @app.get("/api/live/sessions/{session_id}")
-async def api_live_session_detail(session_id: str, email: str = ""):
+async def api_live_session_detail(session_id: str, request: Request, email: str = ""):
     """Full session state. The roster and per-learner joined list are only
-    included when the caller email matches trainerEmail; learners get counts."""
+    included when the caller email matches trainerEmail; learners get counts.
+
+    The trainerEmail match is caller-supplied — anonymous callers get the
+    masked view (no roster/joined/joinCode, masked trainer email) even when
+    they present the trainer's email."""
     sess_key, roster_key, joined_key = _live_keys(session_id)
     session = await pool.hgetall(sess_key)
     if not session:
         raise HTTPException(status_code=404, detail="Session not found or expired")
     roster = await pool.smembers(roster_key)
     joined = await pool.hgetall(joined_key)
-    return live_sessions.shape_detail(session_id, session, roster, joined, email)
+    detail = live_sessions.shape_detail(session_id, session, roster, joined, email)
+    return detail if _has_full_access(request) else masking.mask_live_detail(detail)
 
 
 @app.post("/api/live/sessions/{session_id}/join")
@@ -4920,10 +5013,11 @@ async def api_live_session_join(session_id: str, body: LiveSessionJoin):
 
 
 @app.post("/api/live/sessions/{session_id}/start")
-async def api_live_session_start(session_id: str, body: LiveSessionTrainerAction):
+async def api_live_session_start(session_id: str, body: LiveSessionTrainerAction, request: Request):
     """Trainer starts the session: scheduled|open → running (learners'
     waiting screens flip). Idempotent when already running; 403 on
-    trainerEmail mismatch."""
+    trainerEmail mismatch. Auth: service bearer or signed-in writer."""
+    await _require_service_or_writer(request)
     sess_key, roster_key, joined_key = _live_keys(session_id)
     session = await pool.hgetall(sess_key)
     if not session:
@@ -4946,9 +5040,11 @@ async def api_live_session_start(session_id: str, body: LiveSessionTrainerAction
 
 
 @app.post("/api/live/sessions/{session_id}/end")
-async def api_live_session_end(session_id: str, body: LiveSessionTrainerAction):
+async def api_live_session_end(session_id: str, body: LiveSessionTrainerAction, request: Request):
     """Trainer ends the session: state → ended, freezes the board, and sets a
-    7-day TTL on the session keys (index entry kept; listing tolerates it)."""
+    7-day TTL on the session keys (index entry kept; listing tolerates it).
+    Auth: service bearer or signed-in writer."""
+    await _require_service_or_writer(request)
     sess_key, roster_key, joined_key = _live_keys(session_id)
     session = await pool.hgetall(sess_key)
     if not session:
@@ -4973,12 +5069,14 @@ async def api_live_session_end(session_id: str, body: LiveSessionTrainerAction):
 
 
 @app.post("/api/live/sessions/{session_id}/cancel")
-async def api_live_session_cancel(session_id: str, body: LiveSessionTrainerAction):
+async def api_live_session_cancel(session_id: str, body: LiveSessionTrainerAction, request: Request):
     """Trainer cancels a scheduled/open workshop: state → cancelled, sets
     cancelledAt, freezes the pad into the export snapshot, and applies the
     same 7-day TTL as ended (entity + index kept so learners see it was
     cancelled rather than a vanished session). Idempotent; 409 once running
-    or ended; 403 on trainerEmail mismatch."""
+    or ended; 403 on trainerEmail mismatch. Auth: service bearer or
+    signed-in writer."""
+    await _require_service_or_writer(request)
     sess_key, roster_key, joined_key = _live_keys(session_id)
     session = await pool.hgetall(sess_key)
     if not session:
@@ -5003,10 +5101,11 @@ async def api_live_session_cancel(session_id: str, body: LiveSessionTrainerActio
 
 
 @app.post("/api/live/sessions/{session_id}/open-registration")
-async def api_live_session_open_registration(session_id: str, body: LiveSessionTrainerAction):
+async def api_live_session_open_registration(session_id: str, body: LiveSessionTrainerAction, request: Request):
     """Trainer opens registration on a scheduled workshop: scheduled → open.
     Idempotent when already open; 409 once running/ended/cancelled; 403 on
-    trainerEmail mismatch."""
+    trainerEmail mismatch. Auth: service bearer or signed-in writer."""
+    await _require_service_or_writer(request)
     sess_key, roster_key, joined_key = _live_keys(session_id)
     session = await pool.hgetall(sess_key)
     if not session:
@@ -5027,11 +5126,16 @@ async def api_live_session_open_registration(session_id: str, body: LiveSessionT
 
 
 @app.post("/api/live/sessions/join-by-code")
-async def api_live_session_join_by_code(body: LiveSessionJoinByCode):
+async def api_live_session_join_by_code(body: LiveSessionJoinByCode, request: Request):
     """Join a workshop by its 6-char code (case-insensitive) — appends the
     email to the roster (self-registration), unlike /join which requires an
     invite. 404 unknown code, 409 when full (maxSeats) or ended/cancelled.
-    Returns the session summary (learner view — no joinCode echo)."""
+    Returns the session summary (learner view — no joinCode echo).
+
+    Auth: service bearer or signed-in writer — learners always join through
+    the app's authed proxy, so an anonymous caller has no business here
+    (prevents code-guessing roster injection + email harvesting)."""
+    await _require_service_or_writer(request)
     code = live_sessions.normalize_join_code(body.code)
     if not code:
         raise HTTPException(status_code=400, detail="a join code is required")
@@ -5060,14 +5164,16 @@ async def api_live_session_join_by_code(body: LiveSessionJoinByCode):
 
 
 @app.post("/api/live/sessions/{session_id}/provision-all")
-async def api_live_session_provision_all(session_id: str, body: LiveSessionProvisionAll):
+async def api_live_session_provision_all(session_id: str, body: LiveSessionProvisionAll, request: Request):
     """Trainer pre-provisions a training environment for every roster email.
 
     Reuses the arena provision path verbatim (including its one-active-
     session-per-user+tenant+training dedupe): already-active learners are
     reported as "already-active", everyone else gets a daemon job queued
     exactly as POST /api/arena/provision would. tenant = the trainer's arena
-    tenant URL; the session's trainingId/ref drive repo + branch."""
+    tenant URL; the session's trainingId/ref drive repo + branch.
+    Auth: service bearer or signed-in writer."""
+    await _require_service_or_writer(request)
     sess_key, roster_key, _ = _live_keys(session_id)
     session = await pool.hgetall(sess_key)
     if not session:
@@ -5110,7 +5216,7 @@ async def api_live_session_provision_all(session_id: str, body: LiveSessionProvi
 
 
 @app.get("/api/live/sessions/{session_id}/readiness")
-async def api_live_session_readiness(session_id: str, trainerEmail: str = ""):
+async def api_live_session_readiness(session_id: str, request: Request, trainerEmail: str = ""):
     """Trainer's per-learner provisioning board: for each roster email the
     state of their environment for THIS training — none | queued |
     provisioning | ready | failed. "ready" is the same "Daemon ready"
@@ -5168,7 +5274,10 @@ async def api_live_session_readiness(session_id: str, trainerEmail: str = ""):
                             "jobId": failed_by_email[email]})
         else:
             results.append({"email": email, "state": "none"})
-    return {"results": results}
+    payload = {"results": results}
+    # trainerEmail is caller-supplied — anonymous callers who know it must
+    # not harvest the roster; they get masked emails (states stay visible).
+    return payload if _has_full_access(request) else masking.mask_readiness(payload)
 
 
 @app.get("/api/live/capacity")
@@ -5377,15 +5486,17 @@ async def _resolve_pad_session(pad_session: str) -> dict:
 
 
 @app.get("/api/live/sessions/{session_id}/pad")
-async def api_live_pad_get(session_id: str):
+async def api_live_pad_get(session_id: str, request: Request):
     """Full pad state: the two structured sections + Q&A with answers
     assembled under their questions. Poll-friendly (the in-app tab reads
-    this via the orbital proxy); the popup page uses the SSE stream."""
+    this via the orbital proxy); the popup page uses the SSE stream.
+    Anonymous callers get question authors' emails masked."""
     await _require_live_session(session_id)
     sections_key, qa_key, _ = _pad_keys(session_id)
     sections = await pool.hgetall(sections_key)
     entries = await pool.xrange(qa_key)
-    return live_pad.shape_pad(sections, entries)
+    pad = live_pad.shape_pad(sections, entries)
+    return pad if _has_full_access(request) else masking.mask_pad(pad)
 
 
 @app.post("/api/live/sessions/{session_id}/pad/section")
@@ -5420,8 +5531,13 @@ async def api_live_pad_answer(session_id: str, body: LivePadAnswer):
 
 
 @app.get("/api/live/sessions/{session_id}/pad/stream")
-async def api_live_pad_stream(session_id: str):
-    """SSE pad feed (snapshot + incremental) — session-scoped variant."""
+async def api_live_pad_stream(session_id: str, request: Request):
+    """SSE pad feed (snapshot + incremental) — session-scoped variant.
+
+    Auth: service bearer or signed-in writer. The popup page uses the
+    padSession-authed /api/live/pad/stream instead; this variant has no
+    per-user credential, so anonymous access would leak Q&A emails."""
+    await _require_service_or_writer(request)
     await _require_live_session(session_id)
     return _sse_response(_pad_event_stream(session_id))
 
@@ -5444,13 +5560,16 @@ async def api_live_pad_export(session_id: str, email: str = ""):
 
 
 @app.post("/api/live/sessions/{session_id}/pad-token")
-async def api_live_pad_token(session_id: str, body: LivePadTokenRequest):
+async def api_live_pad_token(session_id: str, body: LivePadTokenRequest, request: Request):
     """Issue a single-use 60-second pad handoff token (shell-token pattern).
 
     Called via the app's authed orbital proxy; the token rides the
     /pad/{id}?token=… URL and is claimed exactly once by the page, which
     mints the 8h pad session. Trainer role requires the trainerEmail match;
-    learners must be on the roster."""
+    learners must be on the roster. Auth: service bearer or signed-in
+    writer (an anonymous caller supplying a rostered email must not be able
+    to mint pad identities)."""
+    await _require_service_or_writer(request)
     session = await _require_live_session(session_id)
     try:
         role = live_pad.validate_role(body.role)

--- a/ops-server/dashboard/masking.py
+++ b/ops-server/dashboard/masking.py
@@ -1,0 +1,88 @@
+"""PII masking for public (anonymous) reads of Orbital APIs.
+
+Running-training payloads carry learner emails and tenant URLs. Those are
+fine for signed-in org members (nginx-verified X-Auth-User) and for the
+Dynatrace app (service bearer), but the dashboard and several read APIs are
+public — anonymous callers must only ever see masked values.
+
+Pure functions, no FastAPI/Redis — unit-tested in dashboard/test_masking.py.
+The identity decision (who is anonymous) lives in app.py; everything here
+just transforms payloads.
+"""
+
+
+def mask_email(email) -> str:
+    """'maria.gonzalez@dynatrace.com' -> 'ma***@d***'.
+
+    Keeps the first 2 chars of the local part and the first char of the
+    domain. Values without an '@' (usernames, hostgroup session ids) are
+    treated as a bare local part: 'sergio_hinojosa_2026aug02' -> 'se***'.
+    Falsy values pass through unchanged so absent fields stay absent.
+    """
+    if not email:
+        return email
+    email = str(email)
+    if "@" not in email:
+        return f"{email[:2]}***"
+    local, _, domain = email.partition("@")
+    return f"{local[:2]}***@{domain[:1]}***"
+
+
+def mask_tenant(tenant) -> str:
+    """'https://sro97894.apps.dynatrace.com' -> 'https://sro***'.
+
+    Keeps the scheme (when present) and the first 3 chars of the tenant id
+    (the host's first label). Bare ids work too: 'sro97894' -> 'sro***'.
+    Falsy values pass through unchanged.
+    """
+    if not tenant:
+        return tenant
+    tenant = str(tenant)
+    scheme, sep, rest = tenant.partition("://")
+    if not sep:
+        scheme, rest = "", tenant
+    tenant_id = rest.split("/", 1)[0].split(".", 1)[0]
+    masked = f"{tenant_id[:3]}***"
+    return f"{scheme}://{masked}" if sep else masked
+
+
+# ── Live-session payload masking ──────────────────────────────────────────────
+# shape_summary/shape_detail (live_sessions.py) trust the CALLER-SUPPLIED email
+# to decide trainer-only fields (joinCode, roster, joined). That is fine for
+# the app's bearer-authed proxy, but an anonymous caller could supply the
+# trainer's email — so anonymous responses are post-processed here: the
+# trainer-only fields are dropped outright and every email is masked.
+
+def mask_live_summary(item: dict) -> dict:
+    """Anonymous view of one GET /api/live/sessions list item."""
+    out = dict(item)
+    out.pop("joinCode", None)
+    if "trainerEmail" in out:
+        out["trainerEmail"] = mask_email(out["trainerEmail"])
+    return out
+
+
+def mask_live_detail(item: dict) -> dict:
+    """Anonymous view of GET /api/live/sessions/{id} (and transition echoes):
+    no joinCode, no roster, no joined list, masked trainer email."""
+    out = mask_live_summary(item)
+    out.pop("roster", None)
+    out.pop("joined", None)
+    return out
+
+
+def mask_readiness(payload: dict) -> dict:
+    """Anonymous view of GET /api/live/sessions/{id}/readiness — the roster
+    emails are masked; states/jobIds stay (jobIds are already public in the
+    dashboard's running list)."""
+    return {**payload,
+            "results": [{**row, "email": mask_email(row.get("email", ""))}
+                        for row in payload.get("results", [])]}
+
+
+def mask_pad(payload: dict) -> dict:
+    """Anonymous view of GET /api/live/sessions/{id}/pad — question authors'
+    emails are masked (names stay: they are free-text display names)."""
+    return {**payload,
+            "qa": [{**q, "email": mask_email(q.get("email", ""))}
+                   for q in payload.get("qa", [])]}

--- a/ops-server/dashboard/test_live_auth.py
+++ b/ops-server/dashboard/test_live_auth.py
@@ -1,0 +1,76 @@
+"""Auth gating for the live-session write endpoints (PII epic).
+
+Verifies the _require_service_or_writer contract over HTTP with Starlette's
+TestClient: anonymous callers get 401 on every live-session write; a caller
+presenting the configured ORBITAL_TOKEN bearer passes the gate (asserted via
+a 400 from body validation — reached only after auth — so no Redis is needed).
+
+Runnable: /home/ops/ops-venv/bin/python -m pytest dashboard/test_live_auth.py
+"""
+
+import dashboard.app as a
+from fastapi.testclient import TestClient
+
+client = TestClient(a.app, raise_server_exceptions=False)
+
+BEARER = {"Authorization": "Bearer test-service-token"}
+
+
+def setup_module(_module):
+    """Accept a known bearer regardless of the (test-runner) environment —
+    other test files may import dashboard.app before this one, so the env
+    var route is not reliable under a full-suite run."""
+    _module._saved_tokens = a.ORBITAL_TOKENS
+    a.ORBITAL_TOKENS = ("test-service-token",)
+
+
+def teardown_module(_module):
+    a.ORBITAL_TOKENS = _module._saved_tokens
+
+WRITE_POSTS = [
+    "/api/live/sessions",
+    "/api/live/sessions/sid-1/start",
+    "/api/live/sessions/sid-1/end",
+    "/api/live/sessions/sid-1/cancel",
+    "/api/live/sessions/sid-1/open-registration",
+    "/api/live/sessions/join-by-code",
+    "/api/live/sessions/sid-1/provision-all",
+    "/api/live/sessions/sid-1/pad-token",
+]
+
+
+def test_orbital_token_configured():
+    assert "test-service-token" in a.ORBITAL_TOKENS
+
+
+def test_anonymous_write_posts_all_401():
+    for path in WRITE_POSTS:
+        r = client.post(path, json={})
+        assert r.status_code == 401, f"{path} -> {r.status_code} (expected 401)"
+
+
+def test_wrong_bearer_is_401():
+    r = client.post("/api/live/sessions", json={},
+                    headers={"Authorization": "Bearer wrong"})
+    assert r.status_code == 401
+
+
+def test_service_bearer_passes_gate_create():
+    # Empty body fails validation with 400 — reached only AFTER the auth gate,
+    # and before any Redis access (validate_create raises first).
+    r = client.post("/api/live/sessions", json={}, headers=BEARER)
+    assert r.status_code == 400
+
+
+def test_service_bearer_passes_gate_join_by_code():
+    # Missing code → 400 from normalize_join_code, again pre-Redis.
+    r = client.post("/api/live/sessions/join-by-code", json={}, headers=BEARER)
+    assert r.status_code == 400
+
+
+def test_spoofed_x_auth_user_is_ignored_when_nginx_cleared_it():
+    # nginx clears X-Auth-User on anonymous paths; FastAPI sees the empty
+    # header exactly as if it were absent → still 401.
+    r = client.post("/api/live/sessions", json={},
+                    headers={"X-Auth-User": ""})
+    assert r.status_code == 401

--- a/ops-server/dashboard/test_masking.py
+++ b/ops-server/dashboard/test_masking.py
@@ -1,0 +1,122 @@
+"""Pure-logic tests for PII masking (dashboard/masking.py).
+
+No Redis, no FastAPI — same approach as test_live_sessions.py: exercises the
+masking transforms applied to anonymous (public) API reads.
+
+Runnable two ways:
+  - pytest:     python3 -m pytest dashboard/test_masking.py
+  - standalone: /home/ops/ops-venv/bin/python -m dashboard.test_masking
+"""
+
+from dashboard import masking as m
+
+
+# ── mask_email ───────────────────────────────────────────────────────────────
+
+def test_mask_email_keeps_two_local_chars_and_domain_initial():
+    assert m.mask_email("maria.gonzalez@dynatrace.com") == "ma***@d***"
+    assert m.mask_email("bob@x.com") == "bo***@x***"
+
+
+def test_mask_email_short_local_part():
+    assert m.mask_email("a@b.com") == "a***@b***"
+
+
+def test_mask_email_without_at_is_treated_as_bare_id():
+    assert m.mask_email("sergio_hinojosa_2026aug02") == "se***"
+    assert m.mask_email("sergiohinojosa") == "se***"
+
+
+def test_mask_email_falsy_passthrough():
+    assert m.mask_email("") == ""
+    assert m.mask_email(None) is None
+
+
+# ── mask_tenant ──────────────────────────────────────────────────────────────
+
+def test_mask_tenant_url_keeps_scheme_and_three_chars():
+    assert m.mask_tenant("https://sro97894.apps.dynatrace.com") == "https://sro***"
+    assert m.mask_tenant("https://geu80787.live.dynatrace.com/") == "https://geu***"
+
+
+def test_mask_tenant_bare_id():
+    assert m.mask_tenant("sro97894") == "sro***"
+    assert m.mask_tenant("ydi9582h.sprint.apps.dynatracelabs.com") == "ydi***"
+
+
+def test_mask_tenant_falsy_passthrough():
+    assert m.mask_tenant("") == ""
+    assert m.mask_tenant(None) is None
+
+
+# ── live-session payload masking ─────────────────────────────────────────────
+
+def _summary(**extra):
+    item = {
+        "sessionId": "msc46p55-7f00", "title": "K8s 101",
+        "trainingId": "kubernetes-101", "state": "open",
+        "trainerEmail": "trainer@dynatrace.com",
+        "joinedCount": 3, "rosterCount": 10,
+        "isTrainer": False, "hasJoined": False,
+    }
+    item.update(extra)
+    return item
+
+
+def test_mask_live_summary_masks_trainer_and_drops_joincode():
+    masked = m.mask_live_summary(_summary(joinCode="ABC234"))
+    assert masked["trainerEmail"] == "tr***@d***"
+    assert "joinCode" not in masked
+    # Non-PII fields untouched
+    assert masked["joinedCount"] == 3 and masked["rosterCount"] == 10
+
+
+def test_mask_live_summary_does_not_mutate_input():
+    item = _summary(joinCode="ABC234")
+    m.mask_live_summary(item)
+    assert item["joinCode"] == "ABC234"
+    assert item["trainerEmail"] == "trainer@dynatrace.com"
+
+
+def test_mask_live_detail_drops_roster_and_joined():
+    detail = _summary(
+        joinCode="ABC234",
+        roster=["a@x.com", "b@y.com"],
+        joined=[{"email": "a@x.com", "joinedAt": "2026-08-02T10:00:00+00:00"}])
+    masked = m.mask_live_detail(detail)
+    assert "roster" not in masked
+    assert "joined" not in masked
+    assert "joinCode" not in masked
+    assert masked["trainerEmail"] == "tr***@d***"
+
+
+def test_mask_readiness_masks_roster_emails_keeps_states():
+    payload = {"results": [
+        {"email": "alice@x.com", "state": "ready", "jobId": "mk3p9aqz-7f3a"},
+        {"email": "bob@y.com", "state": "none"},
+    ]}
+    masked = m.mask_readiness(payload)
+    assert masked["results"][0] == {
+        "email": "al***@x***", "state": "ready", "jobId": "mk3p9aqz-7f3a"}
+    assert masked["results"][1] == {"email": "bo***@y***", "state": "none"}
+    # input untouched
+    assert payload["results"][0]["email"] == "alice@x.com"
+
+
+def test_mask_pad_masks_question_author_emails():
+    payload = {"sections": {"welcome": "hi"}, "qa": [
+        {"qid": "1-0", "name": "Alice", "email": "alice@x.com",
+         "text": "why?", "answers": []},
+    ]}
+    masked = m.mask_pad(payload)
+    assert masked["qa"][0]["email"] == "al***@x***"
+    assert masked["qa"][0]["name"] == "Alice"
+    assert masked["sections"] == {"welcome": "hi"}
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok {name}")
+    print("all masking tests passed")

--- a/ops-server/nginx/ops-server.conf
+++ b/ops-server/nginx/ops-server.conf
@@ -396,16 +396,89 @@ server {
     # longer than the pad's 15 s XREAD/keepalive cycle by a wide margin.
     # HTTP/1.1 + empty Connection header keep the upstream connection open.
     # Auth is the pad session token validated in FastAPI (query param).
+    # X-Auth-User is cleared: no auth_request runs here, so a client-supplied
+    # header must never reach FastAPI looking nginx-verified.
     location ~ ^/api/live/.*stream {
         proxy_pass http://127.0.0.1:8080;
         proxy_http_version 1.1;
         proxy_set_header Connection "";
+        proxy_set_header X-Auth-User  "";
+        proxy_set_header X-Auth-Email "";
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_buffering off;
         proxy_read_timeout 3700s;
+    }
+
+    # ── Live training sessions (PII-masked for anonymous callers) ──────────
+    # Opportunistic auth (the /api/auth/role pattern): a signed-in org member
+    # gets X-Auth-User forwarded (FastAPI returns FULL rosters/emails and may
+    # write); everyone else falls through to @live_anonymous with the header
+    # CLEARED (FastAPI masks emails/tenants and 401s the write endpoints
+    # unless the app's service bearer is presented — the Authorization header
+    # passes through untouched on both paths). Placed AFTER the stream block
+    # so SSE keeps its buffering-off location (first matching regex wins).
+    location ~ ^/api/live/ {
+        auth_request      /oauth2/auth;
+        auth_request_set  $user  $upstream_http_x_auth_request_user;
+        auth_request_set  $email $upstream_http_x_auth_request_email;
+        error_page 401 = @live_anonymous;
+
+        proxy_set_header X-Auth-User  $user;
+        proxy_set_header X-Auth-Email $email;
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # provision-all fans out arena provisions — allow the same headroom
+        # the app function has (its own cap is 120s).
+        proxy_read_timeout 180s;
+        proxy_send_timeout 180s;
+    }
+
+    location @live_anonymous {
+        proxy_set_header X-Auth-User  "";
+        proxy_set_header X-Auth-Email "";
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 180s;
+        proxy_send_timeout 180s;
+    }
+
+    # ── Dashboard reads with PII + writer actions without a dedicated block ─
+    # Same opportunistic pattern: signed-in members see full learner emails /
+    # tenants on the running list + queue and can use rerun / queue-item /
+    # EC2 fleet actions; anonymous callers get masked payloads (and 401 on
+    # the writer actions) because the header is cleared in the fallback.
+    location ~ ^/api/(builds/running|builds/rerun/.+|queue/(list|item)|fleet(/.*)?)$ {
+        auth_request      /oauth2/auth;
+        auth_request_set  $user  $upstream_http_x_auth_request_user;
+        auth_request_set  $email $upstream_http_x_auth_request_email;
+        error_page 401 = @dash_anonymous;
+
+        proxy_set_header X-Auth-User  $user;
+        proxy_set_header X-Auth-Email $email;
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location @dash_anonymous {
+        proxy_set_header X-Auth-User  "";
+        proxy_set_header X-Auth-Email "";
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     # ── Arena API (training sessions, called via the DT app function) ──────
@@ -417,6 +490,11 @@ server {
     # JSON result/timeout — never an nginx 504 HTML page.
     location ~ ^/api/arena/ {
         proxy_pass http://127.0.0.1:8080;
+        # No auth_request here (public contract for the app function, load
+        # bots and nightly) — clear X-Auth-User so a client can't spoof the
+        # nginx-verified identity FastAPI uses for unmasked reads.
+        proxy_set_header X-Auth-User  "";
+        proxy_set_header X-Auth-Email "";
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -501,8 +579,13 @@ server {
     }
 
     # ── Public: dashboard UI + read-only API ───────────────────────────────
+    # X-Auth-User/X-Auth-Email are cleared: no auth_request runs on the
+    # catch-all, so client-supplied copies of the identity headers must never
+    # reach FastAPI (any endpoint trusting them would otherwise be spoofable).
     location / {
         proxy_pass http://127.0.0.1:8080;
+        proxy_set_header X-Auth-User  "";
+        proxy_set_header X-Auth-Email "";
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Sergio's requirement: learner emails + tenant identifiers were public on Orbital surfaces.

- masking.py: mask_email/mask_tenant + payload maskers; anonymous callers get masked
  builds/queue/arena-session/live-session/readiness/pad data; joinCode never exposed anonymously
- Service bearer (ORBITAL_TOKEN, hmac-compared) required on live-session writes
  (create/transitions/join-by-code/provision-all/pad-token); orbital-config app-settings
  objects seeded on SRO/COE/sprint so the app's functions authenticate
- Closed pre-existing X-Auth-User spoofing: nginx now clears client-supplied auth headers
  on public locations; opportunistic-auth locations added for live/builds/queue/fleet
- 158 tests passing (one pre-existing unrelated failure)

Already deployed + live-verified (anon create 401, bearer create 200, masked reads).
Merging so the deployed state matches main — prevents a future ops-checkout sync from
reverting live security code.

Remaining exposure documented for follow-up: arena endpoints (incl. anonymous
shell-token by jobId), /audit page, tenant hostnames in job logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)