### PR TITLE
feat(orbital): tenant-attribution registry (EPIC-002 §9)

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -570,6 +570,55 @@ async def _require_arena_auth(request: Request) -> None:
     )
 
 
+# ── Tenant-attribution registry (EPIC-002 §9) ────────────────────────────────
+# Durable WHO-deployed-WHERE record (dashboard/tenant_registry.py): written at
+# every deploy call site in app_deploy.py; the app's runtime backstop merges
+# the admin's identity in on first admin visit. Distinct from tenant_map.json
+# (content delivery). Both endpoints are auth-gated → entries returned unmasked.
+
+from dashboard import tenant_registry  # noqa: E402
+
+
+@app.post("/api/tenants/register-identity")
+async def tenants_register_identity(request: Request):
+    """Runtime backstop: the Dynatrace app calls this (service bearer from the
+    tenant's orbital-config secret) on first admin visit, reporting the admin's
+    email/name + accountUrn so installs that arrived without attribution (token
+    / auto paths) get an owner. Fills deployerEmail only if the deploy-time
+    record left it empty; always refreshes lastSeen + identity fields."""
+    if not _is_service_caller(request):
+        raise HTTPException(
+            status_code=401,
+            detail={"error": "unauthorized",
+                    "reason": "this endpoint requires the Orbital service bearer"})
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    tenant = (body.get("tenant") or "").strip()
+    email = (body.get("email") or "").strip()
+    name = (body.get("name") or "").strip()
+    account_urn = (body.get("accountUrn") or "").strip()
+    if not tenant:
+        raise HTTPException(400, "tenant is required.")
+    if not (email or name or account_urn):
+        raise HTTPException(400, "at least one of email, name, accountUrn is required.")
+    tenant_id, _ = classify_tenant(tenant)  # 403 if not a Dynatrace domain
+    entry = await tenant_registry.record_identity(
+        pool, tenant_id, email=email, name=name, account_urn=account_urn)
+    return {"ok": True, "tenant": tenant_id, "entry": entry}
+
+
+@app.get("/api/tenants/registry")
+async def tenants_registry(request: Request):
+    """CoE tenant list: every registered install with its attribution
+    (accountUrn, clientId, deployerEmail, via, firstSeen, lastDeploy,
+    appVersion + runtime identity). Writer or service bearer only — full
+    (unmasked) payload by design."""
+    await _require_service_or_writer(request)
+    return {"tenants": await tenant_registry.list_entries(pool)}
+
+
 @app.get("/api/auth/role")
 async def api_auth_role(request: Request):
     """Resolve the caller's role for the dashboard UI.

--- a/ops-server/dashboard/app_deploy.py
+++ b/ops-server/dashboard/app_deploy.py
@@ -38,6 +38,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from webhook.config import REDIS_URL
 from dashboard.content_service import classify_tenant, register_tenant
 from dashboard.github_oauth import _decrypt, _encrypt  # Fernet (GH_OAUTH_ENC_KEY) — COE token + stashed deploy token
+from dashboard import tenant_registry  # durable WHO-deployed-WHERE attribution (EPIC-002 §9)
 
 log = logging.getLogger("ops-dashboard.deploy")
 
@@ -581,10 +582,13 @@ async def deploy_start(tenant: str, action: str = "deploy", x_auth_user: str | N
     return await _begin_sso_flow(tenant, action, user)
 
 
-async def _finish_deploy(user: str, tenant_id: str, tenant_url: str, action: str, token: str) -> HTMLResponse:
+async def _finish_deploy(user: str, tenant_id: str, tenant_url: str, action: str, token: str,
+                         via: str = "sso-deploy", deployer: str = "") -> HTMLResponse:
     """Run the install/upgrade (or uninstall) with a valid bearer and return the result page.
     Shared by the SSO callback and the in-app COE/SRO auto-deploy path. The caller owns the
