### PR TITLE
fix(ops): dedupe training-test triggers + surface queued jobs

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -19,7 +19,7 @@ import termios
 import httpx
 from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel
-from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 import redis.asyncio as redis
@@ -89,6 +89,7 @@ from dashboard import live_pad  # noqa: E402
 # PII masking for anonymous (public) reads — pure transforms in
 # dashboard/masking.py (tested without Redis).
 from dashboard import masking  # noqa: E402
+from dashboard import training_dedupe  # noqa: E402
 
 _PROFILES_PAGE = """<!doctype html><html><head><meta charset=utf-8>
 <title>Content Profiles</title><style>
@@ -1429,31 +1430,34 @@ async def api_terminate_job(job_id: str, request: Request):
 
 @app.get("/api/queue/list")
 async def api_queue_list(request: Request):
-    """Contents of the pending test queues (arm64 + amd64), unordered.
+    """Contents of the pending job queues (arm64 + amd64 tests + training),
+    unordered.
+
+    ``queue:training`` is included so a training-test that is enqueued but
+    still waiting behind the 2-wide training semaphore (no ``job:running:*``
+    key yet) is visible in the dashboard's Queued panel — otherwise the
+    trigger looks dead and users double-click, spawning duplicates.
 
     Public — requested_by (a learner email for queued arena jobs) is masked
     for anonymous callers."""
     full = _has_full_access(request)
     result = []
-    for arch in ("arm64", "amd64"):
-        items = await pool.lrange(f"queue:test:{arch}", 0, -1)
+    # (queue key, default arch). training-test jobs always pin amd64.
+    for queue_key, arch in (
+        ("queue:test:arm64", "arm64"),
+        ("queue:test:amd64", "amd64"),
+        ("queue:training",   "amd64"),
+    ):
+        items = await pool.lrange(queue_key, 0, -1)
         for position, raw in enumerate(items):
             try:
                 j = json.loads(raw)
             except Exception:
                 continue
-            result.append({
-                "queue":        f"queue:test:{arch}",
-                "arch":         arch,
-                "position":     position,
-                "job_id":       j.get("job_id", ""),
-                "repo":         j.get("repo", ""),
-                "ref":          j.get("ref") or j.get("branch") or j.get("head_branch") or "main",
-                "type":         j.get("type", "integration-test"),
-                "queued_at":    j.get("timestamp") or j.get("queued_at"),
-                "requested_by": j.get("requested_by", "") if full
-                                else masking.mask_email(j.get("requested_by", "")),
-            })
+            requested_by = j.get("requested_by", "") if full \
+                else masking.mask_email(j.get("requested_by", ""))
+            result.append(training_dedupe.queue_item_view(
+                j, queue_key, arch, position, requested_by))
     return {"items": result, "total": len(result)}
 
 
@@ -1462,13 +1466,13 @@ async def api_queue_delete_item(job_id: str, request: Request):
     """Remove a pending job from a test queue by job_id. Writer role required."""
     await _require_writer(request)
     removed = 0
-    for arch in ("arm64", "amd64"):
-        items = await pool.lrange(f"queue:test:{arch}", 0, -1)
+    for queue_key in ("queue:test:arm64", "queue:test:amd64", "queue:training"):
+        items = await pool.lrange(queue_key, 0, -1)
         for raw in items:
             try:
                 j = json.loads(raw)
                 if j.get("job_id") == job_id:
-                    count = await pool.lrem(f"queue:test:{arch}", 1, raw)
+                    count = await pool.lrem(queue_key, 1, raw)
                     removed += count
                     break
             except Exception:
@@ -1476,7 +1480,7 @@ async def api_queue_delete_item(job_id: str, request: Request):
         if removed:
             break
     if not removed:
-        raise HTTPException(404, f"Job {job_id} not found in any test queue")
+        raise HTTPException(404, f"Job {job_id} not found in any pending queue")
     log.info("Queue item %s deleted", job_id)
     return {"removed": removed, "job_id": job_id}
 
