### PR TITLE
fix(live): capture joiner tenant; honest provision-all/readiness for foreign learners

### DIFF
--- a/ops-server/CLAUDE.md
+++ b/ops-server/CLAUDE.md
@@ -377,6 +377,7 @@ Redis keys:
 - `live:session:{id}` — hash: title, trainingId, ref, trainerEmail, state (`open|running|ended`), createdAt, startedAt, endedAt
 - `live:session:{id}:roster` — set of lowercase invited emails
 - `live:session:{id}:joined` — hash email → ISO joinedAt
+- `live:session:{id}:tenants` — hash email → normalized tenant URL the learner joined FROM (cross-tenant workshops; absent for pre-fix joins)
 - `live:sessions:index` — zset of sessionId scored by epoch createdAt
 
 TTL: on `end` the three `live:session:{id}*` keys get a 7-day TTL (matches

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -4952,6 +4952,12 @@ def _live_keys(session_id: str) -> tuple[str, str, str]:
     return base, f"{base}:roster", f"{base}:joined"
 
 
+def _live_tenants_key(session_id: str) -> str:
+    """Hash email -> normalized tenant URL the learner joined FROM (cross-
+    tenant workshops). Entries absent for pre-fix joins — always optional."""
+    return f"live:session:{session_id}:tenants"
+
+
 class LiveSessionCreate(BaseModel):
     title: str = ""
     trainingId: str = ""
@@ -4968,6 +4974,9 @@ class LiveSessionCreate(BaseModel):
 
 class LiveSessionJoin(BaseModel):
     email: str = ""
+    # Learner's own tenant URL — stamped SERVER-side by the app function
+    # (never trusted from the browser). Optional: legacy callers omit it.
+    tenant: str = ""
 
 
 class LiveSessionTrainerAction(BaseModel):
@@ -4978,6 +4987,8 @@ class LiveSessionJoinByCode(BaseModel):
     code: str = ""
     email: str = ""
     name: str = ""
+    # Learner's own tenant URL (see LiveSessionJoin.tenant).
+    tenant: str = ""
 
 
 class LiveSessionProvisionAll(BaseModel):
@@ -5117,6 +5128,11 @@ async def api_live_session_join(session_id: str, body: LiveSessionJoin):
     if err:
         raise HTTPException(status_code=err[0], detail=err[1])
     await pool.hsetnx(joined_key, email, datetime.now(timezone.utc).isoformat())
+    # Cross-tenant workshops: remember which tenant the learner joined FROM
+    # (last join wins — a re-join from another tenant updates it).
+    tenant = live_sessions.normalize_tenant(body.tenant)
+    if tenant:
+        await pool.hset(_live_tenants_key(session_id), email, tenant)
     return {"state": session.get("state", ""),
             "joinedCount": await pool.hlen(joined_key)}
 
@@ -5266,6 +5282,10 @@ async def api_live_session_join_by_code(body: LiveSessionJoinByCode, request: Re
         raise HTTPException(status_code=err[0], detail=err[1])
     await pool.sadd(roster_key, email)
     await pool.hsetnx(joined_key, email, datetime.now(timezone.utc).isoformat())
+    # Cross-tenant workshops: record the joiner's tenant (same as /join).
+    tenant = live_sessions.normalize_tenant(body.tenant)
+    if tenant:
+        await pool.hset(_live_tenants_key(session_id), email, tenant)
     roster = await pool.smembers(roster_key)
     joined = await pool.hgetall(joined_key)
     return {"sessionId": session_id,
@@ -5281,19 +5301,35 @@ async def api_live_session_provision_all(session_id: str, body: LiveSessionProvi
     reported as "already-active", everyone else gets a daemon job queued
     exactly as POST /api/arena/provision would. tenant = the trainer's arena
     tenant URL; the session's trainingId/ref drive repo + branch.
+
+    Cross-tenant workshops: the trainer's app can only mint tokens for ITS
+    OWN tenant, so ONLY learners whose recorded join-tenant matches
+    body.tenant are provisioned. Others are reported honestly instead of
+    being pinned to the wrong tenant: "foreign-tenant" (provisions on entry
+    from their own tenant) or "not-joined" (tenant unknown until they join).
     Auth: service bearer or signed-in writer."""
     await _require_service_or_writer(request)
-    sess_key, roster_key, _ = _live_keys(session_id)
+    sess_key, roster_key, joined_key = _live_keys(session_id)
     session = await pool.hgetall(sess_key)
     if not session:
         raise HTTPException(status_code=404, detail="Session not found or expired")
     if not live_sessions.is_trainer(body.trainerEmail, session):
         raise HTTPException(status_code=403, detail="trainerEmail does not match this session's trainer")
     roster = await pool.smembers(roster_key)
+    joined = await pool.hgetall(joined_key)
+    joined_tenants = await pool.hgetall(_live_tenants_key(session_id))
     wanted = {e.strip().lower() for e in body.emails if e.strip()} if body.emails else None
     results = []
     for email in sorted(roster):
         if wanted is not None and email.lower() not in wanted:
+            continue
+        skip = live_sessions.provision_skip_status(
+            email in joined, joined_tenants.get(email, ""), body.tenant)
+        if skip:
+            results.append({"email": email, "status": skip,
+                            "message": (live_sessions.FOREIGN_TENANT_MESSAGE
+                                        if skip == "foreign-tenant"
+                                        else live_sessions.NOT_JOINED_MESSAGE)})
             continue
         per = body.perUser.get(email) or body.perUser.get(email.lower()) or {}
         try:
@@ -5318,29 +5354,41 @@ async def api_live_session_provision_all(session_id: str, body: LiveSessionProvi
         except Exception as exc:
             results.append({"email": email, "status": "error",
                             "error": str(exc)[:200]})
-    log.info("Live session %s provision-all by %s: %d queued, %d active, %d errors",
+    log.info("Live session %s provision-all by %s: %d queued, %d active, "
+             "%d foreign-tenant, %d not-joined, %d errors",
              session_id, body.trainerEmail,
              sum(1 for r in results if r["status"] == "queued"),
              sum(1 for r in results if r["status"] == "already-active"),
+             sum(1 for r in results if r["status"] == "foreign-tenant"),
+             sum(1 for r in results if r["status"] == "not-joined"),
              sum(1 for r in results if r["status"] == "error"))
     return {"results": results}
 
 
 @app.get("/api/live/sessions/{session_id}/readiness")
-async def api_live_session_readiness(session_id: str, request: Request, trainerEmail: str = ""):
+async def api_live_session_readiness(session_id: str, request: Request,
+                                     trainerEmail: str = "", tenant: str = ""):
     """Trainer's per-learner provisioning board: for each roster email the
     state of their environment for THIS training — none | queued |
     provisioning | ready | failed. "ready" is the same "Daemon ready"
     livelog contract as the arena session-status endpoint; "failed" only
     when a failed terminal record newer than the session exists (be honest
-    — no invented states)."""
-    sess_key, roster_key, _ = _live_keys(session_id)
+    — no invented states).
+
+    Cross-tenant workshops: with `tenant` (the trainer's tenant, sent by the
+    updated app function) learners without an environment are classified
+    honestly instead of "none": "foreign" (joined from another tenant —
+    provisions on entry there) or "not-joined" (never joined). Without
+    `tenant` the legacy "none" contract is preserved."""
+    sess_key, roster_key, joined_key = _live_keys(session_id)
     session = await pool.hgetall(sess_key)
     if not session:
         raise HTTPException(status_code=404, detail="Session not found or expired")
     if not live_sessions.is_trainer(trainerEmail, session):
         raise HTTPException(status_code=403, detail="trainerEmail does not match this session's trainer")
     roster = await pool.smembers(roster_key)
+    joined = await pool.hgetall(joined_key)
+    joined_tenants = await pool.hgetall(_live_tenants_key(session_id))
     training_id = session.get("trainingId", "")
 
     # One scan of the running arena jobs → email -> meta for this training.
@@ -5384,7 +5432,10 @@ async def api_live_session_readiness(session_id: str, request: Request, trainerE
             results.append({"email": email, "state": "failed",
                             "jobId": failed_by_email[email]})
         else:
-            results.append({"email": email, "state": "none"})
+            results.append({"email": email,
+                            "state": live_sessions.readiness_gap_state(
+                                email in joined,
+                                joined_tenants.get(email, ""), tenant)})
     payload = {"results": results}
     # trainerEmail is caller-supplied — anonymous callers who know it must
     # not harvest the roster; they get masked emails (states stay visible).
@@ -5437,7 +5488,8 @@ async def _expire_live_session_keys(session_id: str, session: dict):
     (the pad export carries its own 30-day TTL). expire on a missing key is
     a no-op, so this is safe for sessions without a pad or join code."""
     sections_key, qa_key, _ = _pad_keys(session_id)
-    keys = [*_live_keys(session_id), sections_key, qa_key]
+    keys = [*_live_keys(session_id), _live_tenants_key(session_id),
+            sections_key, qa_key]
     if session.get("joinCode"):
         keys.append(f"live:joincode:{session['joinCode']}")
     for key in keys:

--- a/ops-server/dashboard/live_sessions.py
+++ b/ops-server/dashboard/live_sessions.py
@@ -13,6 +13,9 @@ Redis model (docs/live-training-architecture.md, ops-server/CLAUDE.md):
                                   maxSeats, joinCode, cancelledAt
   live:session:{id}:roster  set   lowercase invited emails
   live:session:{id}:joined  hash  email -> ISO joinedAt
+  live:session:{id}:tenants hash  email -> normalized tenant URL the learner
+                                  joined FROM (cross-tenant workshops; absent
+                                  for pre-fix joins — backward compatible)
   live:sessions:index       zset  sessionId scored by epoch createdAt
   live:joincode:{code}      str   sessionId (join-by-code lookup, code UPPER)
 """
@@ -50,6 +53,66 @@ def normalize_roster(emails) -> list[str]:
             seen.add(n)
             out.append(n)
     return out
+
+
+# ── Tenants (cross-tenant workshops) ─────────────────────────────────────────
+#
+# ROOT CONSTRAINT: the trainer's app instance can only mint tokens for ITS OWN
+# tenant, so bulk provisioning can never provision a foreign-tenant learner
+# correctly. The learner's tenant is captured at join time (app-function stamps
+# it server-side); provision-all then only provisions same-tenant learners and
+# reports the rest honestly — foreign learners provision on entry from their
+# own tenant via the unchanged single-user flow.
+
+FOREIGN_TENANT_MESSAGE = "provisions on entry from their own tenant"
+NOT_JOINED_MESSAGE = "hasn't joined yet — will provision on entry"
+
+
+def normalize_tenant(tenant) -> str:
+    """Canonical tenant-URL form for equality checks: trimmed, lowercased,
+    no trailing slash (the app sends https://<env>.apps.dynatrace.com)."""
+    return (tenant or "").strip().rstrip("/").lower()
+
+
+def provision_skip_status(has_joined, joined_tenant, workshop_tenant):
+    """Decide whether provision-all may provision a roster email.
+
+    Returns None → provision; otherwise the skip status string:
+      "not-joined"     — never joined, tenant unknown (provisions on entry)
+      "foreign-tenant" — joined from a DIFFERENT tenant than the workshop's
+                         provisioning tenant (provisions on entry there)
+
+    Backward compatible: a joined entry WITHOUT a recorded tenant (pre-fix
+    join) or a missing workshop tenant keeps the legacy behavior (provision).
+    """
+    if not has_joined:
+        return "not-joined"
+    jt = normalize_tenant(joined_tenant)
+    wt = normalize_tenant(workshop_tenant)
+    if jt and wt and jt != wt:
+        return "foreign-tenant"
+    return None
+
+
+def readiness_gap_state(has_joined, joined_tenant, trainer_tenant) -> str:
+    """State for a roster email with NO running job and NO failed record.
+
+    With the trainer's tenant supplied (updated app), be honest on the board:
+      "not-joined" — the learner never joined (will provision on entry)
+      "foreign"    — joined from another tenant (provisions on entry there)
+      "none"       — joined same-tenant (or tenant unrecorded), simply not
+                     provisioned yet
+    Without a trainer tenant (legacy app) always "none" — the old contract.
+    """
+    tt = normalize_tenant(trainer_tenant)
+    if not tt:
+        return "none"
+    if not has_joined:
+        return "not-joined"
+    jt = normalize_tenant(joined_tenant)
+    if jt and jt != tt:
+        return "foreign"
+    return "none"
 
 
 # ── Create validation ─────────────────────────────────────────────────────────

--- a/ops-server/dashboard/test_workshops.py
+++ b/ops-server/dashboard/test_workshops.py
@@ -259,6 +259,56 @@ def test_failed_job_email_matching():
                                "2026-07-14T11:00:00+00:00") is None
 
 
+# ── Cross-tenant join: tenant capture + provision/readiness decisions ────────
+
+SRO = "https://sro97894.apps.dynatrace.com"
+COE = "https://geu80787.apps.dynatrace.com"
+
+
+def test_normalize_tenant_trims_lowercases_and_strips_slash():
+    assert ls.normalize_tenant("  HTTPS://SRO97894.Apps.Dynatrace.com/  ") == SRO
+    assert ls.normalize_tenant(SRO + "///") == SRO
+    assert ls.normalize_tenant("") == ""
+    assert ls.normalize_tenant(None) == ""
+
+
+def test_provision_skip_same_tenant_provisions():
+    assert ls.provision_skip_status(True, SRO, SRO) is None
+    # trailing slash / case variance must not block provisioning
+    assert ls.provision_skip_status(True, SRO + "/", SRO.upper()) is None
+
+
+def test_provision_skip_foreign_tenant():
+    assert ls.provision_skip_status(True, SRO, COE) == "foreign-tenant"
+
+
+def test_provision_skip_not_joined():
+    assert ls.provision_skip_status(False, "", COE) == "not-joined"
+    # never joined even with a stale tenant record → still not-joined
+    assert ls.provision_skip_status(False, SRO, COE) == "not-joined"
+
+
+def test_provision_skip_backward_compatible_when_tenant_absent():
+    # pre-fix join (no tenant recorded) or legacy caller (no workshop tenant):
+    # keep the old behavior — provision.
+    assert ls.provision_skip_status(True, "", COE) is None
+    assert ls.provision_skip_status(True, SRO, "") is None
+
+
+def test_readiness_gap_state_with_trainer_tenant():
+    assert ls.readiness_gap_state(False, "", COE) == "not-joined"
+    assert ls.readiness_gap_state(True, SRO, COE) == "foreign"
+    assert ls.readiness_gap_state(True, COE, COE) == "none"
+    # joined pre-fix (tenant unrecorded) → not provably foreign → none
+    assert ls.readiness_gap_state(True, "", COE) == "none"
+
+
+def test_readiness_gap_state_legacy_without_trainer_tenant():
+    # legacy app (no tenant param) keeps the original "none" contract
+    assert ls.readiness_gap_state(False, "", "") == "none"
+    assert ls.readiness_gap_state(True, SRO, "") == "none"
+
+
 # ── Pad: question hygiene + section gate ─────────────────────────────────────
 
 def test_clean_text_strips_html_and_caps_length():


### PR DESCRIPTION
## Problem

A workshop created on COE with an SRO learner on the roster had **provision-all pin the SRO learner's environment to the COE tenant** — wrong login, empty workshop. Root constraint: the trainer's app instance can only mint tokens for **its own** tenant (the app-held OAuth client is tenant-local), so bulk provisioning can never provision foreign-tenant learners correctly.

## Design (locked)

Capture the learner's tenant **at join time**; foreign learners **provision on entry** from their own tenant via the unchanged single-user flow.

- `POST /api/live/sessions/{id}/join` and `/join-by-code` accept an optional `tenant` (the app function stamps it server-side — never trusted from the browser) and record it in a new `live:session:{id}:tenants` hash (`email -> normalized tenant URL`). Backward compatible: absent for pre-fix joins; key added to the ended/cancelled 7-day TTL sweep.
- `provision-all` resolves each roster email's tenant from the joined record and provisions **only** learners whose tenant matches the workshop's provisioning tenant (`body.tenant`). Others come back honestly:
  - `foreign-tenant` — "provisions on entry from their own tenant"
  - `not-joined` — tenant unknown until they join (skipped)
  - joined-without-recorded-tenant (legacy entries) keeps provisioning as before.
- `readiness` gains a `tenant` query param (the trainer's tenant): learners with no environment are classified `foreign` / `not-joined` instead of `none`, so the trainer board is honest. Without the param the legacy `none` contract is preserved — older app builds are unaffected.
- Pure decision logic in `live_sessions.py` (`normalize_tenant`, `provision_skip_status`, `readiness_gap_state`) with tests in `test_workshops.py`.

Companion app-side change (dynatrace-app-enablements `master`): live-join / live-join-code / live-readiness send `ownTenant()` server-side; trainer board renders the new statuses and treats foreign/not-joined as acceptable at start.

## Tests

`pytest dashboard/` → **191 passed**; only the pre-existing known failure `test_app_deploy.py::test_register_buttons_have_no_guest_gate` (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)