-    token's lifetime and must `del` it after this returns (it is never logged here)."""
+    token's lifetime and must `del` it after this returns (it is never logged here).
+    `via`/`deployer` feed the tenant-attribution registry (deployer = GitHub username on the
+    SSO path; empty on app-triggered paths — the runtime backstop fills identity later)."""
     app_url = _app_url(tenant_url)
     if action == "undeploy":
         ok, msg = await _run_undeploy(token, tenant_url)
@@ -608,6 +612,8 @@ async def _finish_deploy(user: str, tenant_id: str, tenant_url: str, action: str
 
     reg = await _register_in_content_service(user, tenant_url)
     profile = (reg or {}).get("profile")
+    await tenant_registry.record_deploy(_pool(), tenant_id, via, deployer=deployer,
+                                        app_version=res.get("to") or "")
     await _audit(user, tenant_id, "deploy", res["status"],
                  **{k: res[k] for k in ("from", "to") if res.get(k)}, url=app_url, profile=profile,
                  remote_grail=remote_grail)
@@ -667,7 +673,7 @@ async def deploy_app_start(tenant: str, action: str = "deploy", nonce: str = "")
         if not token:
             return HTMLResponse(_page(f"{auto} auto-deploy not configured.", ok=False), status_code=503)
         try:
-            return await _finish_deploy(f"app:{tenant_id}", tenant_id, tenant, action, token)
+            return await _finish_deploy(f"app:{tenant_id}", tenant_id, tenant, action, token, via="auto")
         finally:
             del token
 
@@ -685,7 +691,7 @@ async def deploy_app_start(tenant: str, action: str = "deploy", nonce: str = "")
             return HTMLResponse(_page("Tenant mismatch for this update session.", ok=False), status_code=400)
         token = stashed.get("token", "")
         try:
-            return await _finish_deploy(f"app:{tenant_id}", tenant_id, tenant, action, token)
+            return await _finish_deploy(f"app:{tenant_id}", tenant_id, tenant, action, token, via="token")
         finally:
             del token
 
@@ -759,7 +765,8 @@ async def deploy_callback(request: Request):
 
     tenant_url = flow["tenant"]
     try:
-        return await _finish_deploy(user, tenant_id, tenant_url, action, token)
+        return await _finish_deploy(user, tenant_id, tenant_url, action, token,
+                                    via="sso-deploy", deployer=user)
     finally:
         del token  # discard the delegated credential on every path
 
@@ -832,6 +839,9 @@ async def deploy_with_token(body: dict, x_auth_user: str | None = Header(default
     profile = (reg or {}).get("profile")
     url = _app_url(tenant)
     warnings = _scope_warnings(allowlist, remote_grail)
+    await tenant_registry.record_deploy(
+        _pool(), tenant_id, "auto" if auto else "token",
+        deployer=x_auth_user or "", app_version=res.get("to") or "")
     await _audit(user, tenant_id, "deploy", res["status"], via=via,
                  **{k: res[k] for k in ("from", "to") if res.get(k)}, url=url, profile=profile,
                  allowlist=allowlist, remote_grail=remote_grail, warnings=warnings)
@@ -911,6 +921,9 @@ async def deploy_with_oauth(body: dict, x_auth_user: str | None = Header(default
     cid = (body.get("clientId") or "").strip()
     csec = (body.get("clientSecret") or "").strip()
     account_urn = (body.get("accountUrn") or "").strip()
+    # Optional attribution: the Register Tenant form asks the admin for their email so the
+    # tenant-attribution registry can answer "who owns this install" later. Never required.
+    deployer_email = (body.get("deployerEmail") or "").strip()
     tenant_id, domain = classify_tenant(tenant)  # 403 if not a Dynatrace domain
     if not (cid and csec):
         raise HTTPException(400, "clientId and clientSecret are required.")
@@ -976,6 +989,11 @@ async def deploy_with_oauth(body: dict, x_auth_user: str | None = Header(default
     profile = (reg or {}).get("profile")
     url = _app_url(tenant)
     warnings = _scope_warnings(allowlist, remote_grail) + scope_warnings
+    # The bootstrap path is the ONE moment Orbital ever sees the account URN + client id —
+    # record them (attribution only, never the secret) before they are discarded.
+    await tenant_registry.record_deploy(
+        _pool(), tenant_id, "oauth-bootstrap", account_urn=account_urn, client_id=cid,
+        deployer=deployer_email or (x_auth_user or ""), app_version=res.get("to") or "")
     await _audit(user, tenant_id, "deploy", res["status"], via="oauth-bootstrap", client_id=cid,
                  **{k: res[k] for k in ("from", "to") if res.get(k)}, url=url, profile=profile,
                  allowlist=allowlist, remote_grail=remote_grail, mint_ready=mint_ready, warnings=warnings)

--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -3337,13 +3337,14 @@ async function goRegisterOauth(action) {
     const cid = document.getElementById('reg-oa-cid').value.trim();
     const sec = document.getElementById('reg-oa-secret').value.trim();
     const urn = document.getElementById('reg-oa-urn').value.trim();
+    const email = (document.getElementById('reg-oa-email') || { value: '' }).value.trim();
     const m = document.getElementById('reg-oa-msg');
     if (!t) { m.textContent = 'tenant required'; return; }
     if (!cid || !sec) { m.textContent = 'client id + secret required'; return; }
     if (!urn.startsWith('urn:dtaccount:')) { m.textContent = 'account URN required (urn:dtaccount:<uuid>)'; return; }
     m.textContent = ''; setRegBusy(true);
     try {
-        const r = await fetch('/api/deploy/oauth', { method: 'POST', headers: { 'Content-Type': 'application/json' }, credentials: 'same-origin', body: JSON.stringify({ action, tenant: t, clientId: cid, clientSecret: sec, accountUrn: urn }) });
+        const r = await fetch('/api/deploy/oauth', { method: 'POST', headers: { 'Content-Type': 'application/json' }, credentials: 'same-origin', body: JSON.stringify({ action, tenant: t, clientId: cid, clientSecret: sec, accountUrn: urn, deployerEmail: email }) });
         const raw = await r.text();
         let j = {}; try { j = JSON.parse(raw); } catch (_) { /* non-JSON gateway page */ }
         if (r.ok) {
@@ -3388,10 +3389,27 @@ async function loadRegisterAudit() {
     } catch (e) { /* ignore */ }
 }
 
+// Tenant-attribution registry (EPIC-002 §9) — who deployed where. Writer-gated:
+// anonymous callers get a 401 and see the sign-in hint instead of rows.
+async function loadTenantRegistry() {
+    const b = document.querySelector('#reg-tenants tbody');
+    if (!b) return;
+    try {
+        const r = await fetch('/api/tenants/registry', { credentials: 'same-origin' });
+        if (!r.ok) { b.innerHTML = '<tr><td colspan="8" class="content-hint">Sign in as an org member to view the tenant registry.</td></tr>'; return; }
+        const rows = (await r.json()).tenants || [];
+        const d = s => escapeHtml((s || '').replace('T', ' ').slice(0, 19));
+        b.innerHTML = rows.length
+            ? rows.map(t => `<tr><td><code>${escapeHtml(t.tenant || '')}</code></td><td>${escapeHtml(t.deployerEmail || '')}</td><td>${escapeHtml(t.identityName ? `${t.identityName} <${t.identityEmail || ''}>` : (t.identityEmail || ''))}</td><td><code>${escapeHtml(t.accountUrn || '')}</code></td><td>${escapeHtml(t.via || '')}</td><td>${escapeHtml(t.appVersion || '')}</td><td>${d(t.firstSeen)}</td><td>${d(t.lastDeploy)}</td></tr>`).join('')
+            : '<tr><td colspan="8" class="content-hint">none yet</td></tr>';
+    } catch (e) { /* ignore */ }
+}
+
 function loadRegister() {
     wireRegister();
     loadRegisterAudit();
     loadMintClients();
+    loadTenantRegistry();
 }
 
 async function loadMintClients() {

--- a/ops-server/dashboard/templates/index.html
+++ b/ops-server/dashboard/templates/index.html
@@ -794,6 +794,7 @@
                     <input type="text" id="reg-oa-cid" placeholder="client id (dt0s02.…)" style="width:180px">
                     <input type="password" id="reg-oa-secret" placeholder="client secret" style="width:220px">
                     <input type="text" id="reg-oa-urn" placeholder="urn:dtaccount:<uuid>" style="width:280px">
+                    <input type="email" id="reg-oa-email" placeholder="your email (optional — install attribution)" style="width:260px" title="Recorded in the tenant registry so the CoE knows who owns this install. Optional.">
                 </div>
                 <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
                     <!-- No data-action: the OAuth client is the account's authority — stays
@@ -812,6 +813,11 @@
             <h3 style="margin:24px 0 8px">Recent deploy activity</h3>
             <table id="reg-audit">
                 <thead><tr><th>When</th><th>User</th><th>Tenant</th><th>Stage</th><th>Action</th><th>Result</th><th>Version</th><th>Via</th></tr></thead>
+                <tbody><tr><td colspan="8" class="loading">Loading…</td></tr></tbody>
+            </table>
+            <h3 style="margin:24px 0 8px">Tenants <span class="content-hint" style="font-weight:normal">(attribution registry — who deployed where; org members only)</span></h3>
+            <table id="reg-tenants">
+                <thead><tr><th>Tenant</th><th>Deployer</th><th>Identity</th><th>Account URN</th><th>Via</th><th>Version</th><th>First seen</th><th>Last deploy</th></tr></thead>
                 <tbody><tr><td colspan="8" class="loading">Loading…</td></tr></tbody>
             </table>
             <div id="reg-mint-clients"></div>

--- a/ops-server/dashboard/tenant_registry.py
+++ b/ops-server/dashboard/tenant_registry.py
@@ -1,0 +1,137 @@
+"""Durable tenant-attribution registry (EPIC-002 §9, workstream D).
+
+Records WHO deployed the Enablement App to WHICH tenant — the attribution
+Dynatrace APIs cannot answer after the fact (OAuth-client owner email, account
+name, envId→account mapping and token lookup-by-secret are all NOT retrievable;
+see ops-server/docs/EPIC-002-ws-d-tenant-identity.md). So we capture identity
+at the only moments we ever hold it:
+
+  1. deploy time — every deploy call site in dashboard/app_deploy.py writes
+     here best-effort (via = sso-deploy | auto | token | oauth-bootstrap);
+     the OAuth-bootstrap path also records the accountUrn + clientId it was
+     handed, and an optional deployer email from the Register Tenant form;
+  2. runtime backstop — the app POSTs /api/tenants/register-identity on first
+     admin visit (service bearer), merging the admin's email/name in.
+
+Redis layout (Orbital Redis, same instance as jobs):
+  tenant:registry:{tenant_id}  hash — accountUrn, clientId, deployerEmail, via,
+                               firstSeen, lastDeploy, appVersion, identityEmail,
+                               identityName, lastSeen
+  tenant:registry:index        set of registered tenant_ids
+
+The shaping/merge logic is pure (no Redis) and unit-tested in
+test_tenant_registry.py; the async helpers below are thin wrappers.
+tenant_map.json (content delivery) is intentionally untouched — different
+concern, different lifecycle.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+log = logging.getLogger("ops-dashboard.tenant-registry")
+
+INDEX_KEY = "tenant:registry:index"
+
+# Deploy attribution channels (see app_deploy.py call sites).
+DEPLOY_VIAS = ("sso-deploy", "auto", "token", "oauth-bootstrap")
+
+
+def registry_key(tenant_id: str) -> str:
+    return f"tenant:registry:{tenant_id}"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ── Pure shaping / merge logic ───────────────────────────────────────────────
+
+def shape_deploy(via: str, *, account_urn: str = "", client_id: str = "",
+                 deployer: str = "", app_version: str = "",
+                 now: str | None = None) -> dict:
+    """Fields a deploy call site contributes. Empty values are DROPPED so a
+    later, less-informed deploy (e.g. token after oauth-bootstrap) never
+    blanks attribution captured earlier."""
+    fields = {"via": via, "lastDeploy": now or _now_iso()}
+    if account_urn:
+        fields["accountUrn"] = account_urn
+    if client_id:
+        fields["clientId"] = client_id
+    if deployer:
+        fields["deployerEmail"] = deployer
+    if app_version:
+        fields["appVersion"] = app_version
+    return fields
+
+
+def merge_fields(existing: dict, fields: dict) -> dict:
+    """The hash fields to actually write: the incoming fields (already
+    empty-stripped by shape_*) plus a firstSeen stamped exactly once."""
+    out = dict(fields)
+    if not (existing or {}).get("firstSeen"):
+        out["firstSeen"] = (fields.get("lastDeploy") or fields.get("lastSeen")
+                            or _now_iso())
+    return out
+
+
+def merge_identity(existing: dict, *, email: str = "", name: str = "",
+                   account_urn: str = "", now: str | None = None) -> dict:
+    """Runtime-backstop merge (POST /api/tenants/register-identity): always
+    refresh lastSeen + the identity fields; FILL deployerEmail only when the
+    deploy-time record left it empty (deploy-time attribution wins)."""
+    now = now or _now_iso()
+    out: dict = {"lastSeen": now}
+    if email:
+        out["identityEmail"] = email
+        if not (existing or {}).get("deployerEmail"):
+            out["deployerEmail"] = email
+    if name:
+        out["identityName"] = name
+    if account_urn:
+        out["accountUrn"] = account_urn
+    return merge_fields(existing or {}, out)
+
+
+# ── Async Redis helpers ──────────────────────────────────────────────────────
+
+async def record_deploy(pool, tenant_id: str, via: str, *,
+                        account_urn: str = "", client_id: str = "",
+                        deployer: str = "", app_version: str = "") -> None:
+    """Best-effort registry write at a deploy call site — a registry failure
+    must NEVER break a deploy, so every error is swallowed (logged)."""
+    try:
+        key = registry_key(tenant_id)
+        existing = await pool.hgetall(key)
+        fields = merge_fields(existing or {}, shape_deploy(
+            via, account_urn=account_urn, client_id=client_id,
+            deployer=deployer, app_version=app_version))
+        await pool.hset(key, mapping=fields)
+        await pool.sadd(INDEX_KEY, tenant_id)
+    except Exception as exc:
+        log.warning("tenant-registry write failed for %s (via=%s): %s",
+                    tenant_id, via, exc)
+
+
+async def record_identity(pool, tenant_id: str, *, email: str = "",
+                          name: str = "", account_urn: str = "") -> dict:
+    """Merge the app-reported admin identity into the registry and return the
+    resulting entry. Raises on Redis errors (the endpoint reports them)."""
+    key = registry_key(tenant_id)
+    existing = await pool.hgetall(key) or {}
+    fields = merge_identity(existing, email=email, name=name,
+                            account_urn=account_urn)
+    await pool.hset(key, mapping=fields)
+    await pool.sadd(INDEX_KEY, tenant_id)
+    return {**existing, **fields, "tenant": tenant_id}
+
+
+async def list_entries(pool) -> list[dict]:
+    """All registry entries, sorted by tenant id. Auth-gated by the caller —
+    values are returned unmasked."""
+    ids = sorted(await pool.smembers(INDEX_KEY) or [])
+    out: list[dict] = []
+    for tid in ids:
+        h = await pool.hgetall(registry_key(tid))
+        if h:
+            out.append({"tenant": tid, **h})
+    return out