@@ -2656,6 +2660,26 @@ async def api_trigger_build(request: Request):
         # Full e2e training test: a master-side orchestrator provisions a real
         # arena session (always amd64 — /api/arena/provision pins the arch) and
         # drives every doc step through the exec API. One job, no per-arch fanout.
+        #
+        # Dedupe (mirrors the integration-test running:lock:* pattern): a real
+        # run burns a worker slot + a full ~8-min SRO session, so a double-click
+        # (the training job is invisible while it waits behind the 2-wide
+        # training semaphore — no job:running:* key exists yet) must NOT enqueue
+        # a duplicate. SET NX a repo+ref-scoped lock here; the worker DELs it in
+        # _run_training_test's finally. Repo+ref scoped so the nightly (distinct
+        # repos) is never blocked; EX auto-expires so a crashed run can't wedge
+        # the repo forever.
+        lock_key = training_dedupe.training_lock_key(repo, ref)
+        acquired = await pool.set(
+            lock_key, requested_by, nx=True,
+            ex=training_dedupe.TRAINING_LOCK_TTL_SECONDS,
+        )
+        if not acquired:
+            holder = await pool.get(lock_key) or ""
+            return JSONResponse(
+                status_code=409,
+                content=training_dedupe.already_queued_response(repo, ref, holder),
+            )
         job = {
             "type": "training-test",
             "repo": repo,

--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -567,11 +567,29 @@ async function triggerBuildFromRow(repo, safeRepo, btn) {
                 window.location.href = '/oauth2/start?rd=' + encodeURIComponent(window.location.pathname);
                 return;
             }
-            if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            const repoShort = repo.split('/').pop();
+            if (res.status === 409 || data.status === 'already-queued') {
+                // Dedupe: a training-test for this repo+ref is already queued
+                // or running (it may be waiting behind the training semaphore
+                // with no running row yet). No duplicate was enqueued.
+                showToast(`⏳ Already queued/running: ${repoShort} @ ${branch} — not duplicated.`, 5000);
+                btn.textContent = '⏳ Queued';
+                setTimeout(() => { btn.textContent = 'Trigger'; }, 2500);
+            } else if (!res.ok) {
                 alert('Trigger failed: HTTP ' + res.status);
+                btn.textContent = 'Trigger';
+            } else {
+                // The trigger response already says status:queued — surface it
+                // so the click never looks dead (esp. for training-test, which
+                // shows no running row until it clears the semaphore).
+                showToast(`✓ Queued ${formatJobType(action)} · ${repoShort} @ ${branch}`, 4000);
+                btn.textContent = '✓ Queued';
+                setTimeout(() => { btn.textContent = 'Trigger'; }, 2500);
             }
         } finally {
-            btn.disabled = false; btn.textContent = 'Trigger';
+            btn.disabled = false;
+            if (btn.textContent === '…') btn.textContent = 'Trigger';  // e.g. network error
             await loadRunning();
         }
     }

