### PR TITLE
Arena endpoint auth with a compatibility window

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -536,6 +536,40 @@ async def _require_service_or_writer(request: Request) -> None:
     )
 
 
+async def _require_arena_auth(request: Request) -> None:
+    """Auth gate for the arena session endpoints (provision, exec, shell-token,
+    terminate, session lookups) — with a COMPATIBILITY WINDOW.
+
+    Passes for the app's service bearer (orbitalFetch sends it from the
+    tenant's orbital-config secret) or a signed-in org member. While
+    ARENA_AUTH_ENFORCE != "1" (the compat window), anonymous callers are STILL
+    ALLOWED but logged loudly (ARENA-LEGACY-CALLER) so every remaining
+    unauthenticated caller can be inventoried from the journal before
+    enforcement flips. Setting ARENA_AUTH_ENFORCE=1 in /home/ops/.env turns
+    anonymous access into a 401.
+
+    The env var is read per-request on purpose: flipping enforcement must not
+    depend on module import order, and tests can toggle it directly.
+    """
+    if _is_service_caller(request):
+        return
+    if request.headers.get("x-auth-user", ""):
+        await _require_writer(request)
+        return
+    if os.environ.get("ARENA_AUTH_ENFORCE", "") != "1":
+        client_ip = (request.headers.get("x-real-ip", "")
+                     or (request.client.host if request.client else "unknown"))
+        log.warning("ARENA-LEGACY-CALLER: %s %s from %s",
+                    request.method, request.url.path, client_ip)
+        return
+    raise HTTPException(
+        status_code=401,
+        detail={"error": "unauthorized",
+                "reason": "this endpoint requires the Orbital service bearer "
+                          "or a signed-in org member session"},
+    )
+
+
 @app.get("/api/auth/role")
 async def api_auth_role(request: Request):
     """Resolve the caller's role for the dashboard UI.
@@ -3797,7 +3831,7 @@ def _gen3_platform_provisioner(tenant_url: str):
 
 
 @app.post("/api/arena/provision")
-async def api_arena_provision(body: ArenaProvisionRequest):
+async def api_arena_provision(body: ArenaProvisionRequest, request: Request):
     """Provision a training environment — queues a real daemon job on the amd64 worker.
 
     If tenantUrl + auth credentials are provided, auto-creates scoped DT API tokens
@@ -3806,6 +3840,7 @@ async def api_arena_provision(body: ArenaProvisionRequest):
 
     Returns: { jobId, wsUrl, expiresAt, status: "provisioning", tokenProvisioned: bool }
     """
+    await _require_arena_auth(request)
     import uuid as _uuid
     from provisioning import DTTokenProvisioner, load_token_specs
 
@@ -4029,7 +4064,14 @@ async def api_arena_session_status(job_id: str, request: Request):
       failed      → creation failed; the retained log explains why (logAvailable)
       terminated  → explicitly terminated
       expired     → job:running key missing and no terminal record (TTL elapsed)
+
+    Gated by _require_arena_auth: every known caller (the app's orbitalFetch,
+    training_test_runner, bootcamp_loadtest, agentic_validator) can carry the
+    service bearer, and the learner-facing /shell + /terminal pages poll
+    /api/jobs/{id}/livelog — NOT this endpoint — so nothing anonymous needs it.
+    The compat window inventories any caller this audit missed.
     """
+    await _require_arena_auth(request)
     meta = await pool.hgetall(f"job:running:{job_id}")
     if not meta:
         # job:running is gone — distinguish a FAILED creation (so the student can
