### PR TITLE
feat(registry): registrant-supplied friendly tenant name

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -599,22 +599,26 @@ async def tenants_register_identity(request: Request):
     email = (body.get("email") or "").strip()
     name = (body.get("name") or "").strip()
     account_urn = (body.get("accountUrn") or "").strip()
+    # Optional registrant-supplied friendly tenant name (the account name is
+    # not retrievable via API) — set when provided, never blanked by empty.
+    friendly_name = (body.get("friendlyName") or "").strip()
     if not tenant:
         raise HTTPException(400, "tenant is required.")
     if not (email or name or account_urn):
         raise HTTPException(400, "at least one of email, name, accountUrn is required.")
     tenant_id, _ = classify_tenant(tenant)  # 403 if not a Dynatrace domain
     entry = await tenant_registry.record_identity(
-        pool, tenant_id, email=email, name=name, account_urn=account_urn)
+        pool, tenant_id, email=email, name=name, account_urn=account_urn,
+        friendly_name=friendly_name)
     return {"ok": True, "tenant": tenant_id, "entry": entry}
 
 
 @app.get("/api/tenants/registry")
 async def tenants_registry(request: Request):
     """CoE tenant list: every registered install with its attribution
-    (accountUrn, clientId, deployerEmail, via, firstSeen, lastDeploy,
-    appVersion + runtime identity). Writer or service bearer only — full
-    (unmasked) payload by design."""
+    (friendlyName, accountUrn, clientId, deployerEmail, via, firstSeen,
+    lastDeploy, appVersion + runtime identity). Writer or service bearer only
+    — full (unmasked) payload by design."""
     await _require_service_or_writer(request)
     return {"tenants": await tenant_registry.list_entries(pool)}
 

--- a/ops-server/dashboard/app_deploy.py
+++ b/ops-server/dashboard/app_deploy.py
@@ -921,9 +921,12 @@ async def deploy_with_oauth(body: dict, x_auth_user: str | None = Header(default
     cid = (body.get("clientId") or "").strip()
     csec = (body.get("clientSecret") or "").strip()
     account_urn = (body.get("accountUrn") or "").strip()
-    # Optional attribution: the Register Tenant form asks the admin for their email so the
-    # tenant-attribution registry can answer "who owns this install" later. Never required.
+    # Optional attribution: the Register Tenant form asks the admin for their email (so the
+    # tenant-attribution registry can answer "who owns this install" later) and a friendly
+    # tenant name (the account name is NOT retrievable via API, so the registrant supplies
+    # it). Never required.
     deployer_email = (body.get("deployerEmail") or "").strip()
+    friendly_name = (body.get("friendlyName") or "").strip()
     tenant_id, domain = classify_tenant(tenant)  # 403 if not a Dynatrace domain
     if not (cid and csec):
         raise HTTPException(400, "clientId and clientSecret are required.")
@@ -993,7 +996,8 @@ async def deploy_with_oauth(body: dict, x_auth_user: str | None = Header(default
     # record them (attribution only, never the secret) before they are discarded.
     await tenant_registry.record_deploy(
         _pool(), tenant_id, "oauth-bootstrap", account_urn=account_urn, client_id=cid,
-        deployer=deployer_email or (x_auth_user or ""), app_version=res.get("to") or "")
+        deployer=deployer_email or (x_auth_user or ""), friendly_name=friendly_name,
+        app_version=res.get("to") or "")
     await _audit(user, tenant_id, "deploy", res["status"], via="oauth-bootstrap", client_id=cid,
                  **{k: res[k] for k in ("from", "to") if res.get(k)}, url=url, profile=profile,
                  allowlist=allowlist, remote_grail=remote_grail, mint_ready=mint_ready, warnings=warnings)

--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -3338,13 +3338,14 @@ async function goRegisterOauth(action) {
     const sec = document.getElementById('reg-oa-secret').value.trim();
     const urn = document.getElementById('reg-oa-urn').value.trim();
     const email = (document.getElementById('reg-oa-email') || { value: '' }).value.trim();
+    const friendly = (document.getElementById('reg-oa-name') || { value: '' }).value.trim();
     const m = document.getElementById('reg-oa-msg');
     if (!t) { m.textContent = 'tenant required'; return; }
     if (!cid || !sec) { m.textContent = 'client id + secret required'; return; }
     if (!urn.startsWith('urn:dtaccount:')) { m.textContent = 'account URN required (urn:dtaccount:<uuid>)'; return; }
     m.textContent = ''; setRegBusy(true);
     try {
-        const r = await fetch('/api/deploy/oauth', { method: 'POST', headers: { 'Content-Type': 'application/json' }, credentials: 'same-origin', body: JSON.stringify({ action, tenant: t, clientId: cid, clientSecret: sec, accountUrn: urn, deployerEmail: email }) });
+        const r = await fetch('/api/deploy/oauth', { method: 'POST', headers: { 'Content-Type': 'application/json' }, credentials: 'same-origin', body: JSON.stringify({ action, tenant: t, clientId: cid, clientSecret: sec, accountUrn: urn, deployerEmail: email, friendlyName: friendly }) });
         const raw = await r.text();
         let j = {}; try { j = JSON.parse(raw); } catch (_) { /* non-JSON gateway page */ }
         if (r.ok) {
@@ -3396,12 +3397,12 @@ async function loadTenantRegistry() {
     if (!b) return;
     try {
         const r = await fetch('/api/tenants/registry', { credentials: 'same-origin' });
-        if (!r.ok) { b.innerHTML = '<tr><td colspan="8" class="content-hint">Sign in as an org member to view the tenant registry.</td></tr>'; return; }
+        if (!r.ok) { b.innerHTML = '<tr><td colspan="9" class="content-hint">Sign in as an org member to view the tenant registry.</td></tr>'; return; }
         const rows = (await r.json()).tenants || [];
         const d = s => escapeHtml((s || '').replace('T', ' ').slice(0, 19));
         b.innerHTML = rows.length
-            ? rows.map(t => `<tr><td><code>${escapeHtml(t.tenant || '')}</code></td><td>${escapeHtml(t.deployerEmail || '')}</td><td>${escapeHtml(t.identityName ? `${t.identityName} <${t.identityEmail || ''}>` : (t.identityEmail || ''))}</td><td><code>${escapeHtml(t.accountUrn || '')}</code></td><td>${escapeHtml(t.via || '')}</td><td>${escapeHtml(t.appVersion || '')}</td><td>${d(t.firstSeen)}</td><td>${d(t.lastDeploy)}</td></tr>`).join('')
-            : '<tr><td colspan="8" class="content-hint">none yet</td></tr>';
+            ? rows.map(t => `<tr><td><code>${escapeHtml(t.tenant || '')}</code></td><td>${escapeHtml(t.friendlyName || '')}</td><td>${escapeHtml(t.deployerEmail || '')}</td><td>${escapeHtml(t.identityName ? `${t.identityName} <${t.identityEmail || ''}>` : (t.identityEmail || ''))}</td><td><code>${escapeHtml(t.accountUrn || '')}</code></td><td>${escapeHtml(t.via || '')}</td><td>${escapeHtml(t.appVersion || '')}</td><td>${d(t.firstSeen)}</td><td>${d(t.lastDeploy)}</td></tr>`).join('')
+            : '<tr><td colspan="9" class="content-hint">none yet</td></tr>';
     } catch (e) { /* ignore */ }
 }
 

--- a/ops-server/dashboard/templates/index.html
+++ b/ops-server/dashboard/templates/index.html
@@ -795,6 +795,7 @@
                     <input type="password" id="reg-oa-secret" placeholder="client secret" style="width:220px">
                     <input type="text" id="reg-oa-urn" placeholder="urn:dtaccount:<uuid>" style="width:280px">
                     <input type="email" id="reg-oa-email" placeholder="your email (optional — install attribution)" style="width:260px" title="Recorded in the tenant registry so the CoE knows who owns this install. Optional.">
+                    <input type="text" id="reg-oa-name" placeholder="tenant name (friendly, optional)" style="width:220px" title="A human-readable name for this tenant (e.g. the account/customer name) — the account name is not retrievable via API, so you supply it. Shown in the CoE tenant registry. Optional.">
                 </div>
                 <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
                     <!-- No data-action: the OAuth client is the account's authority — stays
@@ -817,8 +818,8 @@
             </table>
             <h3 style="margin:24px 0 8px">Tenants <span class="content-hint" style="font-weight:normal">(attribution registry — who deployed where; org members only)</span></h3>
             <table id="reg-tenants">
-                <thead><tr><th>Tenant</th><th>Deployer</th><th>Identity</th><th>Account URN</th><th>Via</th><th>Version</th><th>First seen</th><th>Last deploy</th></tr></thead>
-                <tbody><tr><td colspan="8" class="loading">Loading…</td></tr></tbody>
+                <thead><tr><th>Tenant</th><th>Name</th><th>Deployer</th><th>Identity</th><th>Account URN</th><th>Via</th><th>Version</th><th>First seen</th><th>Last deploy</th></tr></thead>
+                <tbody><tr><td colspan="9" class="loading">Loading…</td></tr></tbody>
             </table>
             <div id="reg-mint-clients"></div>
         </section>

--- a/ops-server/dashboard/tenant_registry.py
+++ b/ops-server/dashboard/tenant_registry.py
@@ -14,9 +14,9 @@ at the only moments we ever hold it:
      admin visit (service bearer), merging the admin's email/name in.
 
 Redis layout (Orbital Redis, same instance as jobs):
-  tenant:registry:{tenant_id}  hash — accountUrn, clientId, deployerEmail, via,
-                               firstSeen, lastDeploy, appVersion, identityEmail,
-                               identityName, lastSeen
+  tenant:registry:{tenant_id}  hash — accountUrn, clientId, deployerEmail,
+                               friendlyName, via, firstSeen, lastDeploy,
+                               appVersion, identityEmail, identityName, lastSeen
   tenant:registry:index        set of registered tenant_ids
 
 The shaping/merge logic is pure (no Redis) and unit-tested in
@@ -47,8 +47,8 @@ def _now_iso() -> str:
 # ── Pure shaping / merge logic ───────────────────────────────────────────────
 
 def shape_deploy(via: str, *, account_urn: str = "", client_id: str = "",
-                 deployer: str = "", app_version: str = "",
-                 now: str | None = None) -> dict:
+                 deployer: str = "", friendly_name: str = "",
+                 app_version: str = "", now: str | None = None) -> dict:
     """Fields a deploy call site contributes. Empty values are DROPPED so a
     later, less-informed deploy (e.g. token after oauth-bootstrap) never
     blanks attribution captured earlier."""
@@ -59,6 +59,8 @@ def shape_deploy(via: str, *, account_urn: str = "", client_id: str = "",
         fields["clientId"] = client_id
     if deployer:
         fields["deployerEmail"] = deployer
+    if friendly_name:
+        fields["friendlyName"] = friendly_name
     if app_version:
         fields["appVersion"] = app_version
     return fields
@@ -75,10 +77,13 @@ def merge_fields(existing: dict, fields: dict) -> dict:
 
 
 def merge_identity(existing: dict, *, email: str = "", name: str = "",
-                   account_urn: str = "", now: str | None = None) -> dict:
+                   account_urn: str = "", friendly_name: str = "",
+                   now: str | None = None) -> dict:
     """Runtime-backstop merge (POST /api/tenants/register-identity): always
     refresh lastSeen + the identity fields; FILL deployerEmail only when the