--- a/ops-server/dashboard/test_training_dedupe.py
+++ b/ops-server/dashboard/test_training_dedupe.py
@@ -1,0 +1,129 @@
+"""Pure-logic tests for training-test enqueue dedupe + queued visibility
+(dashboard/training_dedupe.py).
+
+No Redis, no FastAPI — exercises only the helpers the /api/builds/trigger
+(training-test branch), /api/queue/list, and workers/manager.py
+_run_training_test share: the lock-key construction (must be identical on the
+SET-NX enqueue side and the DEL release side), the already-queued 409 body
+shape, and the queue LRANGE -> dashboard-row mapping.
+
+Runnable two ways:
+  - pytest:     python3 -m pytest dashboard/test_training_dedupe.py
+  - standalone: /home/ops/ops-venv/bin/python -m dashboard.test_training_dedupe
+"""
+
+from dashboard import training_dedupe as td
+
+REPO = "dynatrace-wwse/live-debugger"
+
+
+# ── Lock key construction ────────────────────────────────────────────────────
+
+def test_lock_key_is_repo_and_ref_scoped():
+    # The whole point: repo+ref, never bare type — so the nightly (distinct
+    # repos) is never blocked by a manual trigger.
+    assert td.training_lock_key(REPO, "main") == \
+        "training:lock:dynatrace-wwse/live-debugger:main"
+
+
+def test_lock_key_distinct_repos_do_not_collide():
+    a = td.training_lock_key("dynatrace-wwse/kubernetes-101", "main")
+    b = td.training_lock_key("dynatrace-wwse/dtwiz-101", "main")
+    assert a != b
+
+
+def test_lock_key_distinct_refs_do_not_collide():
+    assert td.training_lock_key(REPO, "main") != td.training_lock_key(REPO, "dev")
+
+
+def test_lock_key_empty_ref_is_stable():
+    # Nightly enqueues carry no ref -> "" ; must be deterministic, not crash.
+    assert td.training_lock_key(REPO, "") == "training:lock:dynatrace-wwse/live-debugger:"
+    assert td.training_lock_key(REPO, None) == td.training_lock_key(REPO, "")
+
+
+def test_enqueue_and_release_agree_on_the_key():
+    # Simulate the two sides. Enqueue (app.py): ref defaults to "main".
+    enqueue_ref = "main"
+    enqueue_key = td.training_lock_key(REPO, enqueue_ref)
+    # Release (manager.py): ref = job.get("ref") or job.get("branch") or "".
+    job = {"repo": REPO, "ref": "main", "type": "training-test"}
+    release_ref = job.get("ref") or job.get("branch") or ""
+    release_key = td.training_lock_key(job["repo"], release_ref)
+    assert enqueue_key == release_key, "dedupe is broken if the keys diverge"
+
+
+def test_lock_ttl_exceeds_runner_timeout():
+    # A crashed run must auto-clear; the backstop TTL must outlast the 90-min
+    # (5400s) hard runner timeout so it never expires mid-run.
+    assert td.TRAINING_LOCK_TTL_SECONDS > 5400
+
+
+# ── already-queued 409 body ──────────────────────────────────────────────────
+
+def test_already_queued_response_shape():
+    body = td.already_queued_response(REPO, "main", holder="alice")
+    assert body["status"] == "already-queued"
+    assert body["repo"] == REPO
+    assert body["ref"] == "main"
+    assert body["type"] == "training-test"
+    assert body["requested_by"] == "alice"
+    assert "already queued or running" in body["detail"]
+
+
+def test_already_queued_response_tolerates_missing_holder():
+    body = td.already_queued_response(REPO, "main")
+    assert body["requested_by"] == ""
+    assert body["status"] == "already-queued"
+
+
+# ── queue LRANGE -> dashboard row ────────────────────────────────────────────
+
+def test_queue_item_view_training_job():
+    job = {
+        "type": "training-test", "repo": REPO, "arch": "amd64", "ref": "main",
+        "timestamp": "2026-08-03T10:00:00+00:00", "requested_by": "bob",
+        "job_id": "mk3p9aqz-7f3a",
+    }
+    row = td.queue_item_view(job, "queue:training", "amd64", 0, "bob")
+    assert row["queue"] == "queue:training"
+    assert row["type"] == "training-test"
+    assert row["repo"] == REPO
+    assert row["ref"] == "main"
+    assert row["arch"] == "amd64"
+    assert row["position"] == 0
+    assert row["queued_at"] == "2026-08-03T10:00:00+00:00"
+    assert row["requested_by"] == "bob"      # caller passes it already masked
+    assert row["job_id"] == "mk3p9aqz-7f3a"
+
+
+def test_queue_item_view_nightly_training_job_has_no_ref():
+    # Nightly (scheduler.py) enqueues without ref/requested_by.
+    job = {"type": "training-test", "repo": REPO, "arch": "amd64",
+           "timestamp": "2026-08-03T02:00:00+00:00", "nightly_run_id": "nightly-x"}
+    row = td.queue_item_view(job, "queue:training", "amd64", 2, "")
+    assert row["ref"] == "main"              # falls back, never blank/None
+    assert row["requested_by"] == ""
+    assert row["position"] == 2
+
+
+def test_queue_item_view_default_arch_for_test_queue():
+    job = {"type": "integration-test", "repo": REPO, "branch": "dev"}
+    row = td.queue_item_view(job, "queue:test:arm64", "arm64", 1, "")
+    assert row["arch"] == "arm64"            # falls back to the queue's arch
+    assert row["ref"] == "dev"               # branch used when ref absent
+
+
+if __name__ == "__main__":
+    failed = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"ok {name}")
+            except AssertionError as e:
+                failed += 1
+                print(f"FAIL {name}: {e}")
+    if failed:
+        raise SystemExit(f"{failed} test(s) failed")
+    print("all training-dedupe tests passed")

