### PR TITLE
fix(pad): URL token wins over stored sessionStorage pad session

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -5947,17 +5947,22 @@ button:disabled { opacity: .5; cursor: default; }
   }
 
   // ── Claim the single-use token → 8h pad session (survives reloads via
-  // sessionStorage; the URL token is dead after first use). ──
+  // sessionStorage; the URL token is dead after first use). A fresh URL token
+  // always WINS over a stored session — reopening from the app may carry a
+  // different identity/role; a dead token (page reload) falls back to the
+  // stored session. The token is stripped from the URL after the claim
+  // attempt so reloads don't retry a dead token. ──
   let me = null;
   try { me = JSON.parse(sessionStorage.getItem(store) || 'null'); } catch (e) {}
   const urlToken = new URLSearchParams(location.search).get('token') || '';
-  if (!me && urlToken) {
+  if (urlToken) {
     try {
       const r = await fetch(BASE + '/api/live/pad-claim', {
         method: 'POST', headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({token: urlToken})});
       if (r.ok) { me = await r.json(); sessionStorage.setItem(store, JSON.stringify(me)); }
     } catch (e) {}
+    try { history.replaceState(null, '', location.pathname); } catch (e) {}
   }
   if (!me) return fail('This pad link has expired — reopen the pad from the app to get a fresh one.');
 


### PR DESCRIPTION
## Summary
- The `/pad/{id}` page only claimed the single-use URL token when NO pad session was stored in `sessionStorage` (`if (!me && urlToken)`), so reopening the pad from the app with a fresh token — possibly a different identity or role — silently kept the old stored identity.
- Now a present URL token is always claimed: a successful claim replaces the stored session; a dead token (page reload after first use) falls back to the stored session, so reload behavior is unchanged.
- After the claim attempt the token is stripped from the URL (`history.replaceState`) so reloads don't retry a dead token.

Closes the "Pad nit: URL token should win over stored sessionStorage session" item from the 2026-08-02 workshops handoff.

## Test plan
- [ ] Open pad from app as learner → sessionStorage session stored.
- [ ] Reopen from app as trainer (fresh token, same browser tab session) → page now shows trainer identity/editing.
- [ ] Reload the pad page → stored session still used, no expired-link error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)