--- a/ops-server/dashboard/test_tenant_registry.py
+++ b/ops-server/dashboard/test_tenant_registry.py
@@ -1,0 +1,193 @@
+"""Tenant-attribution registry (EPIC-002 §9) — dashboard/tenant_registry.py.
+
+Two halves, same approach as test_masking.py / test_live_auth.py:
+  - pure shaping/merge logic (no Redis, no FastAPI);
+  - endpoint auth gating over HTTP with Starlette's TestClient (anonymous 401,
+    wrong bearer 401, service bearer passes — asserted via pre-Redis validation
+    responses so no Redis is needed).
+
+Runnable two ways:
+  - pytest:     python3 -m pytest dashboard/test_tenant_registry.py
+  - standalone (logic tests only): python3 -m dashboard.test_tenant_registry
+"""
+
+from dashboard import tenant_registry as tr
+
+
+# ── shape_deploy ─────────────────────────────────────────────────────────────
+
+def test_shape_deploy_drops_empty_fields():
+    f = tr.shape_deploy("token", now="2026-08-03T10:00:00+00:00")
+    assert f == {"via": "token", "lastDeploy": "2026-08-03T10:00:00+00:00"}
+
+
+def test_shape_deploy_keeps_provided_attribution():
+    f = tr.shape_deploy("oauth-bootstrap", account_urn="urn:dtaccount:abc",
+                        client_id="dt0s02.XYZ", deployer="admin@acme.com",
+                        app_version="1.0.255", now="2026-08-03T10:00:00+00:00")
+    assert f["accountUrn"] == "urn:dtaccount:abc"
+    assert f["clientId"] == "dt0s02.XYZ"
+    assert f["deployerEmail"] == "admin@acme.com"
+    assert f["appVersion"] == "1.0.255"
+    assert f["via"] == "oauth-bootstrap"
+
+
+def test_deploy_vias_match_locked_design():
+    assert set(tr.DEPLOY_VIAS) == {"sso-deploy", "auto", "token", "oauth-bootstrap"}
+
+
+# ── merge_fields (firstSeen semantics) ───────────────────────────────────────
+
+def test_merge_fields_stamps_first_seen_once():
+    first = tr.merge_fields({}, tr.shape_deploy("token", now="2026-08-01T00:00:00+00:00"))
+    assert first["firstSeen"] == "2026-08-01T00:00:00+00:00"
+    # second deploy: existing entry already has firstSeen → NOT restamped
+    second = tr.merge_fields(first, tr.shape_deploy("auto", now="2026-08-02T00:00:00+00:00"))
+    assert "firstSeen" not in second
+    assert second["lastDeploy"] == "2026-08-02T00:00:00+00:00"
+
+
+def test_merge_fields_never_blanks_earlier_attribution():
+    # A later token deploy carries no accountUrn/clientId — shape_deploy drops
+    # the empties, so an HSET of the merged fields leaves the bootstrap values.
+    later = tr.merge_fields({"firstSeen": "x", "accountUrn": "urn:dtaccount:abc"},
+                            tr.shape_deploy("token", now="t2"))
+    assert "accountUrn" not in later  # untouched in the hash
+
+
+# ── merge_identity (runtime backstop) ────────────────────────────────────────
+
+def test_merge_identity_fills_deployer_email_only_when_empty():
+    out = tr.merge_identity({}, email="admin@acme.com", now="t1")
+    assert out["deployerEmail"] == "admin@acme.com"
+    assert out["identityEmail"] == "admin@acme.com"
+    assert out["lastSeen"] == "t1"
+    # deploy-time attribution wins: existing deployerEmail is never replaced
+    out2 = tr.merge_identity({"deployerEmail": "original@acme.com", "firstSeen": "t0"},
+                             email="other@acme.com", now="t2")
+    assert "deployerEmail" not in out2
+    assert out2["identityEmail"] == "other@acme.com"
+
+
+def test_merge_identity_always_updates_identity_fields_and_urn():
+    out = tr.merge_identity(
+        {"firstSeen": "t0", "identityName": "Old", "accountUrn": "urn:dtaccount:old"},
+        email="a@b.com", name="New Name", account_urn="urn:dtaccount:new", now="t3")
+    assert out["identityName"] == "New Name"
+    assert out["accountUrn"] == "urn:dtaccount:new"
+    assert out["lastSeen"] == "t3"
+
+
+def test_merge_identity_stamps_first_seen_for_unseen_tenant():
+    out = tr.merge_identity({}, email="a@b.com", now="t1")
+    assert out["firstSeen"] == "t1"
+
+
+def test_registry_key_shape():
+    assert tr.registry_key("abc12345") == "tenant:registry:abc12345"
+    assert tr.INDEX_KEY == "tenant:registry:index"
+
+
+# ── Endpoint auth gating (TestClient; pre-Redis assertions) ──────────────────
+
+def _client():
+    import dashboard.app as a
+    from fastapi.testclient import TestClient
+    return a, TestClient(a.app, raise_server_exceptions=False)
+
+
+BEARER = {"Authorization": "Bearer test-service-token"}
+
+
+def setup_module(_module):
+    """Accept a known bearer regardless of the (test-runner) environment —
+    same pattern as test_live_auth.py."""
+    import dashboard.app as a
+    _module._saved_tokens = a.ORBITAL_TOKENS
+    a.ORBITAL_TOKENS = ("test-service-token",)
+
+
+def teardown_module(_module):
+    import dashboard.app as a
+    a.ORBITAL_TOKENS = _module._saved_tokens
+
+
+def test_register_identity_anonymous_401():
+    _, client = _client()
+    r = client.post("/api/tenants/register-identity",
+                    json={"tenant": "https://abc12345.apps.dynatrace.com",
+                          "email": "a@b.com"})
+    assert r.status_code == 401
+
+
+def test_register_identity_wrong_bearer_401():
+    _, client = _client()
+    r = client.post("/api/tenants/register-identity", json={},
+                    headers={"Authorization": "Bearer wrong"})
+    assert r.status_code == 401
+
+
+def test_register_identity_spoofed_x_auth_user_still_401():
+    # X-Auth-User never grants this endpoint (service bearer only) — and nginx
+    # clears the header on anonymous paths anyway.
+    _, client = _client()
+    r = client.post("/api/tenants/register-identity",
+                    json={"tenant": "https://abc12345.apps.dynatrace.com", "email": "a@b.com"},
+                    headers={"X-Auth-User": "someone"})
+    assert r.status_code == 401
+
+
+def test_register_identity_bearer_passes_gate_missing_tenant_400():
+    # Validation runs only AFTER auth and BEFORE any Redis access.
+    _, client = _client()
+    r = client.post("/api/tenants/register-identity", json={}, headers=BEARER)
+    assert r.status_code == 400
+
+
+def test_register_identity_bearer_missing_identity_fields_400():
+    _, client = _client()
+    r = client.post("/api/tenants/register-identity",
+                    json={"tenant": "https://abc12345.apps.dynatrace.com"}, headers=BEARER)
+    assert r.status_code == 400
+
+
+def test_register_identity_bearer_non_dynatrace_domain_403():
+    _, client = _client()
+    r = client.post("/api/tenants/register-identity",
+                    json={"tenant": "https://evil.example.com", "email": "a@b.com"},
+                    headers=BEARER)
+    assert r.status_code == 403
+
+
+def test_registry_get_anonymous_401():
+    _, client = _client()
+    r = client.get("/api/tenants/registry")
+    assert r.status_code == 401
+
+
+def test_registry_get_wrong_bearer_401():
+    _, client = _client()
+    r = client.get("/api/tenants/registry", headers={"Authorization": "Bearer nope"})
+    assert r.status_code == 401
+
+
+def test_registry_get_service_bearer_full_payload(monkeypatch):
+    a, client = _client()
+    async def fake_list(pool):
+        return [{"tenant": "abc12345", "deployerEmail": "admin@acme.com",
+                 "via": "oauth-bootstrap"}]
+    monkeypatch.setattr(a.tenant_registry, "list_entries", fake_list)
+    r = client.get("/api/tenants/registry", headers=BEARER)
+    assert r.status_code == 200
+    tenants = r.json()["tenants"]
+    # auth-gated endpoint → full, unmasked values
+    assert tenants[0]["deployerEmail"] == "admin@acme.com"
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if (name.startswith("test_") and callable(fn)
+                and fn.__code__.co_argcount == 0 and "_client" not in fn.__code__.co_names):
+            fn()
+            print(f"ok {name}")
+    print("logic tests passed (run under pytest for the endpoint auth tests)")