--- a/ops-server/dashboard/training_dedupe.py
+++ b/ops-server/dashboard/training_dedupe.py
@@ -1,0 +1,70 @@
+"""Pure helpers for training-test enqueue dedupe + queued visibility.
+
+Dependency-free (no redis / httpx / fastapi) so that BOTH sides of the
+lifecycle import the *same* lock-key construction:
+
+  * dashboard/app.py  — SET NX at enqueue (dedupe) + queue:training listing
+  * workers/manager.py — DEL in _run_training_test's finally (release)
+
+and so the logic is unit-testable without a running Redis. See
+ISSUES-TO-SOLVE.md "BUG: training-test trigger — no queued feedback +
+duplicate enqueues".
+"""
+
+# Auto-expire backstop for the enqueue lock: a crashed / killed / lost run can
+# never wedge a repo forever. 2h comfortably exceeds the 90-min (5400s) hard
+# runner timeout in workers/manager.py:_run_training_test.
+TRAINING_LOCK_TTL_SECONDS = 7200
+
+
+def training_lock_key(repo: str, ref: str) -> str:
+    """Redis STRING key that dedupes one queued-or-running training-test per
+    ``(repo, ref)``.
+
+    Set ``NX EX TRAINING_LOCK_TTL_SECONDS`` at enqueue (dashboard/app.py) and
+    released in the worker's ``_run_training_test`` finally-block — same
+    lifecycle as ``running:lock:*``. Scoped by repo+ref so the nightly (which
+    enqueues *distinct* repos) is never blocked; MUST NOT lock on the bare
+    job type.
+    """
+    return f"training:lock:{repo}:{ref or ''}"
+
+
+def already_queued_response(repo: str, ref: str, holder: str = "") -> dict:
+    """Body returned (with HTTP 409) when a training-test for this ``(repo,
+    ref)`` is already queued or running, instead of pushing a duplicate.
+
+    ``holder`` is the ``requested_by`` recorded on the existing lock (best
+    effort — may be empty if the lock value was lost)."""
+    return {
+        "status": "already-queued",
+        "repo": repo,
+        "ref": ref,
+        "type": "training-test",
+        "requested_by": holder,
+        "detail": (
+            f"A training-test for {repo} @ {ref or 'catalog branch'} is "
+            f"already queued or running — not enqueuing a duplicate."
+        ),
+    }
+
+
+def queue_item_view(job: dict, queue_key: str, arch: str, position: int,
+                    requested_by: str) -> dict:
+    """Map one raw queued job (already JSON-decoded) to a dashboard queue row.
+
+    ``requested_by`` is passed in already masked/unmasked by the caller so
+    this helper stays free of the PII-masking dependency.
+    """
+    return {
+        "queue":        queue_key,
+        "arch":         job.get("arch", arch),
+        "position":     position,
+        "job_id":       job.get("job_id", ""),
+        "repo":         job.get("repo", ""),
+        "ref":          job.get("ref") or job.get("branch")
+                        or job.get("head_branch") or "main",
+        "type":         job.get("type", "integration-test"),
+        "queued_at":    job.get("timestamp") or job.get("queued_at"),
+        "requested_by": requested_by,
+    }

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -982,61 +982,79 @@ class WorkerManager:
         → terminate. We just stream its stdout to the livelog and record the
         verdict; the heavy lifting happens in the session on the AMD worker.
         """
+        # Shared, dependency-free helper — single source of truth for the
+        # enqueue-dedupe lock key (SET NX in dashboard/app.py's training-test
+        # trigger, DEL here). Lazy import mirrors the codespace_service import
+        # style below and keeps the dashboard package off the module-load path.
+        from dashboard.training_dedupe import training_lock_key
+
         repo = job["repo"]
         job_id = job["job_id"]
         ref = job.get("ref") or job.get("branch") or ""
         run_tag = job.get("nightly_run_id") or job.get("trigger") or "manual"
+        # Release the enqueue-dedupe lock (set at trigger time in app.py) on
+        # EVERY exit path — success, runner failure, timeout, or exception —
+        # so a fresh trigger for this repo+ref is accepted once this run ends.
+        # (EX auto-expires it too; this just frees it immediately.) The key
+        # MUST match the one app.py set — hence the shared helper.
+        lock_key = training_lock_key(repo, ref)
 
-        livelog_key = f"job:livelog:{job_id}"
-        header = (f"=== ACTION: training-test (end-to-end learner flow via the app path) ===\n"
-                  f"=== training-test for {repo} @ {ref or 'catalog branch'} ===\n")
-        await self.pool.set(livelog_key, header, ex=7200)
-
-        log_file = LOGS_DIR / f"{job_id}.log"
-        start_time = time.time()
-
-        runner = Path(__file__).resolve().parent.parent / "tools" / "training_test_runner.py"
-        cmd = [sys.executable, "-u", str(runner), "--repo", repo, "--run-tag", run_tag]
-        if ref:
-            cmd += ["--ref", ref]
-
-        env = dict(os.environ)
-        # Talk to the local dashboard directly — no nginx/oauth2-proxy hop.
-        env.setdefault("ORBITAL_API", "http://127.0.0.1:8080")
-
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            env=env,
-        )
-
-        # Provisioning alone can take ~15 min; full k8s labs with operator
-        # deploys run ~30-45 min through the exec API. Hard cap at 90 min.
-        timeout_s = int(os.environ.get("TRAINING_TEST_TIMEOUT_S", "5400"))
-        timed_out = False
         try:
-            output = await self._stream_to_redis(proc, livelog_key, timeout_s)
-        except asyncio.TimeoutError:
-            timed_out = True
-            output = f"(training-test timed out after {timeout_s}s — killing runner)"
-            try:
-                proc.kill()
-            except ProcessLookupError:
-                pass
-        await proc.wait()
+            livelog_key = f"job:livelog:{job_id}"
+            header = (f"=== ACTION: training-test (end-to-end learner flow via the app path) ===\n"
+                      f"=== training-test for {repo} @ {ref or 'catalog branch'} ===\n")
+            await self.pool.set(livelog_key, header, ex=7200)
 
-        log_file.write_text(self._mask_secrets(header + output + "\n"))
-        passed = (not timed_out) and proc.returncode == 0 \
-            and "TRAINING_TEST: SUCCESS" in output
-        return {
-            "job_type":         "training-test",
-            "exit_code":        proc.returncode if not timed_out else -1,
-            "duration_seconds": int(time.time() - start_time),
-            "passed":           passed,
-            "arch":             "amd64",
-            "log_file":         str(log_file),
-        }
+            log_file = LOGS_DIR / f"{job_id}.log"
+            start_time = time.time()
+
+            runner = Path(__file__).resolve().parent.parent / "tools" / "training_test_runner.py"
+            cmd = [sys.executable, "-u", str(runner), "--repo", repo, "--run-tag", run_tag]
+            if ref:
+                cmd += ["--ref", ref]
+
+            env = dict(os.environ)
+            # Talk to the local dashboard directly — no nginx/oauth2-proxy hop.
+            env.setdefault("ORBITAL_API", "http://127.0.0.1:8080")
+
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                env=env,
+            )
+
+            # Provisioning alone can take ~15 min; full k8s labs with operator
+            # deploys run ~30-45 min through the exec API. Hard cap at 90 min.
+            timeout_s = int(os.environ.get("TRAINING_TEST_TIMEOUT_S", "5400"))
+            timed_out = False
+            try:
+                output = await self._stream_to_redis(proc, livelog_key, timeout_s)
+            except asyncio.TimeoutError:
+                timed_out = True
+                output = f"(training-test timed out after {timeout_s}s — killing runner)"
+                try:
+                    proc.kill()
+                except ProcessLookupError:
+                    pass
+            await proc.wait()
+
+            log_file.write_text(self._mask_secrets(header + output + "\n"))
+            passed = (not timed_out) and proc.returncode == 0 \
+                and "TRAINING_TEST: SUCCESS" in output
+            return {
+                "job_type":         "training-test",
+                "exit_code":        proc.returncode if not timed_out else -1,
+                "duration_seconds": int(time.time() - start_time),
+                "passed":           passed,
+                "arch":             "amd64",
+                "log_file":         str(log_file),
+            }
+        finally:
+            try:
+                await self.pool.delete(lock_key)
+            except Exception as e:
+                log.warning("Could not release training lock %s: %s", lock_key, e)
 
     async def _run_deploy_ghpages(self, job: dict) -> dict:
         """Trigger deploy-ghpages.yaml via workflow_dispatch and stream progress.