-    deploy-time record left it empty (deploy-time attribution wins)."""
+    deploy-time record left it empty (deploy-time attribution wins).
+    friendlyName (registrant-supplied — the account name is not retrievable
+    via API) is set when provided, never blanked by an empty value."""
     now = now or _now_iso()
     out: dict = {"lastSeen": now}
     if email:
@@ -89,6 +94,8 @@ def merge_identity(existing: dict, *, email: str = "", name: str = "",
         out["identityName"] = name
     if account_urn:
         out["accountUrn"] = account_urn
+    if friendly_name:
+        out["friendlyName"] = friendly_name
     return merge_fields(existing or {}, out)
 
 
@@ -96,7 +103,8 @@ def merge_identity(existing: dict, *, email: str = "", name: str = "",
 
 async def record_deploy(pool, tenant_id: str, via: str, *,
                         account_urn: str = "", client_id: str = "",
-                        deployer: str = "", app_version: str = "") -> None:
+                        deployer: str = "", friendly_name: str = "",
+                        app_version: str = "") -> None:
     """Best-effort registry write at a deploy call site — a registry failure
     must NEVER break a deploy, so every error is swallowed (logged)."""
     try:
@@ -104,7 +112,8 @@ async def record_deploy(pool, tenant_id: str, via: str, *,
         existing = await pool.hgetall(key)
         fields = merge_fields(existing or {}, shape_deploy(
             via, account_urn=account_urn, client_id=client_id,
-            deployer=deployer, app_version=app_version))
+            deployer=deployer, friendly_name=friendly_name,
+            app_version=app_version))
         await pool.hset(key, mapping=fields)
         await pool.sadd(INDEX_KEY, tenant_id)
     except Exception as exc:
@@ -113,13 +122,15 @@ async def record_deploy(pool, tenant_id: str, via: str, *,
 
 
 async def record_identity(pool, tenant_id: str, *, email: str = "",
-                          name: str = "", account_urn: str = "") -> dict:
+                          name: str = "", account_urn: str = "",
+                          friendly_name: str = "") -> dict:
     """Merge the app-reported admin identity into the registry and return the
     resulting entry. Raises on Redis errors (the endpoint reports them)."""
     key = registry_key(tenant_id)
     existing = await pool.hgetall(key) or {}
     fields = merge_identity(existing, email=email, name=name,
-                            account_urn=account_urn)
+                            account_urn=account_urn,
+                            friendly_name=friendly_name)
     await pool.hset(key, mapping=fields)
     await pool.sadd(INDEX_KEY, tenant_id)
     return {**existing, **fields, "tenant": tenant_id}

--- a/ops-server/dashboard/test_tenant_registry.py
+++ b/ops-server/dashboard/test_tenant_registry.py
@@ -32,6 +32,15 @@ def test_shape_deploy_keeps_provided_attribution():
     assert f["via"] == "oauth-bootstrap"
 
 
+def test_shape_deploy_friendly_name_set_when_provided():
+    f = tr.shape_deploy("oauth-bootstrap", friendly_name="ACME Corp (prod)",
+                        now="2026-08-03T10:00:00+00:00")
+    assert f["friendlyName"] == "ACME Corp (prod)"
+    # empty → dropped, so an HSET never blanks a name captured earlier
+    f2 = tr.shape_deploy("token", now="t2")
+    assert "friendlyName" not in f2
+
+
 def test_deploy_vias_match_locked_design():
     assert set(tr.DEPLOY_VIAS) == {"sso-deploy", "auto", "token", "oauth-bootstrap"}
 