--- a/ops-server/docs/EPIC-002-ws-d-tenant-identity.md
+++ b/ops-server/docs/EPIC-002-ws-d-tenant-identity.md
@@ -1,0 +1,41 @@
+# EPIC-002 §9 — Workstream D: Tenant identity & attribution
+
+**Question:** given a tenant the app is installed on (envId, or the OAuth client /
+platform token it presented), can Orbital find out *who* owns it — an email, an
+account name?
+
+**Answer: no — not via any Dynatrace API.** Attribution must be captured at
+deploy time and backstopped at runtime. That is what the tenant-attribution
+registry implements (`dashboard/tenant_registry.py`).
+
+## What is NOT retrievable via API (verified)
+
+| Wanted | Why it's not available |
+|---|---|
+| Email of an OAuth client's owner | The Account Management API returns OAuth client metadata (id, scopes, description) but **no owner user/email**. Clients belong to the *account*, not a person. See [OAuth clients](https://docs.dynatrace.com/docs/manage/identity-access-management/access-tokens-and-oauth-clients/oauth-clients) and the [Account Management API](https://docs.dynatrace.com/docs/dynatrace-api/account-management-api). |
+| Account *name* for an account URN | `urn:dtaccount:<uuid>` is all a client credential exposes; resolving it to a human-readable account name needs Account-Management read scopes **on that account** — which Orbital doesn't and shouldn't hold for foreign accounts. |
+| envId → account mapping | There is no public cross-account directory. The [environment-management endpoints](https://docs.dynatrace.com/docs/dynatrace-api/account-management-api) only enumerate environments *within an account you can already access*. |
+| Platform-token lookup-by-secret | The [Platform tokens API](https://docs.dynatrace.com/docs/manage/identity-access-management/access-tokens-and-oauth-clients/platform-tokens) has no "who does this token belong to" lookup; token metadata (owner) is only listable *from inside the owning tenant* with `platform-token:tokens:read`. |
+
+## Solution (shipped in this workstream)
+
+1. **Deploy-time registry** — every deploy call site in
+   `dashboard/app_deploy.py` writes a Redis hash `tenant:registry:{tenant_id}`
+   (+ index set `tenant:registry:index`) with `{accountUrn, clientId,
+   deployerEmail, via, firstSeen, lastDeploy, appVersion}`.
+   `via ∈ {sso-deploy, auto, token, oauth-bootstrap}`. The OAuth-bootstrap path
+   already holds the accountUrn + clientId (previously discarded after the
+   deploy) — now recorded (never the secret). The SSO path records the GitHub
+   username as deployer. The Register Tenant form gained an optional
+   "your email" field feeding `deployerEmail`.
+2. **Runtime backstop** — `POST /api/tenants/register-identity`
+   `{tenant, email, name, accountUrn}` (Orbital service bearer required): the
+   app reports its admin's identity on first admin visit; fills
+   `deployerEmail` if the deploy-time record left it empty, always refreshes
+   `lastSeen` + identity fields.
+3. **CoE list** — `GET /api/tenants/registry` (writer or service bearer):
+   full, unmasked entries; surfaced as a "Tenants" table on the dashboard's
+   Register Tenant tab.
+
+`tenant_map.json` (content delivery) is intentionally untouched — separate
+concern.

--- a/ops-server/nginx/ops-server.conf
+++ b/ops-server/nginx/ops-server.conf
@@ -456,7 +456,10 @@ server {
     # tenants on the running list + queue and can use rerun / queue-item /
     # EC2 fleet actions; anonymous callers get masked payloads (and 401 on
     # the writer actions) because the header is cleared in the fallback.
-    location ~ ^/api/(builds/running|builds/rerun/.+|queue/(list|item)|fleet(/.*)?)$ {
+    # /api/tenants/* (attribution registry) rides the same block: signed-in
+    # members read it in the browser; the app's service bearer passes through
+    # the anonymous fallback untouched (Authorization is never stripped).
+    location ~ ^/api/(builds/running|builds/rerun/.+|queue/(list|item)|fleet(/.*)?|tenants(/.*)?)$ {
         auth_request      /oauth2/auth;
         auth_request_set  $user  $upstream_http_x_auth_request_user;
         auth_request_set  $email $upstream_http_x_auth_request_email;


### PR DESCRIPTION
## Summary

Durable **tenant-attribution registry**: records WHO deployed the Enablement App to WHICH tenant — the identifiers Dynatrace APIs cannot give us after the fact (findings doc: `ops-server/docs/EPIC-002-ws-d-tenant-identity.md`).

### What's in

- **Registry** (`dashboard/tenant_registry.py`): Redis hash `tenant:registry:{tenant_id}` `{accountUrn, clientId, deployerEmail, via, firstSeen, lastDeploy, appVersion, identity*}` + index set `tenant:registry:index`. Written best-effort at every deploy call site in `app_deploy.py` (`via = sso-deploy | auto | token | oauth-bootstrap`). The OAuth-bootstrap path records the `accountUrn` + `clientId` it already held in hand (previously dropped — never the secret); the SSO path records the GitHub username as deployer. `tenant_map.json` untouched.
- **Register Tenant form**: optional "your email" input → `deployerEmail` through `/api/deploy/oauth`.
- **Runtime backstop**: `POST /api/tenants/register-identity` `{tenant, email, name, accountUrn}` — Orbital service bearer required (`_is_service_caller`); fills `deployerEmail` only when empty, always refreshes `lastSeen` + identity fields. (App-side caller is a separate task.)
- **CoE list**: `GET /api/tenants/registry` — writer or service bearer; full unmasked entries + a "Tenants" table on the Register tab. `/api/tenants/*` added to the opportunistic-auth nginx block (bearer passes through the anonymous fallback untouched).

### Tests

18 new tests (pure shape/merge logic in `test_masking.py` style + endpoint auth via TestClient): dashboard suite **184 passed**, only the known pre-existing `test_app_deploy.py::test_register_buttons_have_no_guest_gate` failure remains.

### Live verification (already deployed to ops path + restarted)

- anonymous `POST /api/tenants/register-identity` → **401**; anonymous `GET /api/tenants/registry` → **401**
- with `ORBITAL_TOKEN` bearer → **200**, entry visible via `GET /api/tenants/registry` (synthetic entry removed after verification)
- dashboard **200**, Register Tenant form shows the email field + Tenants section; `nginx -t` clean, reloaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)