@@ -4087,6 +4129,7 @@ async def api_arena_user_session(userId: str, trainingId: str, request: Request,
     match. `tenant` is the caller's own environment URL (getEnvironmentUrl()),
     compared against the job's stored tenant URL/id. Returns 404 if none found.
     """
+    await _require_arena_auth(request)
     cursor = 0
     while True:
         cursor, keys = await pool.scan(cursor, match="job:running:enablement-*", count=100)
@@ -4134,7 +4177,11 @@ async def api_arena_active_sessions(userId: str, request: Request, tenant: str =
     provisioned while ANY session is still running here — authoritative even when
     the learner switches browser/device (localStorage can't see those). Mirrors
     user-session but drops the training filter and returns a list.
+
+    Compat window: anonymous callers still get the (PII-masked) list; under
+    ARENA_AUTH_ENFORCE=1 they get 401 instead.
     """
+    await _require_arena_auth(request)
     full = _has_full_access(request)
     sessions = []
     cursor = 0
@@ -4169,12 +4216,21 @@ async def api_arena_active_sessions(userId: str, request: Request, tenant: str =
 
 
 @app.post("/api/arena/sessions/{job_id}/shell-token")
-async def api_arena_shell_token(job_id: str):
+async def api_arena_shell_token(job_id: str, request: Request):
     """Issue a single-use 60-second shell token for an arena session.
 
     Arena orbital proxy function calls this server-side (no browser OAuth needed).
     The returned token is passed to the /terminal/{job_id}?token=... page.
+
+    NOTE (enforcement blocker): the /shell/{job_id} and /terminal/{job_id}
+    pages ALSO call this anonymously from the learner's browser (their inline
+    JS refreshes the 60 s token right before connecting). Browser JS cannot
+    hold the service bearer, so those flows will show up as
+    ARENA-LEGACY-CALLER during the compat window and would break under
+    ARENA_AUTH_ENFORCE=1 — they need a page-scoped token scheme before
+    enforcement flips.
     """
+    await _require_arena_auth(request)
     meta = await pool.hgetall(f"job:running:{job_id}")
     if not meta:
         raise HTTPException(status_code=404, detail="Session not found or expired")
@@ -4606,7 +4662,7 @@ class ArenaExecRequest(BaseModel):
 
 
 @app.post("/api/arena/sessions/{job_id}/exec-start")
-async def api_arena_session_exec_start(job_id: str, body: ArenaExecRequest):
+async def api_arena_session_exec_start(job_id: str, body: ArenaExecRequest, request: Request):
     """Start a command in the background and return an execId immediately.
 
     For long-running commands (solution runs: operator deploy, ActiveGate
@@ -4614,6 +4670,7 @@ async def api_arena_session_exec_start(job_id: str, body: ArenaExecRequest):
     starts the exec here and polls /exec-status/{execId} until done. The
     result is kept in Redis for 1 h.
     """
+    await _require_arena_auth(request)
     import uuid as _uuid
 
     meta = await pool.hgetall(f"job:running:{job_id}")
@@ -4638,8 +4695,9 @@ async def api_arena_session_exec_start(job_id: str, body: ArenaExecRequest):
 
 
 @app.get("/api/arena/sessions/{job_id}/exec-status/{exec_id}")
-async def api_arena_session_exec_status(job_id: str, exec_id: str):
+async def api_arena_session_exec_status(job_id: str, exec_id: str, request: Request):
     """Poll a background exec started via /exec-start. Returns {done, stdout, stderr, exitCode}."""
+    await _require_arena_auth(request)
     raw = await pool.get(f"exec:result:{job_id}:{exec_id}")
     if not raw:
         raise HTTPException(status_code=404, detail="Unknown or expired execId")
@@ -4647,7 +4705,7 @@ async def api_arena_session_exec_status(job_id: str, exec_id: str):
 
 
 @app.post("/api/arena/sessions/{job_id}/exec")
-async def api_arena_session_exec(job_id: str, body: ArenaExecRequest):
+async def api_arena_session_exec(job_id: str, body: ArenaExecRequest, request: Request):
     """Run a command inside the training container.
 
     Uses the same SSH→docker-exec chain as the PTY bridge but without a TTY.
@@ -4658,6 +4716,7 @@ async def api_arena_session_exec(job_id: str, body: ArenaExecRequest):
 
     Returns: { stdout, stderr, exitCode }
     """
+    await _require_arena_auth(request)
     meta = await pool.hgetall(f"job:running:{job_id}")
     if not meta:
         raise HTTPException(status_code=404, detail="Session not found or expired")
@@ -4773,7 +4832,7 @@ async def _arena_exec_run(job_id: str, meta: dict, body: ArenaExecRequest) -> di
 
 
 @app.post("/api/arena/sessions/{job_id}/terminate")
-async def api_arena_terminate(job_id: str):
+async def api_arena_terminate(job_id: str, request: Request):
     """Terminate a training session from the Arena app (no oauth2-proxy auth required).
 
     Publishes on ``ops:terminate`` — the worker kills the Sysbox container and
@@ -4783,6 +4842,7 @@ async def api_arena_terminate(job_id: str):
 
     Returns 404 if the job is not currently running.
     """
+    await _require_arena_auth(request)
     if not await pool.exists(f"job:running:{job_id}"):
         in_completed = await pool.exists(f"job:log:{job_id}")
         detail = (
@@ -5188,6 +5248,8 @@ async def api_live_session_provision_all(session_id: str, body: LiveSessionProvi
             continue
         per = body.perUser.get(email) or body.perUser.get(email.lower()) or {}
         try:
+            # Pass the trainer's (already-authenticated) request through the
+            # arena gate — provision-all itself is service/writer-gated above.
             provisioned = await api_arena_provision(ArenaProvisionRequest(
                 trainingId=session.get("trainingId", ""),
                 userId=email,
@@ -5195,7 +5257,7 @@ async def api_live_session_provision_all(session_id: str, body: LiveSessionProvi
                 ref=session.get("ref", ""),
                 dtEnv=per.get("dtEnv") or {},
                 dtTokenIds=per.get("dtTokenIds") or [],
-            ))
+            ), request)
             results.append({
                 "email":  email,
                 "status": "already-active" if provisioned.get("deduped") else "queued",

--- a/ops-server/dashboard/test_arena_auth.py
+++ b/ops-server/dashboard/test_arena_auth.py
@@ -1,0 +1,165 @@
+"""Arena endpoint auth — compatibility-window contract (_require_arena_auth).
+
+Three behaviours, verified over HTTP with Starlette's TestClient:
+  1. COMPAT (ARENA_AUTH_ENFORCE unset): anonymous callers still pass the gate
+     but an ARENA-LEGACY-CALLER warning is logged so they can be inventoried
+     from the journal before enforcement flips.
+  2. ENFORCE (ARENA_AUTH_ENFORCE=1): anonymous callers get 401 on every gated
+     arena endpoint; the service bearer still passes.
+  3. GET /api/arena/trainings stays public (catalog) in both modes.
+
+Redis is replaced with an empty FakePool so gate-passing is observable as the
+endpoint's own "not found"-style response (404 / expired / empty list) —
+reached only AFTER the auth gate.
+
+Runnable: /home/ops/ops-venv/bin/python -m pytest dashboard/test_arena_auth.py
+"""
+
+import logging
+import os
+
+import dashboard.app as a
+from fastapi.testclient import TestClient
+
+client = TestClient(a.app, raise_server_exceptions=False)
+
+BEARER = {"Authorization": "Bearer test-service-token"}
+
+
+class FakePool:
+    """Just enough async Redis for the arena endpoints, all empty."""
+
+    async def get(self, key):
+        # Non-empty catalog cache so /trainings and /provision never fall
+        # through to the live GitHub scrape.
+        return "[]" if key == a._ARENA_CATALOG_CACHE_KEY else None
+
+    async def hgetall(self, key):
+        return {}
+
+    async def exists(self, key):
+        return 0
+
+    async def scan(self, cursor, match=None, count=None):
+        return 0, []
+
+
+def setup_module(_module):
+    _module._saved_tokens = a.ORBITAL_TOKENS
+    _module._saved_pool = a.pool
+    a.ORBITAL_TOKENS = ("test-service-token",)
+    a.pool = FakePool()
+    os.environ.pop("ARENA_AUTH_ENFORCE", None)
+
+
+def teardown_module(_module):
+    a.ORBITAL_TOKENS = _module._saved_tokens
+    a.pool = _module._saved_pool
+    os.environ.pop("ARENA_AUTH_ENFORCE", None)
+
+
+# (method, path, json-body or None). Bodies are minimally valid so pydantic
+# validation (which runs BEFORE the handler/gate) does not mask the auth check.
+GATED = [
+    ("POST", "/api/arena/provision", {"trainingId": "x", "userId": "u"}),
+    ("GET",  "/api/arena/sessions/job-1", None),
+    ("GET",  "/api/arena/user-session?userId=u&trainingId=x", None),
+    ("GET",  "/api/arena/active-sessions?userId=u", None),
+    ("POST", "/api/arena/sessions/job-1/shell-token", None),
+    ("POST", "/api/arena/sessions/job-1/exec", {"command": "true"}),
+    ("POST", "/api/arena/sessions/job-1/exec-start", {"command": "true"}),
+    ("GET",  "/api/arena/sessions/job-1/exec-status/e1", None),
+    ("POST", "/api/arena/sessions/job-1/terminate", None),
+]
+
+
+def _call(method, path, body, headers=None):
+    if method == "GET":
+        return client.get(path, headers=headers)
+    return client.post(path, json=body, headers=headers)
+
+
+# ── Compat window (default): anonymous allowed + logged loudly ───────────────
+
+def test_compat_anonymous_passes_gate_and_logs_legacy(caplog):
+    for method, path, body in GATED:
+        with caplog.at_level(logging.WARNING, logger="ops-dashboard"):
+            caplog.clear()
+            r = _call(method, path, body)
+            # Gate passed: the endpoint answered from (empty) state, not 401.
+            assert r.status_code in (200, 404, 409), \
+                f"{method} {path} -> {r.status_code} (expected pass-through)"
+            assert any("ARENA-LEGACY-CALLER" in rec.getMessage()
+                       for rec in caplog.records), \
+                f"{method} {path}: no ARENA-LEGACY-CALLER warning logged"
+
+
+def test_compat_bearer_passes_without_legacy_warning(caplog):
+    with caplog.at_level(logging.WARNING, logger="ops-dashboard"):
+        r = client.post("/api/arena/sessions/job-1/shell-token", headers=BEARER)
+    assert r.status_code == 404  # empty FakePool — session unknown, gate passed
+    assert not any("ARENA-LEGACY-CALLER" in rec.getMessage()
+                   for rec in caplog.records)
+
+
+def test_compat_legacy_warning_names_method_path(caplog):
+    with caplog.at_level(logging.WARNING, logger="ops-dashboard"):
+        client.post("/api/arena/sessions/job-9/shell-token")
+    msgs = [rec.getMessage() for rec in caplog.records
+            if "ARENA-LEGACY-CALLER" in rec.getMessage()]
+    assert msgs and "POST" in msgs[0] and "/api/arena/sessions/job-9/shell-token" in msgs[0]
+
+
+# ── Enforcement (ARENA_AUTH_ENFORCE=1): anonymous → 401, bearer passes ───────
+
+def test_enforce_anonymous_401_everywhere():
+    os.environ["ARENA_AUTH_ENFORCE"] = "1"
+    try:
+        for method, path, body in GATED:
+            r = _call(method, path, body)
+            assert r.status_code == 401, \
+                f"{method} {path} -> {r.status_code} (expected 401)"
+    finally:
+        os.environ.pop("ARENA_AUTH_ENFORCE", None)
+
+
+def test_enforce_wrong_bearer_is_401():
+    os.environ["ARENA_AUTH_ENFORCE"] = "1"
+    try:
+        r = client.post("/api/arena/sessions/job-1/shell-token",
+                        headers={"Authorization": "Bearer wrong"})
+        assert r.status_code == 401
+    finally:
+        os.environ.pop("ARENA_AUTH_ENFORCE", None)
+
+
+def test_enforce_service_bearer_still_passes():
+    os.environ["ARENA_AUTH_ENFORCE"] = "1"
+    try:
+        r = client.post("/api/arena/sessions/job-1/shell-token", headers=BEARER)
+        assert r.status_code == 404  # past the gate, unknown session
+    finally:
+        os.environ.pop("ARENA_AUTH_ENFORCE", None)
+
+
+def test_enforce_spoofed_empty_x_auth_user_is_401():
+    # nginx clears X-Auth-User on /api/arena/ — an empty header must not
+    # count as a signed-in member.
+    os.environ["ARENA_AUTH_ENFORCE"] = "1"
+    try:
+        r = client.post("/api/arena/sessions/job-1/shell-token",
+                        headers={"X-Auth-User": ""})
+        assert r.status_code == 401
+    finally:
+        os.environ.pop("ARENA_AUTH_ENFORCE", None)
+
+
+# ── Public catalog stays public ──────────────────────────────────────────────
+
+def test_trainings_catalog_public_in_both_modes():
+    assert client.get("/api/arena/trainings").status_code == 200
+    os.environ["ARENA_AUTH_ENFORCE"] = "1"
+    try:
+        assert client.get("/api/arena/trainings").status_code == 200
+    finally:
+        os.environ.pop("ARENA_AUTH_ENFORCE", None)

--- a/ops-server/tools/agentic_validator.py
+++ b/ops-server/tools/agentic_validator.py
@@ -111,6 +111,27 @@ def load_env_qa() -> dict[str, str]:
 # Orbital API helpers
 # ---------------------------------------------------------------------------
 
+def orbital_bearer() -> str:
+    """Service bearer for Orbital's /api/arena/* endpoints (arena auth).
+
+    ORBITAL_TOKEN from the environment wins; otherwise sudo-read it from
+    /home/ops/.env. Empty result = legacy caller: Orbital logs
+    ARENA-LEGACY-CALLER during the compat window and 401s once
+    ARENA_AUTH_ENFORCE=1.
+    """
+    tok = os.environ.get("ORBITAL_TOKEN", "")
+    if not tok:
+        try:
+            out = subprocess.run(
+                ["sudo", "-n", "grep", "-E", "^ORBITAL_TOKEN=", "/home/ops/.env"],
+                capture_output=True, text=True)
+            if out.returncode == 0 and "=" in out.stdout:
+                tok = out.stdout.strip().split("=", 1)[1]
+        except Exception:
+            tok = ""
+    return tok.split(",")[0].strip()
+
+
 def provision(session: requests.Session, training_id: str, env_qa: dict[str, str]) -> str:
     """Queue a daemon session. Returns job_id."""
     payload = {
@@ -609,6 +630,11 @@ def main():
 
     session = requests.Session()
     session.headers["User-Agent"] = "DT-QA-Validator/1.0"
+    bearer = orbital_bearer()
+    if bearer:
+        # Arena endpoints are auth-gated (compat window): send the Orbital
+        # service bearer so this tool is not an ARENA-LEGACY-CALLER.
+        session.headers["Authorization"] = f"Bearer {bearer}"
 
     training_ids = (
         [args.training_id] if args.training_id

--- a/ops-server/tools/bootcamp_loadtest.py
+++ b/ops-server/tools/bootcamp_loadtest.py
@@ -61,6 +61,33 @@ def http_json(url: str, payload=None, bearer: str | None = None, method=None):
         return resp.status, (json.loads(body) if body.strip() else {})
 
 
+_ORBITAL_BEARER: str | None = None
+
+
+def orbital_bearer() -> str:
+    """Service bearer for Orbital's /api/arena/* endpoints (arena auth).
+
+    ORBITAL_TOKEN from the environment wins; otherwise sudo-read it from
+    /home/ops/.env (same pattern as coe_token below). Cached. Empty result =
+    legacy caller: Orbital logs ARENA-LEGACY-CALLER during the compat window
+    and 401s once ARENA_AUTH_ENFORCE=1.
+    """
+    global _ORBITAL_BEARER
+    if _ORBITAL_BEARER is None:
+        tok = os.environ.get("ORBITAL_TOKEN", "")
+        if not tok:
+            try:
+                out = subprocess.run(
+                    ["sudo", "-n", "grep", "-E", "^ORBITAL_TOKEN=", "/home/ops/.env"],
+                    capture_output=True, text=True)
+                if out.returncode == 0 and "=" in out.stdout:
+                    tok = out.stdout.strip().split("=", 1)[1]
+            except Exception:
+                tok = ""
+        _ORBITAL_BEARER = tok.split(",")[0].strip()
+    return _ORBITAL_BEARER
+
+
 def coe_token() -> str:
     """Ingest token for INGEST_TENANT.
 
@@ -113,7 +140,7 @@ def provision(n: int) -> dict:
                 "userId": email,
                 "tenantId": "geu80787",
                 "tenantUrl": COE_APPS,
-            })
+            }, bearer=orbital_bearer())
             sessions[email] = {"jobId": body["jobId"], "dtSessionId": body.get("dtSessionId", "")}
             print(f"  {email}: {body['jobId']} dtSessionId={body.get('dtSessionId')}")
         except urllib.error.HTTPError as e:
@@ -130,7 +157,8 @@ def wait_ready(state: dict):
     while pending and time.time() < deadline:
         for email, s in list(pending.items()):
             try:
-                _, body = http_json(f"{ORBITAL}/api/arena/sessions/{s['jobId']}")
+                _, body = http_json(f"{ORBITAL}/api/arena/sessions/{s['jobId']}",
+                                    bearer=orbital_bearer())
             except Exception:
                 continue
             st = body.get("status")
@@ -219,7 +247,8 @@ def terminate():
     for email, s in state.get("sessions", {}).items():
         try:
             status, body = http_json(
-                f"{ORBITAL}/api/arena/sessions/{s['jobId']}/terminate", {})
+                f"{ORBITAL}/api/arena/sessions/{s['jobId']}/terminate", {},
+                bearer=orbital_bearer())
             print(f"  {email}: {body.get('status', status)}")
         except urllib.error.HTTPError as e:
             print(f"  {email}: HTTP {e.code}")
@@ -232,7 +261,8 @@ def status():
     state = load_state()
     for email, s in state.get("sessions", {}).items():
         try:
-            _, body = http_json(f"{ORBITAL}/api/arena/sessions/{s['jobId']}")
+            _, body = http_json(f"{ORBITAL}/api/arena/sessions/{s['jobId']}",
+                                bearer=orbital_bearer())
             print(f"  {email}: {body.get('status')} {s['jobId']} {s.get('dtSessionId','')}")
         except Exception as e:
             print(f"  {email}: ? ({e})")

--- a/ops-server/tools/training_test_runner.py
+++ b/ops-server/tools/training_test_runner.py
@@ -47,6 +47,7 @@ Environment (all optional):
 import argparse
 import json
 import os
+import subprocess
 import sys
 import time
 import urllib.error
@@ -73,12 +74,38 @@ def log(msg=""):
     print(msg, flush=True)
 
 
+def orbital_bearer() -> str:
+    """Service bearer for Orbital's /api/arena/* endpoints (arena auth).
+
+    ORBITAL_TOKEN is in the environment when run under an ops service
+    (systemd EnvironmentFile=/home/ops/.env — the training-test worker path);
+    manual runs fall back to sudo-reading /home/ops/.env (same pattern as
+    bootcamp_loadtest). Empty result = legacy caller: Orbital logs
+    ARENA-LEGACY-CALLER during the compat window and 401s once
+    ARENA_AUTH_ENFORCE=1.
+    """
+    tok = os.environ.get("ORBITAL_TOKEN", "")
+    if not tok:
+        try:
+            out = subprocess.run(
+                ["sudo", "-n", "grep", "-E", "^ORBITAL_TOKEN=", "/home/ops/.env"],
+                capture_output=True, text=True)
+            if out.returncode == 0 and "=" in out.stdout:
+                tok = out.stdout.strip().split("=", 1)[1]
+        except Exception:
+            tok = ""
+    return tok.split(",")[0].strip()  # comma-separated for rotation; send the first
+
+
 class Orbital:
     def __init__(self, base):
         self.base = base.rstrip("/")
+        self.bearer = orbital_bearer()
 
     def _req(self, method, path, body=None, timeout=30):
         req = urllib.request.Request(self.base + path, method=method)
+        if self.bearer:
+            req.add_header("Authorization", f"Bearer {self.bearer}")
         if body is not None:
             req.add_header("Content-Type", "application/json")
             req.data = json.dumps(body).encode()


### PR DESCRIPTION
## Why

The arena endpoints were fully public. Worst exposure: read any jobId from the public dashboard, `POST /api/arena/sessions/{id}/shell-token`, and get a **terminal into a learner's environment**.

## What

New `_require_arena_auth(request)` in `dashboard/app.py` — passes for the Orbital service bearer (`ORBITAL_TOKEN`) or a signed-in org member. **Compat window:** while `ARENA_AUTH_ENFORCE != "1"`, anonymous callers are still allowed but logged loudly:

```
[WARNING] ARENA-LEGACY-CALLER: POST /api/arena/sessions/<id>/shell-token from <ip>
```

so remaining unauthenticated callers can be inventoried from `journalctl -u ops-dashboard`. Setting `ARENA_AUTH_ENFORCE=1` in `/home/ops/.env` flips anonymous access to 401. Enforcement is NOT enabled by this PR.

### Gated
`POST /provision`, `GET /sessions/{id}` (status), `GET /user-session`, `GET /active-sessions` (keeps PII masking for anonymous during the window), `POST /shell-token`, `POST /exec`, `POST /exec-start`, `GET /exec-status/{id}`, `POST /terminate`.

### Deliberately not gated
- `GET /api/arena/trainings` — public catalog.
- `/shell/{id}` page + `/ws/...` — the single-use shell token is the auth there; gating token **issuance** is what matters.

### Session-status decision
`GET /api/arena/sessions/{id}` **is gated**: the app polls it through the authed `orbital` app function, the test/load tools now send the bearer, and the `/shell` + `/terminal` browser pages poll `/api/jobs/{id}/livelog` instead — no anonymous caller needs it. The compat window will surface anything this audit missed before enforcement flips.

### Enforcement blocker (known, documented — NOT fixed here)
The `/shell/{job_id}` and `/terminal/{job_id}` pages refresh the 60 s shell token from **anonymous browser JS** (`fetch(.../shell-token)` inline). Browser JS cannot hold the service bearer — these flows log as ARENA-LEGACY-CALLER and would break under enforcement. They need a page-scoped token scheme before the window closes.

## Caller updates (bearer sent now)
- `tools/training_test_runner.py` — `ORBITAL_TOKEN` from env (ops-worker has `EnvironmentFile=/home/ops/.env`) with sudo-grep fallback for manual runs.
- `tools/bootcamp_loadtest.py`, `tools/agentic_validator.py` — same pattern.
- `dashboard/app.py` live-session `provision-all` — passes its already-authed request through the arena gate.
- DT app: already sends the bearer via `orbitalFetch` (provision/status/user-session/active-sessions/exec/exec-start/exec-status/shell-token/terminate all route through it) — no app change. Note: `orbitalFetch` only adds the header when the tenant's orbital-config token is set.
- No arena callers in `stress_test.py` / `capacity_stress_test.py` / `app_layer_driver.py` / `nightly/scheduler.py` / devcontainer scripts (audited).

## nginx
No change needed: the `^/api/arena/` location never touches `Authorization` (passes through) and already clears `X-Auth-User`/`X-Auth-Email` on all arena paths.

## Tests
`dashboard/test_arena_auth.py` (FakePool, no Redis): compat allows + warns with method/path, bearer passes with no warning, enforce 401s all 9 endpoints (incl. wrong bearer + spoofed empty X-Auth-User), catalog public in both modes. Full suite: **166 passed**, 1 pre-existing known failure (`test_app_deploy.py::test_register_buttons_have_no_guest_gate`).

## Live verification (deployed to prod, window open)
- Anonymous `POST .../shell-token` → 404 (not 401) + journal `ARENA-LEGACY-CALLER` line; bearer → 404 with no warning; `/api/arena/trainings` and dashboard `/` → 200.
- Within 2 minutes the journal already caught a real legacy caller polling a live session status anonymously — exactly the inventory the window is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)