### PR DESCRIPTION
## Problem

Double-clicking a **training-test** on the ops dashboard spawned duplicate runs. Training tests run max 2 concurrent (`training_semaphore = Semaphore(2)`); a 3rd trigger is enqueued to `queue:training` but **no `job:running:*` key exists until the manager picks it up**, so the click looks dead — users re-click, producing identical jobs (reproduced live: 3× live-debugger, 2 duplicates sitting in `queue:training`). Each duplicate burns a worker slot + a full ~8-min SRO session for nothing.

Two gaps (both ops-server, master-side): **no dedupe on trigger** and **no queued-state visibility**. Full RCA in `ISSUES-TO-SOLVE.md`.

## Fix (mirrors the existing integration-test `running:lock:*` pattern)

1. **Dedupe at enqueue** — `dashboard/app.py` training-test branch: `SET training:lock:{repo}:{ref} NX EX 7200` before the `rpush`. If the lock is held, return `409 {"status":"already-queued", ...}` instead of pushing a duplicate. Repo+ref scoped, so the nightly (distinct repos) is never blocked; the TTL auto-clears a crashed run.
2. **Release** — `workers/manager.py` `_run_training_test` DELs the lock in a `finally` on **every** exit path: success, runner failure, timeout, exception.
3. **Queued visibility** — `/api/queue/list` now includes `queue:training` (and the queue-delete endpoint accepts it), so waiting training-tests appear in the dashboard **Queued** panel and can be removed.
4. **Frontend** — the trigger button toasts `Queued` / `Already queued` from the response instead of silently returning.

A shared, dependency-free helper (`dashboard/training_dedupe.py`) is the single source of truth for the lock key — imported by **both** `app.py` (set) and `manager.py` (release) so the two sides can never drift — plus the queue-row mapping. Pure-logic tests in `dashboard/test_training_dedupe.py` (11 tests).

## Guardrails respected

- Does **not** touch worker-agent files (master-side only).
- Does **not** touch the `manager.py` `TRAINING_TEST: SUCCESS` success-string contract or the runner.
- Nightly scheduler enqueue path unchanged (it never took the lock; distinct repos = safe).

## Tests

`dashboard/` + `workers/` suite: **211 passed, 1 failed** — the single failure is the pre-existing, unrelated `test_app_deploy::test_register_buttons_have_no_guest_gate`. New `test_training_dedupe` (11) all green.

## Live verification

Deployed master-side (`ops-dashboard` + `ops-worker`). Rapid double-POST of the training-test trigger for the same repo+ref: 1st → `queued`, 2nd → `409 already-queued`; `queue:training` length went 0 → 1 (not 2). Test lock + entry cleaned up afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