@@ -76,6 +85,17 @@ def test_merge_identity_always_updates_identity_fields_and_urn():
     assert out["identityName"] == "New Name"
     assert out["accountUrn"] == "urn:dtaccount:new"
     assert out["lastSeen"] == "t3"
+
+
+def test_merge_identity_friendly_name_set_when_provided_never_blanked():
+    # provided → set (latest registrant-supplied name wins)
+    out = tr.merge_identity({"firstSeen": "t0", "friendlyName": "Old Name"},
+                            email="a@b.com", friendly_name="New Name", now="t1")
+    assert out["friendlyName"] == "New Name"
+    # empty → absent from the merge, so the stored name survives the HSET
+    out2 = tr.merge_identity({"firstSeen": "t0", "friendlyName": "Kept Name"},
+                             email="a@b.com", now="t2")
+    assert "friendlyName" not in out2
 
 
 def test_merge_identity_stamps_first_seen_for_unseen_tenant():


### PR DESCRIPTION
## What

The §9 tenant-attribution registry shipped without a friendly tenant name. Since the account name is **not retrievable via any Dynatrace API**, the registrant supplies one.

- **Registry** (`dashboard/tenant_registry.py`): new `friendlyName` field — same merge semantics as `deployerEmail` shaping: set when provided, never blanked by an empty value (in both `shape_deploy` and `merge_identity`).
- **Register Tenant form** (OAuth bootstrap): optional "tenant name (friendly)" input next to the email field, flows through the `/api/deploy/oauth` body into the registry.
- **`POST /api/tenants/register-identity`**: accepts optional `friendlyName` (runtime backstop path).
- **`GET /api/tenants/registry` + dashboard Tenants table**: `friendlyName` shown as the first column after tenant id.

## Tests

- `dashboard/test_tenant_registry.py`: +2 tests covering shape/merge behavior for the new field — 20 passed. (Pre-existing `test_app_deploy.py::test_register_buttons_have_no_guest_gate` failure is unrelated — it references the removed token-paste card buttons.)

## Live verification (already deployed to ops)

- Dashboard HTML serves the new `reg-oa-name` input and the `Name` column.
- Bearer `register-identity` round-trip with `friendlyName` persisted, appeared in `GET /api/tenants/registry`, synthetic entry cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)