### PR TITLE
feat(tokens): mint one platform token per session instead of one per spec

### DIFF
--- a/ops-server/provisioning/dt_token_provisioner.py
+++ b/ops-server/provisioning/dt_token_provisioner.py
@@ -289,26 +289,46 @@ class PlatformTokenProvisioner:
         token_ids: list[str] = []
         errors: list[str] = []
         needs_ag = False
+        # ONE platform token per user carrying the union of every spec's scopes — not one per
+        # spec. Platform tokens are capped per OWNER (~50), and the owner is whoever owns the
+        # delivery tenant, so the budget to fit inside is one room's worth of learners. At the
+        # ~20-seat target three tokens a seat is 60 against a 50 ceiling — a full room breaches
+        # it with no leaks at all; one token a seat is 20. Exhausting this cap is also what
+        # broke every provision on 2026-08-08. Each spec's env_var still gets the value, so
+        # nothing downstream (functions.sh, labs) changes. Classic minting keeps one token per
+        # spec — classic apiTokens have no such cap.
+        all_scopes: list[str] = []
+        for spec in specs:
+            # Classic apiToken scopes are meaningless to the platform-token API — translate
+            # to platform scopes. activeGateTokenManagement.* has no platform equivalent →
+            # flags an ActiveGate-token pre-mint instead.
+            platform_scopes, spec_needs_ag = to_platform_scopes(spec.scopes)
+            needs_ag = needs_ag or spec_needs_ag
+            if not platform_scopes:
+                log.info("Spec '%s' has no platform scopes after translation — contributes none", spec.name_suffix)
+            all_scopes.extend(platform_scopes)
+        union_scopes = sorted(set(all_scopes))
         async with httpx.AsyncClient(timeout=20) as client:
-            for spec in specs:
-                # Classic apiToken scopes are meaningless to the platform-token API — translate
-                # to platform scopes. activeGateTokenManagement.* has no platform equivalent →
-                # flags an ActiveGate-token pre-mint instead.
-                platform_scopes, spec_needs_ag = to_platform_scopes(spec.scopes)
-                needs_ag = needs_ag or spec_needs_ag
-                if not platform_scopes:
-                    log.info("Spec '%s' has no platform scopes after translation — skipping platform token", spec.name_suffix)
-                    continue
-                name = f"{prefix}-{spec.name_suffix}"[:100]
-                payload = {"name": name, "scope": platform_scopes, "resource": resource,
+            if union_scopes:
+                name = f"{prefix}-session"[:100]
+                payload = {"name": name, "scope": union_scopes, "resource": resource,
                            "tags": ["enablement", repo_short], "expirationDate": expires_iso}
                 try:
                     r = await client.post(self._tokens_url, headers=headers, json=payload)
                     r.raise_for_status()
                     data = r.json()
-                    env[spec.env_var] = data["token"]
-                    token_ids.append(data.get("tokenId") or data.get("id"))
-                    log.info("Created platform token '%s' (id=%s, scopes=%s)", name, token_ids[-1], platform_scopes)
+                    token = data["token"]
+                    for spec in specs:
+                        env[spec.env_var] = token
+                    # Only one id is appended now, so a None here would be the whole revoke
+                    # list — the token would then be unreclaimable and sit on the cap.
+                    token_id = data.get("tokenId") or data.get("id")
+                    if token_id:
+                        token_ids.append(token_id)
+                    else:
+                        errors.append(f"platform token '{name}': created but returned no id (cannot be revoked)")
+                    log.info("Created platform token '%s' (id=%s, env=%s, scopes=%s)",
+                             name, token_id, [s.env_var for s in specs], union_scopes)
                 except httpx.HTTPStatusError as exc:
                     errors.append(f"platform token '{name}': HTTP {exc.response.status_code} — {exc.response.text[:200]}")
         # An operator spec that needed activeGateTokenManagement → pre-mint an ActiveGate token

--- a/ops-server/provisioning/test_dt_token_provisioner.py
+++ b/ops-server/provisioning/test_dt_token_provisioner.py
@@ -225,16 +225,23 @@ def test_platform_token_create_uses_account_api_and_env_resource():
         res = asyncio.run(_pt().create_tokens("dynatrace-wwse/enablement-kubernetes-101", "devlove@dynatracelabs.com", SPECS))
     finally:
         restore()
-    # tokens minted into env vars
+    # ONE token per user (platform tokens are capped per owner across accounts), and every
+    # spec's env var carries that same value.
     assert res.env["DT_OPERATOR_TOKEN"].startswith("dt0s16.")
-    assert res.env["DT_INGEST_TOKEN"].startswith("dt0s16.")
-    assert len(res.token_ids) == 2
+    assert res.env["DT_INGEST_TOKEN"] == res.env["DT_OPERATOR_TOKEN"]
+    assert len(res.token_ids) == 1
     # create POSTs hit the account platform-tokens endpoint with the env URN as resource
     creates = [c for c in calls if c[0] == "POST" and c[1].endswith("/platform-tokens")]
-    assert creates and all("/iam/v1/accounts/ceae4b9d/platform-tokens" in c[1] for c in creates)
+    assert len(creates) == 1
+    assert all("/iam/v1/accounts/ceae4b9d/platform-tokens" in c[1] for c in creates)
     body = creates[0][2]["json"]
     assert body["resource"] == ["urn:dtenvironment:ydi9582h"]
     assert "expirationDate" in body and isinstance(body["scope"], list)
+    # name keeps the enbl-{repo}-{user} prefix the sweeper's live-allowlist matches on
+    assert body["name"] == "enbl-enablement-kubernete-devlove-session"
+    # scopes are the UNION of both specs, deduped + sorted
+    assert "storage:metrics:write" in body["scope"] and "settings:objects:write" in body["scope"]
+    assert body["scope"] == sorted(set(body["scope"]))
     # bearer fetched with platform-token scope + account resource
     tok = [c for c in calls if c[1].endswith("/sso/oauth2/token")][0][2]["data"]
     assert "platform-token:tokens:write" in tok["scope"]


### PR DESCRIPTION
## What

`PlatformTokenProvisioner.create_tokens` now unions every spec's translated scopes into a **single** platform token per session, instead of one token per spec. Each spec's `env_var` still receives that one value, so nothing downstream (`functions.sh`, the labs) changes.

The name stays `enbl-{repo}-{user}-session`, so the dashboard's orphan sweep — which matches on the `enbl-{repo}-{user}` prefix — is unaffected.

## Why

Platform tokens are capped **per owner** (~50), and the owner is whoever owns the delivery tenant. At the ~20-seat GA target, three tokens a seat is 60 against a 50 ceiling — a full room breaches it with no leaks at all. One token a seat is 20.

Exhausting this cap is what broke every provision on 2026-08-08, surfacing minutes later as the unrelated-looking `DT_OPERATOR_TOKEN is required but not set`.

## Also

- A single token removes the partial-mint failure mode: there is no longer a half-created set to roll back.
- **The token id is now guarded before it is recorded.** With one token per session a missing id would have been the entire revoke list, leaving the token unreclaimable and permanent against the cap. It is reported as an error instead.

## Scope

This only takes effect for tenants Orbital mints for — those with a `MINT_*_<DOMAIN>` group, which today is sprint. COE and SRO have no such group; the app mints there with its own client, and the matching app-side change is dynatrace-app-enablements#70.

## Test

`11 passed` (`provisioning/`).

Deploying this needs the ops-server three-place rollout (master + both workers + restart), so it is deliberately not bundled with the app deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
