### PR TITLE
fix(loadtest): slot re-init race, bot teardown convergence, rehearsal sourceTenant

### DIFF
--- a/ops-server/tools/bootcamp_loadtest.py
+++ b/ops-server/tools/bootcamp_loadtest.py
@@ -15,16 +15,32 @@ Usage (from ops-server/, any python3 — stdlib only):
 
 The bizevent token is the remote-grail COE platform token, decrypted from
 /home/ops/.env (needs sudo) — the same credential the app's ingest path uses.
+
+Every emitted bizevent is stamped with ``sourceTenant`` (mirrors the app's
+server-side stamp in ingestTrainingEvent.function.ts) so tenant-scoped boards
+can filter rehearsal traffic. Default is the COE apps domain; for an SRO
+rehearsal pass ``--tenant https://sro97894.apps.dynatrace.com``.
+
+Teardown (``--terminate``) is state-file independent: it drains queued bot
+provisions from ``queue:test:amd64`` first (so freed slots can't backfill),
+then terminates every live bot session discovered via
+``/api/arena/active-sessions`` — plus anything the state file still tracks.
+The state file is per-invoking-user (``/tmp/bootcamp_loadtest_state-$USER.json``,
+legacy shared path read as fallback) so runs by different users can't collide
+on file permissions.
 """
 
 import argparse
+import getpass
 import os
 import json
 import random
+import re
 import subprocess
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 
 ORBITAL = "https://autonomous-enablements.whydevslovedynatrace.com"
@@ -43,11 +59,47 @@ STEP_COUNT = 4
 QUESTIONS = 5
 READY_TIMEOUT_S = 20 * 60
 POLL_INTERVAL_S = 20
-STATE_FILE = "/tmp/bootcamp_loadtest_state.json"
+PROVISION_QUEUE = "queue:test:amd64"
+# Highest bot index probed by --terminate's live-session scan (env-overridable).
+TERMINATE_SCAN_MAX = int(os.environ.get("BOT_SCAN_MAX", "100"))
+
+
+def state_file_for(user: str) -> str:
+    """Per-user state path — avoids cross-user /tmp permission collisions."""
+    return f"/tmp/bootcamp_loadtest_state-{user}.json"
+
+
+STATE_FILE = state_file_for(getpass.getuser())
+LEGACY_STATE_FILE = "/tmp/bootcamp_loadtest_state.json"  # pre-per-user path, read-only fallback
 
 
 def bot_email(i: int) -> str:
     return f"{BOT_PREFIX}{i:02d}@{BOT_DOMAIN}"
+
+
+BOT_EMAIL_RE = re.compile(rf"^{re.escape(BOT_PREFIX)}\d+@{re.escape(BOT_DOMAIN)}$")
+
+
+def is_bot_email(email) -> bool:
+    """True for load-test bot identities (bot\\d+@bootcamp.dev by default)."""
+    return bool(BOT_EMAIL_RE.match((email or "").strip().lower()))
+
+
+def queue_entry_bot_email(raw):
+    """Bot email owning a queued provision payload, or None.
+
+    Queued arena jobs (see api_arena_provision) carry the learner email in
+    ``requested_by``. Non-JSON entries and non-bot jobs return None — those
+    entries must never be touched (other users' jobs share the queue).
+    """
+    try:
+        j = json.loads(raw)
+    except Exception:
+        return None
+    if not isinstance(j, dict):
+        return None
+    email = (j.get("requested_by") or "").strip().lower()
+    return email if is_bot_email(email) else None
 
 
 def http_json(url: str, payload=None, bearer: str | None = None, method=None):
@@ -114,14 +166,20 @@ def coe_token() -> str:
 
 
 def load_state() -> dict:
-    try:
-        return json.load(open(STATE_FILE))
-    except Exception:
-        return {}
+    for path in (STATE_FILE, LEGACY_STATE_FILE):
+        try:
+            return json.load(open(path))
+        except Exception:
+            continue
+    return {}
 
 
 def save_state(state: dict):
-    json.dump(state, open(STATE_FILE, "w"), indent=2)
+    """Best-effort persist — a stale/foreign-owned /tmp file must not crash a run."""
+    try:
+        json.dump(state, open(STATE_FILE, "w"), indent=2)
+    except Exception as e:
+        print(f"  WARNING: could not write state file {STATE_FILE}: {e} — continuing without it")
 
 
 # ── Provisioning ─────────────────────────────────────────────────────────────
@@ -180,7 +238,7 @@ def wait_ready(state: dict):
 
 # ── Telemetry ────────────────────────────────────────────────────────────────
 
-def base_event(email: str, event_type: str, extra: dict) -> dict:
+def base_event(email: str, event_type: str, extra: dict, tenant: str = COE_APPS) -> dict:
     return {
         "event.type": f"com.dynatrace.enablement.training.{event_type}",
         "userEmail": email,
@@ -188,6 +246,10 @@ def base_event(email: str, event_type: str, extra: dict) -> dict:
         "trainingTitle": TRAINING_TITLE,
         "trainingType": "lab",
         "trainingCategory": "hands-on",
+        # The app's ingest function stamps sourceTenant server-side on every
+        # event (ingestTrainingEvent.function.ts) — tenant-scoped boards (SRO)
+        # filter on it, so rehearsal traffic must carry it too (--tenant flag).
+        "sourceTenant": tenant,
         "tags": json.dumps(["kubernetes", "bootcamp-loadtest"]),
         "timestamp": None,  # filled at send time
         **extra,
@@ -202,7 +264,7 @@ def emit(token: str, event: dict):
         print(f"    ingest HTTP {status} for {event['event.type']}")
 
 
-def emit_cohort(n: int):
+def emit_cohort(n: int, tenant: str = COE_APPS):
     """Emit a realistic funnel: everyone starts, most progress, ~70% finish."""
     token = coe_token()
     rng = random.Random(42)
@@ -210,12 +272,12 @@ def emit_cohort(n: int):
     for i in range(1, n + 1):
         email = bot_email(i)
         print(f"  {email}:")
-        emit(token, base_event(email, "started", {"stepCount": STEP_COUNT}))
+        emit(token, base_event(email, "started", {"stepCount": STEP_COUNT}, tenant))
         steps_done = STEP_COUNT if rng.random() < 0.7 else rng.randint(1, STEP_COUNT - 1)
         for s in range(1, steps_done + 1):
             emit(token, base_event(email, "step.completed", {
                 "stepIndex": s - 1, "stepCount": STEP_COUNT, "completedSteps": s,
-            }))
+            }, tenant))
             time.sleep(0.2)
         correct = 0
         for q in range(QUESTIONS if steps_done == STEP_COUNT else rng.randint(0, 3)):
@@ -223,7 +285,7 @@ def emit_cohort(n: int):
             correct += ok
             emit(token, base_event(email, "question.answered", {
                 "questionIndex": q, "correct": bool(ok), "points": 10 if ok else 0,
-            }))
+            }, tenant))
             time.sleep(0.1)
         if steps_done == STEP_COUNT:
             finishers += 1
@@ -233,7 +295,7 @@ def emit_cohort(n: int):
                 "timeSpent": rng.randint(300, 1500),
                 "completedAt": time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime()),
                 "stepCount": STEP_COUNT, "completedSteps": STEP_COUNT,
-            }))
+            }, tenant))
             print(f"    completed score={min(score, QUESTIONS*10)}/{QUESTIONS*10}")
         else:
             print(f"    in-progress at step {steps_done}/{STEP_COUNT}")
@@ -242,18 +304,126 @@ def emit_cohort(n: int):
 
 # ── Teardown / status ────────────────────────────────────────────────────────
 
-def terminate():
-    state = load_state()
-    for email, s in state.get("sessions", {}).items():
+def _redis_cli(*args):
+    """Run redis-cli against the local (master) Redis, auth from env or /home/ops/.env."""
+    pw = os.environ.get("REDIS_PASSWORD", "")
+    if not pw:
+        try:
+            out = subprocess.run(
+                ["sudo", "-n", "grep", "-E", "^REDIS_PASSWORD=", "/home/ops/.env"],
+                capture_output=True, text=True)
+            if out.returncode == 0 and "=" in out.stdout:
+                pw = out.stdout.strip().split("=", 1)[1]
+        except Exception:
+            pw = ""
+    env = dict(os.environ)
+    if pw:
+        env["REDISCLI_AUTH"] = pw  # avoids the -a plaintext-password warning
+    return subprocess.run(["redis-cli", *args], capture_output=True, text=True, env=env)
+
+
+def drain_bot_queue(queue: str = PROVISION_QUEUE) -> int:
+    """Remove QUEUED bot provisions so freed slots can't backfill during drain.
+
+    During a mass-terminate, every slot a terminated bot frees immediately pulls
+    the next queued bot provision — termination never converges. Only entries
+    whose ``requested_by`` matches the bot pattern are LREM'd; other users'
+    queued jobs are never touched (never DEL the whole queue).
+    """
+    out = _redis_cli("lrange", queue, "0", "-1")
+    if out.returncode != 0:
+        print(f"  WARNING: cannot read {queue} ({out.stderr.strip()[:200] or 'redis-cli failed'})"
+              f" — queued bot provisions (if any) NOT drained; they will backfill freed slots")
+        return 0
+    matched = [raw for raw in out.stdout.splitlines() if raw and queue_entry_bot_email(raw)]
+    if not matched:
+        print(f"  No queued bot provisions in {queue}.")
+        return 0
+    print(f"  WARNING: {len(matched)} queued bot provision(s) still in {queue} — "
+          f"removing them BEFORE terminating so freed slots don't backfill")
+    removed = 0
+    for raw in matched:
+        res = _redis_cli("lrem", queue, "1", raw)
+        try:
+            removed += int(res.stdout.strip() or 0) if res.returncode == 0 else 0
+        except ValueError:
+            pass
+    print(f"  Removed {removed}/{len(matched)} queued bot provision(s) from {queue} "
+          f"(other users' jobs untouched)")
+    return removed
+
+
+def live_bot_sessions(scan_max: int) -> dict:
+    """Live bot sessions discovered from Orbital — state-file independent.
+
+    A killed run leaves live sessions the (stale or unreadable) state file
+    doesn't track, so teardown asks Orbital directly:
+    GET /api/arena/active-sessions?userId=<bot email> for bot01..bot{scan_max}.
+    Returns {email: [jobId, ...]}.
+    """
+    found = {}
+    for i in range(1, scan_max + 1):
+        email = bot_email(i)
+        try:
+            _, body = http_json(
+                f"{ORBITAL}/api/arena/active-sessions?"
+                + urllib.parse.urlencode({"userId": email}),
+                bearer=orbital_bearer())
+        except Exception:
+            continue
+        job_ids = [s["jobId"] for s in body.get("sessions", []) if s.get("jobId")]
+        if job_ids:
+            found[email] = job_ids
+    return found
+
+
+def merge_terminate_targets(live: dict, state_sessions: dict) -> list:
+    """Ordered, de-duplicated (email, jobId) teardown targets.
+
+    Union of the live Orbital scan (authoritative — survives a killed run whose
+    state file is stale/partial) and the state file (catches sessions the scan
+    missed, e.g. Orbital briefly unreachable for one probe). Live entries come
+    first; a jobId tracked by both sources is terminated once.
+    """
+    targets = {}  # (email, jobId) -> None (ordered set)
+    for email, job_ids in (live or {}).items():
+        for jid in job_ids:
+            targets[(email, jid)] = None
+    for email, s in (state_sessions or {}).items():
+        jid = (s or {}).get("jobId")
+        if jid:
+            targets[(email, jid)] = None
+    return list(targets)
+
+
+def terminate(scan_max: int = TERMINATE_SCAN_MAX):
+    # 1. Queue first — otherwise every slot we free below pulls a queued bot
+    #    provision and termination never converges (2026-08-03 load test).
+    drain_bot_queue()
+
+    # 2. Targets = live scan (authoritative) ∪ state file (may be stale/empty).
+    print(f"  Scanning live sessions for {BOT_PREFIX}01..{BOT_PREFIX}{scan_max:02d}@{BOT_DOMAIN}…")
+    targets = merge_terminate_targets(
+        live_bot_sessions(scan_max), load_state().get("sessions", {}))
+    if not targets:
+        print("  No live or tracked bot sessions found.")
+    for email, job_id in targets:
         try:
             status, body = http_json(
-                f"{ORBITAL}/api/arena/sessions/{s['jobId']}/terminate", {},
+                f"{ORBITAL}/api/arena/sessions/{job_id}/terminate", {},
                 bearer=orbital_bearer())
-            print(f"  {email}: {body.get('status', status)}")
+            print(f"  {email}: {body.get('status', status)} ({job_id})")
         except urllib.error.HTTPError as e:
-            print(f"  {email}: HTTP {e.code}")
+            print(f"  {email}: HTTP {e.code} ({job_id})")
+        except Exception as e:
+            print(f"  {email}: {e} ({job_id})")
         time.sleep(1)
     save_state({})
+    try:  # best-effort: clear the legacy shared file too so it can't resurface
+        if os.path.exists(LEGACY_STATE_FILE):
+            os.remove(LEGACY_STATE_FILE)
+    except OSError:
+        pass
     print("State cleared.")
 
 
@@ -275,12 +445,25 @@ def main():
                     help="skip provisioning; just emit the telemetry funnel")
     ap.add_argument("--no-emit", action="store_true",
                     help="provision + wait only; skip telemetry")
-    ap.add_argument("--terminate", action="store_true")
+    ap.add_argument("--terminate", action="store_true",
+                    help="full bot teardown: FIRST removes queued bot provisions from "
+                         f"{PROVISION_QUEUE} (only entries whose requested_by matches "
+                         f"{BOT_PREFIX}<N>@{BOT_DOMAIN} — other users' queued jobs are "
+                         "never touched) so freed slots don't backfill, THEN terminates "
+                         "every live bot session found via /api/arena/active-sessions "
+                         f"(scans bot 1..max(--sessions, {TERMINATE_SCAN_MAX}); override "
+                         "with BOT_SCAN_MAX) plus anything in the state file, then "
+                         "clears the state file")
     ap.add_argument("--status", action="store_true")
+    ap.add_argument("--tenant", default=f"https://{INGEST_TENANT}.apps.dynatrace.com",
+                    help="sourceTenant stamped on every emitted bizevent "
+                         "(default: derived from INGEST_TENANT, i.e. the tenant the "
+                         "events are ingested into; pass "
+                         "https://sro97894.apps.dynatrace.com for an SRO rehearsal)")
     args = ap.parse_args()
 
     if args.terminate:
-        return terminate()
+        return terminate(max(args.sessions, TERMINATE_SCAN_MAX))
     if args.status:
         return status()
     if not args.emit_only:
@@ -290,7 +473,7 @@ def main():
         wait_ready(state)
     if not args.no_emit:
         print(f"\nEmitting telemetry funnel for {args.sessions} bots…")
-        emit_cohort(args.sessions)
+        emit_cohort(args.sessions, args.tenant.rstrip("/"))
 
 
 if __name__ == "__main__":

--- a/ops-server/tools/test_bootcamp_loadtest.py
+++ b/ops-server/tools/test_bootcamp_loadtest.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Tests for the pure helpers in tools/bootcamp_loadtest.py.
+
+Covers the 2026-08-03 load-test hardening:
+  - bot-email matching (teardown must only ever touch bot identities)
+  - queue-entry matching (drain removes ONLY queued bot provisions)
+  - per-user state-path selection (cross-user /tmp permission collisions)
+  - save_state never crashes on an unwritable path
+  - sourceTenant stamped on every emitted bizevent (--tenant)
+
+Run:  python3 -m pytest tools/test_bootcamp_loadtest.py
+  or: python3 tools/test_bootcamp_loadtest.py
+"""
+import getpass
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import bootcamp_loadtest as blt  # noqa: E402
+
+
+# ── bot-email matching ───────────────────────────────────────────────────────
+
+def test_is_bot_email_matches_default_pattern():
+    assert blt.is_bot_email("bot01@bootcamp.dev")
+    assert blt.is_bot_email("bot7@bootcamp.dev")       # unpadded index
+    assert blt.is_bot_email("bot150@bootcamp.dev")     # >2 digits
+    assert blt.is_bot_email("  Bot03@BOOTCAMP.DEV  ")  # case/whitespace-insensitive
+
+
+def test_is_bot_email_rejects_non_bots():
+    assert not blt.is_bot_email("sergio@dynatrace.com")
+    assert not blt.is_bot_email("bot01@dynatrace.com")   # wrong domain
+    assert not blt.is_bot_email("robot01@bootcamp.dev")  # prefix must anchor at start
+    assert not blt.is_bot_email("bot@bootcamp.dev")      # no index
+    assert not blt.is_bot_email("bot01@bootcamp.devx")   # domain must anchor at end
+    assert not blt.is_bot_email("")
+    assert not blt.is_bot_email(None)
+
+
+def test_bot_email_roundtrips_through_matcher():
+    for i in (1, 9, 42, 100):
+        assert blt.is_bot_email(blt.bot_email(i))
+
+
+# ── queue-entry matching ─────────────────────────────────────────────────────
+
+def _queued(requested_by):
+    return json.dumps({
+        "job_id": "enablement-abc123", "type": "daemon",
+        "repo": "dynatrace-wwse/enablement-kubernetes-101",
+        "arch": "amd64", "requested_by": requested_by,
+    })
+
+
+def test_queue_entry_bot_email_matches_bot_jobs():
+    assert blt.queue_entry_bot_email(_queued("bot05@bootcamp.dev")) == "bot05@bootcamp.dev"
+    assert blt.queue_entry_bot_email(_queued("BOT05@bootcamp.dev")) == "bot05@bootcamp.dev"
+
+
+def test_queue_entry_bot_email_never_matches_other_users():
+    assert blt.queue_entry_bot_email(_queued("student@example.com")) is None
+    assert blt.queue_entry_bot_email(_queued("")) is None
+    # Nightly/CI jobs have no requested_by at all.
+    assert blt.queue_entry_bot_email(json.dumps({"job_id": "x", "repo": "r"})) is None
+
+
+def test_queue_entry_bot_email_tolerates_garbage():
+    assert blt.queue_entry_bot_email("not json {") is None
+    assert blt.queue_entry_bot_email("") is None
+    assert blt.queue_entry_bot_email(json.dumps(["a", "list"])) is None
+    assert blt.queue_entry_bot_email(json.dumps("a string")) is None
+
+
+# ── state-path selection ─────────────────────────────────────────────────────
+
+def test_state_file_is_per_user():
+    assert blt.state_file_for("alice") == "/tmp/bootcamp_loadtest_state-alice.json"
+    assert blt.state_file_for("bob") != blt.state_file_for("alice")
+
+
+def test_module_state_file_uses_invoking_user_and_keeps_legacy_fallback():
+    assert blt.STATE_FILE == blt.state_file_for(getpass.getuser())
+    assert blt.LEGACY_STATE_FILE == "/tmp/bootcamp_loadtest_state.json"
+    assert blt.STATE_FILE != blt.LEGACY_STATE_FILE
+
+
+def test_save_state_warns_but_does_not_crash_on_unwritable_path(monkeypatch=None):
+    orig = blt.STATE_FILE
+    blt.STATE_FILE = "/nonexistent-dir/bootcamp_loadtest_state.json"
+    try:
+        blt.save_state({"sessions": {}})  # must not raise (PermissionError regression)
+    finally:
+        blt.STATE_FILE = orig
+
+
+# ── terminate target merge (live scan ∪ state file) ──────────────────────────
+
+def test_merge_prefers_live_and_dedupes_state_overlap():
+    live = {"bot01@bootcamp.dev": ["job-live-1"], "bot02@bootcamp.dev": ["job-live-2"]}
+    state = {"bot01@bootcamp.dev": {"jobId": "job-live-1"},        # tracked AND live
+             "bot03@bootcamp.dev": {"jobId": "job-stale-3"}}       # state-only (stale run)
+    targets = blt.merge_terminate_targets(live, state)
+    assert targets == [
+        ("bot01@bootcamp.dev", "job-live-1"),
+        ("bot02@bootcamp.dev", "job-live-2"),
+        ("bot03@bootcamp.dev", "job-stale-3"),
+    ]
+
+
+def test_merge_handles_multiple_live_sessions_per_bot():
+    # active-sessions is a list — a bot can own >1 running env after a crashed run.
+    live = {"bot01@bootcamp.dev": ["job-a", "job-b"]}
+    assert blt.merge_terminate_targets(live, {}) == [
+        ("bot01@bootcamp.dev", "job-a"), ("bot01@bootcamp.dev", "job-b")]
+
+
+def test_merge_survives_empty_stale_or_malformed_state():
+    # The stale-state bug: --terminate must still work from the live scan alone.
+    live = {"bot01@bootcamp.dev": ["job-1"]}
+    assert blt.merge_terminate_targets(live, {}) == [("bot01@bootcamp.dev", "job-1")]
+    assert blt.merge_terminate_targets(live, None) == [("bot01@bootcamp.dev", "job-1")]
+    assert blt.merge_terminate_targets(
+        live, {"bot02@bootcamp.dev": {}, "bot03@bootcamp.dev": None}
+    ) == [("bot01@bootcamp.dev", "job-1")]
+    assert blt.merge_terminate_targets({}, {}) == []
+    assert blt.merge_terminate_targets(None, None) == []
+
+
+# ── sourceTenant stamping ────────────────────────────────────────────────────
+
+def test_base_event_stamps_default_source_tenant():
+    ev = blt.base_event("bot01@bootcamp.dev", "started", {"stepCount": 4})
+    assert ev["sourceTenant"] == blt.COE_APPS
+
+
+def test_base_event_stamps_custom_source_tenant_on_every_event_type():
+    sro = "https://sro97894.apps.dynatrace.com"
+    for etype in ("started", "step.completed", "question.answered", "completed"):
+        ev = blt.base_event("bot01@bootcamp.dev", etype, {}, sro)
+        assert ev["sourceTenant"] == sro, etype
+        assert ev["event.type"] == f"com.dynatrace.enablement.training.{etype}"
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"  PASS {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"  FAIL {name}: {e}")
+    print(f"{'FAILED' if failures else 'OK'} ({failures} failures)")
+    sys.exit(1 if failures else 0)

--- a/ops-server/worker-agent/agent.py
+++ b/ops-server/worker-agent/agent.py
@@ -67,6 +67,19 @@ LOCK_TTL_SECONDS = 7200
 # this guarantees a terminated session always converges to a clean state.
 RECONCILE_INTERVAL = 15
 
+# Bounded retry for slot re-initialization. Under mass-terminate the old slot
+# container's removal can still be in progress when release() re-inits, so the
+# first docker run hits "Conflict: name already in use". One failed attempt
+# must NOT shrink the pool forever — retry with backoff before giving up.
+SLOT_REINIT_ATTEMPTS = 5
+SLOT_REINIT_BACKOFF_S = 5  # doubled each attempt, capped at SLOT_REINIT_BACKOFF_MAX_S
+SLOT_REINIT_BACKOFF_MAX_S = 60
+
+
+def _reinit_backoff_s(attempt: int) -> int:
+    """Backoff (seconds) before re-init retry ``attempt`` (1-based): 5,10,20,40,60."""
+    return min(SLOT_REINIT_BACKOFF_S * (2 ** (attempt - 1)), SLOT_REINIT_BACKOFF_MAX_S)
+
 
 def _terminate_candidate_names(job_id, slot_sb_name=None, redis_sb_name=None):
     """Ordered, de-duplicated Sysbox container names to try when killing a job.
@@ -81,6 +94,20 @@ def _terminate_candidate_names(job_id, slot_sb_name=None, redis_sb_name=None):
         if n and n not in names:
             names.append(n)
     return names
+
+
+def _is_container_name_conflict(stderr_text) -> bool:
+    """Whether a ``docker run`` failure is a container-name conflict.
+
+    Under mass-terminate, a terminate's ``docker rm -f`` for a slot container
+    can still be in flight (or the pre-create rm timed out under daemon load)
+    when ``_init_slot`` issues its ``docker run`` — Docker then rejects the
+    create with 'Conflict. The container name "/sb-slot-…" is already in use'.
+    Detecting it lets _init_slot force-remove and retry once instead of
+    dropping the slot from the pool until the next agent restart.
+    """
+    text = stderr_text or ""
+    return "is already in use" in text or "Conflict" in text
 
 
 def _docker_rm_removed(returncode, stderr_text):
@@ -207,20 +234,45 @@ class SysboxPool:
 
         # Start outer Sysbox with the workspace directory mounted at /workspaces.
         # The port is fixed per slot so no dynamic allocation is needed.
-        proc = await asyncio.create_subprocess_exec(
-            "docker", "run", "-d",
-            "--runtime=sysbox-runc",
-            "--name", slot.sb_name,
-            "-p", f"{slot.port}:{K3D_LB_HTTP_PORT}",
-            "-v", f"{slot.workspace}:/workspaces",
-            "docker:25-dind",
-            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
-        )
-        _, err = await proc.communicate()
-        if proc.returncode != 0:
+        # Retried once on a name conflict: under mass-terminate, a concurrent
+        # ``docker rm -f`` of the same slot name (terminate listener/reconciler)
+        # can race this create — the pre-create rm above sees nothing (or the
+        # removal is still in flight), then the run hits "name already in use"
+        # and the slot used to fall out of the pool until agent restart.
+        for attempt in (1, 2):
+            proc = await asyncio.create_subprocess_exec(
+                "docker", "run", "-d",
+                "--runtime=sysbox-runc",
+                "--name", slot.sb_name,
+                "-p", f"{slot.port}:{K3D_LB_HTTP_PORT}",
+                "-v", f"{slot.workspace}:/workspaces",
+                "docker:25-dind",
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+            )
+            _, err = await proc.communicate()
+            if proc.returncode == 0:
+                break
+            err_text = err.decode(errors="replace")
+            if attempt == 1 and _is_container_name_conflict(err_text):
+                log.warning(
+                    "Slot %d: name conflict on %s (concurrent rm in flight?) — "
+                    "force-removing and retrying once",
+                    slot.index, slot.sb_name,
+                )
+                try:
+                    rm = await asyncio.create_subprocess_exec(
+                        "docker", "rm", "-fv", slot.sb_name,
+                        stdout=asyncio.subprocess.DEVNULL,
+                        stderr=asyncio.subprocess.DEVNULL,
+                    )
+                    await asyncio.wait_for(rm.wait(), timeout=30)
+                except Exception:
+                    pass
+                await asyncio.sleep(3)
+                continue
             log.error(
                 "Slot %d: sysbox start failed: %s",
-                slot.index, err.decode(errors="replace")[:300],
+                slot.index, err_text[:300],
             )
             return False
 
@@ -282,13 +334,22 @@ class SysboxPool:
         """
         if not healthy:
             log.warning("Slot %d unhealthy — re-initializing", slot.index)
-            ok = await self._init_slot(slot)
-            if not ok:
-                log.error(
-                    "Slot %d re-init failed — slot removed from pool until next agent restart",
-                    slot.index,
-                )
-            # _init_slot puts slot back into the queue on success.
+            for attempt in range(1, SLOT_REINIT_ATTEMPTS + 1):
+                # _init_slot puts slot back into the queue on success.
+                if await self._init_slot(slot):
+                    return
+                if attempt < SLOT_REINIT_ATTEMPTS:
+                    backoff = _reinit_backoff_s(attempt)
+                    log.warning(
+                        "Slot %d re-init attempt %d/%d failed — retrying in %ds",
+                        slot.index, attempt, SLOT_REINIT_ATTEMPTS, backoff,
+                    )
+                    await asyncio.sleep(backoff)
+            log.error(
+                "Slot %d re-init failed after %d attempts — "
+                "slot removed from pool until next agent restart",
+                slot.index, SLOT_REINIT_ATTEMPTS,
+            )
             return
 
         # Wipe inner docker state without touching the outer Sysbox or its image cache.

--- a/ops-server/worker-agent/test_slot_reinit.py
+++ b/ops-server/worker-agent/test_slot_reinit.py
@@ -1,0 +1,70 @@
+"""Tests for the slot re-init race hardening (2026-08-03 load test).
+
+Pure logic — no Redis/Docker — so it runs anywhere.
+
+Runnable two ways (mirrors test_scheduler.py / test_terminate.py):
+  - pytest:     /home/ops/ops-venv/bin/python -m pytest worker-agent/test_slot_reinit.py
+  - standalone: cd ops-server && /home/ops/ops-venv/bin/python -m worker-agent.test_slot_reinit
+
+Regression contract: under mass-terminate, a terminate's ``docker rm -f`` of a
+slot container races the pool's re-init ``docker run`` for the same name —
+'docker: Conflict. The container name "/sb-slot-amd001-3" is already in use'.
+That single failure used to remove the slot from the pool until the next agent
+restart. Now the conflict is detected (force-remove + one in-place retry) and
+release() retries the whole re-init with bounded backoff before giving up.
+"""
+
+from .agent import (
+    SLOT_REINIT_ATTEMPTS,
+    SLOT_REINIT_BACKOFF_MAX_S,
+    _is_container_name_conflict,
+    _reinit_backoff_s,
+)
+
+
+# ── name-conflict detection ──────────────────────────────────────────────────
+
+def test_conflict_detected_from_journal_message():
+    # Exact shape seen on amd001 during the 2026-08-03 mass-terminate.
+    err = ('docker: Conflict. The container name "/sb-slot-amd001-3" is already '
+           'in use by container "1f2e3d". You have to remove (or rename) that '
+           'container to be able to reuse that name.')
+    assert _is_container_name_conflict(err) is True
+
+
+def test_conflict_detected_case_variants():
+    assert _is_container_name_conflict("Conflict. The container name ...") is True
+    assert _is_container_name_conflict('name "/x" is already in use by container') is True
+
+
+def test_non_conflict_errors_not_matched():
+    assert _is_container_name_conflict("") is False
+    assert _is_container_name_conflict(None) is False
+    assert _is_container_name_conflict("docker: Error response from daemon: OCI runtime create failed") is False
+    assert _is_container_name_conflict("No such container: sb-slot-amd001-3") is False
+
+
+# ── re-init backoff schedule ─────────────────────────────────────────────────
+
+def test_backoff_doubles_and_caps():
+    assert [_reinit_backoff_s(a) for a in range(1, SLOT_REINIT_ATTEMPTS + 1)] == [5, 10, 20, 40, 60]
+
+
+def test_backoff_never_exceeds_cap():
+    for a in range(1, 20):
+        assert _reinit_backoff_s(a) <= SLOT_REINIT_BACKOFF_MAX_S
+
+
+if __name__ == "__main__":
+    import sys
+    failures = 0
+    for name, fn in sorted(list(globals().items())):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"  PASS {name}")
+            except AssertionError as e:
+                failures += 1
+                print(f"  FAIL {name}: {e}")
+    print(f"{'FAILED' if failures else 'OK'} ({failures} failures)")
+    sys.exit(1 if failures else 0)

--- a/ops-server/worker-agent/test_slot_reinit.py
+++ b/ops-server/worker-agent/test_slot_reinit.py
@@ -14,7 +14,11 @@ restart. Now the conflict is detected (force-remove + one in-place retry) and
 release() retries the whole re-init with bounded backoff before giving up.
 """
 
+import asyncio
+
+from . import agent
 from .agent import (
+    SysboxPool,
     SLOT_REINIT_ATTEMPTS,
     SLOT_REINIT_BACKOFF_MAX_S,
     _is_container_name_conflict,
@@ -53,6 +57,76 @@ def test_backoff_doubles_and_caps():
 def test_backoff_never_exceeds_cap():
     for a in range(1, 20):
         assert _reinit_backoff_s(a) <= SLOT_REINIT_BACKOFF_MAX_S
+
+
+# ── release(healthy=False) bounded retry ─────────────────────────────────────
+# The docker-facing _init_slot is stubbed; only the retry/backoff/queue contract
+# of release() is exercised, so these stay pure and fast.
+
+def _pool_with_stubbed_init(fail_first_n: int):
+    """SysboxPool(1) whose _init_slot fails ``fail_first_n`` times, then succeeds.
+
+    The stub mirrors the real contract: on success the slot is put back into
+    the pool queue and True is returned; on failure nothing is enqueued.
+    """
+    pool = SysboxPool(1)
+    calls = []
+
+    async def fake_init(slot):
+        calls.append(slot.index)
+        if len(calls) <= fail_first_n:
+            return False
+        await pool._queue.put(slot)
+        return True
+
+    pool._init_slot = fake_init
+    return pool, calls
+
+
+def _run_release_unhealthy(pool):
+    """Drive release(healthy=False) with instant (recorded) sleeps."""
+    sleeps = []
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(s):
+        sleeps.append(s)
+        await real_sleep(0)
+
+    agent.asyncio.sleep = fake_sleep
+    try:
+        asyncio.run(pool.release(pool.slots[0], healthy=False))
+    finally:
+        agent.asyncio.sleep = real_sleep
+    return sleeps
+
+
+def test_release_retries_transient_failure_and_returns_slot_to_pool():
+    # Two failed re-inits (old container's rm still in flight), third succeeds —
+    # the slot MUST come back instead of being dropped forever.
+    pool, calls = _pool_with_stubbed_init(fail_first_n=2)
+    sleeps = _run_release_unhealthy(pool)
+    assert len(calls) == 3
+    assert sleeps == [5, 10]          # capped-exponential backoff between attempts
+    assert pool._queue.qsize() == 1   # slot restored to the pool
+
+
+def test_release_happy_first_attempt_no_backoff():
+    # Pre-fix behavior preserved: first re-init succeeds → no sleeps, one call.
+    pool, calls = _pool_with_stubbed_init(fail_first_n=0)
+    sleeps = _run_release_unhealthy(pool)
+    assert len(calls) == 1
+    assert sleeps == []
+    assert pool._queue.qsize() == 1
+
+
+def test_release_gives_up_after_bounded_attempts():
+    # Permanent failure (e.g. docker daemon wedged): retry exactly
+    # SLOT_REINIT_ATTEMPTS times, then drop — never an unbounded loop.
+    pool, calls = _pool_with_stubbed_init(fail_first_n=10 ** 6)
+    sleeps = _run_release_unhealthy(pool)
+    assert len(calls) == SLOT_REINIT_ATTEMPTS
+    assert len(sleeps) == SLOT_REINIT_ATTEMPTS - 1
+    assert pool._queue.qsize() == 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Four bugs surfaced by the 2026-08-03 bootcamp load tests.

## 1. Slot re-init race under mass-terminate (worker-agent)
`journal (amd001): Slot 3: sysbox start failed: docker: Conflict. The container name sb-slot-amd001-3 is already in use` → `Slot 3 re-init failed — slot removed from pool until next agent restart`.

A terminate's `docker rm -f` of the slot container races the pool's re-init `docker run` for the same fixed name. Fix in `worker-agent/agent.py`:
- `_init_slot` detects the name conflict (`_is_container_name_conflict`), force-removes the leftover container and retries the create once in place;
- `release(healthy=False)` now retries the whole re-init with bounded backoff (5/10/20/40/60 s, `SLOT_REINIT_ATTEMPTS=5`) before dropping the slot, instead of giving up after a single failure.

## 2. `--terminate` used stale state (tools/bootcamp_loadtest.py)
After a killed run (or a state file owned by another user — we hit `PermissionError`), teardown missed live sessions. Now:
- live bot sessions are discovered via `GET /api/arena/active-sessions?userId=botNN@bootcamp.dev` (scan 1..max(`--sessions`, 100), `BOT_SCAN_MAX` override) and merged with state-file entries (`merge_terminate_targets`);
- `save_state` warns instead of crashing;
- state path is per-user (`/tmp/bootcamp_loadtest_state-$USER.json`), legacy shared path kept as read-only fallback.

## 3. Teardown queue-backfill
During drain, freed slots pulled queued bot provisions from `queue:test:amd64`, so termination never converged. `--terminate` now drains the queue FIRST: `LRANGE` + `LREM` of only the entries whose `requested_by` matches `bot\d+@bootcamp.dev`, with a loud warning of the count. Other users' queued jobs are never touched; the queue is never DEL'd wholesale.

## 4. Emitted bizevents missing `sourceTenant`
Tenant-scoped boards (SRO) could not show rehearsal traffic. Every emitted event now stamps `sourceTenant` (mirrors the app's server-side stamp in `ingestTrainingEvent.function.ts`), value from the new `--tenant` flag (default derived from `INGEST_TENANT`; for an SRO rehearsal pass `--tenant https://sro97894.apps.dynatrace.com`).

## Tests
- `tools/test_bootcamp_loadtest.py` — 14 pure-logic tests (bot-email matching, queue-entry matching, state-path selection, save_state resilience, target merge, sourceTenant stamping)
- `worker-agent/test_slot_reinit.py` — name-conflict detection, backoff schedule, and async `release()` retry-loop tests via a stubbed `SysboxPool`
- Full dashboard + tools + worker-agent suites green (210 passed); pre-existing failures unrelated to this PR: `dashboard/test_app_deploy.py::test_register_buttons_have_no_guest_gate` (known) and `tools/test_training_test_runner.py::test_e2e_failure_still_terminates` (asserts uncolored output against the already-merged ANSI-colors runner).

## Deploy state
- Master ops checkout: `ops-server/tools/bootcamp_loadtest.py` + test already `sudo cp`'d to `/home/ops/.../ops-server/tools/` (ad-hoc tool, no service restart needed).
- `worker-agent/agent.py` NOT yet deployed — at merge, pull on amd001 + amd002 and `systemctl restart ops-worker-agent` on both (defer restart if a load test is running on the worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)