### PR TITLE
fix(codespaces): install sshd only for Orbital-launched Codespaces

### DIFF
--- a/.devcontainer/test/unit/test_install_codespace_ssh.bats
+++ b/.devcontainer/test/unit/test_install_codespace_ssh.bats
@@ -87,3 +87,19 @@ source_functions() {
   [[ "$output" == *'INSTANTIATION_TYPE'* ]]
   [[ "$output" == *'orbital_codespaces'* ]]
 }
+
+@test "installCodespaceSSH: a plain github-codespaces Codespace never triggers it" {
+  # Regression guard. The gate once read `orbital_codespaces|github-codespaces)`,
+  # which made every hand-opened Codespace run a 7-minute apt-get it cannot use.
+  # The condition itself must not mention github-codespaces.
+  run grep -B2 "    installCodespaceSSH" "$FAKE_REPO/.devcontainer/util/functions.sh"
+  [[ "$output" != *'github-codespaces'* ]]
+}
+
+@test "installCodespaceSSH: apt-get runs with --no-install-recommends" {
+  # openssh-server's Recommends line (default-logind|logind|libpam-systemd, …)
+  # drags in systemd, systemd-sysv, systemd-resolved and dbus: 7 minutes, a
+  # rewritten /etc/nsswitch.conf and a replaced /sbin/init inside the devcontainer.
+  run grep -A3 "apt-get install" "$FAKE_REPO/.devcontainer/util/functions.sh"
+  [[ "$output" == *'--no-install-recommends'* ]]
+}

--- a/.devcontainer/test/unit/test_instantiation_type.bats
+++ b/.devcontainer/test/unit/test_instantiation_type.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+# Tests for INSTANTIATION_TYPE detection (variables.sh).
+#
+# The tricky case is telling an Orbital-orchestrated Codespace apart from one the
+# learner opened by hand on the same repo. ORBITAL_ENVIRONMENT is a repo-scoped
+# USER Codespaces secret, so it survives the session that set it and cannot, on its
+# own, answer that question. variables.sh therefore treats it as a hint and
+# confirms it against Orbital's GET /api/codespace/orbital/{name}.
+#
+# curl is stubbed throughout — no test here touches the network.
+
+setup() {
+  export TEST_DIR="$(mktemp -d)"
+  export HOME="$TEST_DIR/home"
+  mkdir -p "$HOME"
+
+  export FAKE_REPO="$TEST_DIR/workspaces/test-enablement"
+  mkdir -p "$FAKE_REPO/.devcontainer/util"
+  export REPO_PATH="$FAKE_REPO"
+  export RepositoryName="test-enablement"
+
+  export VARS="$BATS_TEST_DIRNAME/../../util/variables.sh"
+
+  # Pre-set so variables.sh skips its `git remote get-url origin` probe: the fake
+  # repo is not a git checkout, and bats runs the body under `set -e`.
+  export GITHUB_REPOSITORY="dynatrace-wwse/test-enablement"
+
+  # Point the confirmation at nothing real; the stub below answers instead.
+  export ORBITAL_BASE_URL="http://orbital.invalid"
+  export CURL_LOG="$TEST_DIR/curl.log"
+  : > "$CURL_LOG"
+
+  # Neutral starting env — bats inherits the developer's shell.
+  unset CODESPACES ORBITAL_ENVIRONMENT CODESPACE_NAME REMOTE_CONTAINERS \
+        GITHUB_WORKFLOW GITHUB_STEP_SUMMARY INSTANTIATION_TYPE
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# variables.sh probes the cluster with `docker inspect` / `kubectl cluster-info`
+# in plain command substitutions. Those pre-date this file and are not strict-mode
+# safe, and bats runs every test body under `set -e` — so source with errexit off.
+# The detection logic under test is asserted on the exported result, not on $?.
+source_vars() {
+  set +e
+  source "$VARS"
+  set -e
+  return 0
+}
+
+# Stub curl: records the URL it was asked for, prints $CURL_BODY, exits $CURL_RC.
+stub_curl() {
+  export CURL_BODY="${1-}"
+  export CURL_RC="${2-0}"
+  curl() {
+    echo "$*" >> "$CURL_LOG"
+    [ -n "$CURL_BODY" ] && printf '%s' "$CURL_BODY"
+    return "$CURL_RC"
+  }
+  export -f curl
+}
+
+@test "plain Codespace (no marker) is github-codespaces and never calls Orbital" {
+  stub_curl '{"orbital":false}' 0
+  export CODESPACES=true CODESPACE_NAME="fluffy-space-guacamole"
+  source_vars
+  [ "$INSTANTIATION_TYPE" = "github-codespaces" ]
+  [ ! -s "$CURL_LOG" ]
+}
+
+@test "Orbital Codespace: marker confirmed → orbital_codespaces" {
+  stub_curl '{"orbital":true}' 0
+  export CODESPACES=true ORBITAL_ENVIRONMENT=true CODESPACE_NAME="fluffy-space-guacamole"
+  source_vars
+  [ "$INSTANTIATION_TYPE" = "orbital_codespaces" ]
+  grep -q "fluffy-space-guacamole" "$CURL_LOG"
+}
+
+@test "stale marker: Orbital says not mine → downgraded to github-codespaces" {
+  # The regression this whole change exists for: a hand-opened Codespace on a repo
+  # that Orbital used once before must not claim to be Orbital-orchestrated.
+  stub_curl '{"orbital":false}' 0
+  export CODESPACES=true ORBITAL_ENVIRONMENT=true CODESPACE_NAME="stale-marker-codespace"
+  source_vars
+  [ "$INSTANTIATION_TYPE" = "github-codespaces" ]
+}
+
+@test "ops server unreachable → keeps orbital_codespaces (fail-safe direction)" {
+  # Wrongly downgrading a real Orbital session breaks the in-app terminal for a
+  # whole training; wrongly keeping the marker costs one small apt-get.
+  stub_curl '' 7
+  export CODESPACES=true ORBITAL_ENVIRONMENT=true CODESPACE_NAME="unreachable-codespace"
+  source_vars
+  [ "$INSTANTIATION_TYPE" = "orbital_codespaces" ]
+}
+
+@test "verdict is cached per Codespace — variables.sh is sourced on every terminal open" {
+  stub_curl '{"orbital":false}' 0
+  export CODESPACES=true ORBITAL_ENVIRONMENT=true CODESPACE_NAME="cached-codespace"
+  source_vars
+  [ "$INSTANTIATION_TYPE" = "github-codespaces" ]
+  [ "$(wc -l < "$CURL_LOG")" -eq 1 ]
+
+  unset INSTANTIATION_TYPE
+  source_vars
+  [ "$INSTANTIATION_TYPE" = "github-codespaces" ]
+  [ "$(wc -l < "$CURL_LOG")" -eq 1 ]   # answered from cache, no second 5s call
+}
+
+@test "Sysbox/Orbital job (marker, not a Codespace) stays orbital and skips the probe" {
+  stub_curl '{"orbital":false}' 0
+  export ORBITAL_ENVIRONMENT=true
+  source_vars
+  [ "$INSTANTIATION_TYPE" = "orbital" ]
+  [ ! -s "$CURL_LOG" ]
+}
+
+@test "local container: no marker, no Codespaces" {
+  stub_curl '{"orbital":false}' 0
+  source_vars
+  [ "$INSTANTIATION_TYPE" = "local-docker-container" ]
+  [ ! -s "$CURL_LOG" ]
+}

--- a/.devcontainer/util/functions.sh
+++ b/.devcontainer/util/functions.sh
@@ -373,18 +373,19 @@ setUpTerminal(){
   # MCP is opt-in — not auto-configured. Users can type 'enableMCP' to set it up.
   printInfo "Type 'enableMCP' to connect VS Code to a Dynatrace MCP Server"
 
-  # Codespaces need an SSH server so `gh codespace ssh` works — and the Orbital
-  # relay (Enablement App terminal/exec) depends on it. The stock image ships
-  # none. Install it for EVERY Codespace, not just orbital_codespaces: the
-  # ORBITAL_ENVIRONMENT secret occasionally fails to surface in the post-create
-  # environment (GitHub secret-injection flake), which used to silently skip
-  # sshd and permanently break the in-app terminal. Local, dev-container and
-  # Sysbox/orbital instantiations are left untouched.
-  case "$INSTANTIATION_TYPE" in
-    orbital_codespaces|github-codespaces)
-      installCodespaceSSH
-      ;;
-  esac
+  # Only an Orbital-orchestrated Codespace needs an SSH server: the Enablement App
+  # relays its terminal in over `gh codespace ssh`, and the stock image ships no
+  # sshd. A plain Codespace opened from GitHub must NOT pay for that install, and
+  # local, dev-container and Sysbox/orbital instantiations never needed it.
+  #
+  # This used to also fire for `github-codespaces`, as belt-and-braces against
+  # GitHub failing to surface the ORBITAL_ENVIRONMENT secret in the post-create
+  # environment. That belt is now in variables.sh, which reads the canonical
+  # /workspaces/.codespaces/shared/.env-secrets *before* computing the type — so
+  # the braces here only cost every manual Codespace an apt-get it cannot use.
+  if [ "$INSTANTIATION_TYPE" = "orbital_codespaces" ]; then
+    installCodespaceSSH
+  fi
 }
 
 installCodespaceSSH() {
@@ -396,8 +397,17 @@ installCodespaceSSH() {
     printInfo "openssh-server already present at /usr/sbin/sshd — skipping install"
   else
     printInfo "openssh-server not found — installing via apt-get"
+    # --no-install-recommends is load-bearing, not tidiness. openssh-server's hard
+    # Depends are all small and mostly already in the image; its *Recommends* line
+    # ("default-logind | logind | libpam-systemd, ncurses-term, xauth, ssh-import-id")
+    # drags in systemd, systemd-sysv, systemd-resolved, systemd-timesyncd and dbus.
+    # That took 7 minutes, rewrote /etc/nsswitch.conf, tried to take over
+    # /etc/resolv.conf and replaced /sbin/init inside the devcontainer. Nothing here
+    # needs a logind session: the Codespaces agent starts sshd itself, we only have
+    # to put the binary and its host keys on disk.
     sudo apt-get update -qq \
-      && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq openssh-server \
+      && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+           --no-install-recommends openssh-server \
       || printWarn "Failed to install openssh-server"
   fi
 

--- a/.devcontainer/util/variables.sh
+++ b/.devcontainer/util/variables.sh
@@ -92,6 +92,53 @@ elif [[ -n $GITHUB_WORKFLOW ]] || [[ -n $GITHUB_STEP_SUMMARY ]]; then
 else
   INSTANTIATION_TYPE="local-docker-container"
 fi
+
+# Orbital ops server — overridable so a dev/staging deployment can be pointed at.
+export ORBITAL_BASE_URL="${ORBITAL_BASE_URL:-https://autonomous-enablements.whydevslovedynatrace.com}"
+
+# Confirm "orbital_codespaces" against Orbital itself.
+#
+# ORBITAL_ENVIRONMENT is a *user* Codespaces secret scoped to the repo, so it
+# outlives the session that set it: after one app-launched training, every
+# Codespace the learner later opens BY HAND on that repo also sees the secret and
+# would claim to be Orbital-orchestrated. The secret cannot be bound to a single
+# Codespace — but Orbital knows exactly which Codespace names it created
+# (job:running:{name}), so ask it about this one.
+#
+# Fail-safe direction: only an explicit "not mine" downgrades the type. Ops server
+# unreachable, no curl, no CODESPACE_NAME, unparseable answer → stay
+# orbital_codespaces. A stale marker then costs one small apt-get, whereas wrongly
+# downgrading a real Orbital session kills the in-app terminal for that training.
+#
+# The verdict is cached per Codespace: variables.sh is sourced on every terminal
+# open, and no shell may hang on a 5s HTTP call more than once.
+if [ "$INSTANTIATION_TYPE" = "orbital_codespaces" ] && [ -n "${CODESPACE_NAME:-}" ]; then
+  _orb_cache="${HOME}/.cache/dt-framework/orbital-codespace.${CODESPACE_NAME}"
+  if [ -r "$_orb_cache" ]; then
+    _orb_verdict=$(cat "$_orb_cache" 2>/dev/null)
+  else
+    _orb_verdict="1"   # default: trust the marker
+    if command -v curl >/dev/null 2>&1; then
+      # `|| true`: a non-zero curl must leave the fail-safe default in place, not
+      # abort a caller that sources this under `set -e`.
+      _orb_answer=$(curl -fsS -m 5 \
+        "${ORBITAL_BASE_URL}/api/codespace/orbital/${CODESPACE_NAME}" 2>/dev/null || true)
+      case "$_orb_answer" in
+        *'"orbital":false'*|*'"orbital": false'*) _orb_verdict="0" ;;
+      esac
+      unset _orb_answer
+    fi
+    # Cache every completed attempt, including the fail-safe one, so the 5s
+    # timeout is paid at most once per Codespace.
+    mkdir -p "$(dirname "$_orb_cache")" 2>/dev/null \
+      && printf '%s' "$_orb_verdict" > "$_orb_cache" 2>/dev/null
+  fi
+  if [ "$_orb_verdict" = "0" ]; then
+    INSTANTIATION_TYPE="github-codespaces"
+  fi
+  unset _orb_cache _orb_verdict
+fi
+
 export INSTANTIATION_TYPE=$INSTANTIATION_TYPE
 
 if [ -e "$COUNT_FILE" ]; then

--- a/docs/instantiation-types.md
+++ b/docs/instantiation-types.md
@@ -207,6 +207,47 @@ Key points:
 `getAppURL()` and `registerApp()` use to build the wildcard subdomain URL instead of
 the sslip.io or Codespaces URL.
 
+#### Telling an Orbital Codespace from a hand-opened one
+
+A Codespace can be started two ways, and only one of them wants an SSH server:
+
+| Launch path | `ORBITAL_ENVIRONMENT` | `INSTANTIATION_TYPE` | sshd installed |
+|---|---|---|---|
+| GitHub UI / `gh codespace create`, repo Orbital never touched | absent | `github-codespaces` | no |
+| GitHub UI, repo Orbital used **before** | stale `true` → confirmed away | `github-codespaces` | no |
+| Enablement App → Orbital | `true` | `orbital_codespaces` | yes |
+| Sysbox job / local / dev container / CI | n/a | `orbital` / `local-docker-container` / `remote-container` / `github-workflow` | no |
+
+The subtlety is row 2. Orbital passes its signal by setting `ORBITAL_ENVIRONMENT`
+as a **user Codespaces secret scoped to the repo** — the only channel GitHub offers
+for getting a value into a Codespace it is about to create. A secret cannot be bound
+to one Codespace, so on its own the marker is sticky: after a single app-launched
+training, every Codespace the learner later opens by hand on that repo sees it too.
+
+Two mechanisms keep row 2 honest:
+
+1. **Confirmation.** `variables.sh` treats the secret as a hint and asks Orbital
+   about *this* Codespace: `GET /api/codespace/orbital/$CODESPACE_NAME` →
+   `{"orbital": true|false}`, answered from the `job:running:{name}` record Orbital
+   writes for every Codespace it creates. Only an explicit `false` downgrades the
+   type — an unreachable ops server, a missing `curl` or an unparseable answer keeps
+   `orbital_codespaces`, because a stale marker costs one small `apt-get` while a
+   wrong downgrade kills the in-app terminal for a whole training. The verdict is
+   cached under `~/.cache/dt-framework/orbital-codespace.$CODESPACE_NAME`, so the
+   5-second call is paid at most once per Codespace and not on every terminal open.
+   Point it elsewhere with `ORBITAL_BASE_URL`.
+2. **Cleanup.** `_clear_orbital_marker()` un-scopes the secret from the repo when
+   Orbital deletes or reaps the Codespace, so the marker does not outlive the
+   session that needed it.
+
+`setUpTerminal` installs sshd for `orbital_codespaces` only. The install uses
+`apt-get --no-install-recommends`: `openssh-server` *recommends*
+`default-logind | logind | libpam-systemd`, which pulls systemd, systemd-sysv,
+systemd-resolved, systemd-timesyncd and dbus into the devcontainer — a 7-minute
+install that rewrites `/etc/nsswitch.conf` and replaces `/sbin/init`. None of it is
+needed: the Codespaces agent starts sshd itself, the framework only puts the binary
+and its host keys on disk.
+
 ### 5. 🧑‍🚀 Codespaces launched from the Enablement App (planned)
 
 The [Enablement App](enablement-app.md) lets a learner launch a training from inside their

--- a/ops-server/dashboard/codespace_service.py
+++ b/ops-server/dashboard/codespace_service.py
@@ -99,6 +99,40 @@ def _tenant_meta(dt_environment: str) -> tuple[str, str]:
     return tenant_id, stage
 
 
+async def _clear_orbital_marker(dtUser: str, repo: str) -> None:
+    """Un-scope the ORBITAL_ENVIRONMENT Codespaces secret from ``repo``.
+
+    ``provision()`` sets it as a *user* secret scoped to the repo, because that is
+    the only channel GitHub gives us for passing a signal into a Codespace. But a
+    Codespaces secret cannot be bound to a single Codespace: left behind, it makes
+    every Codespace the learner later opens BY HAND on that repo report
+    ``INSTANTIATION_TYPE=orbital_codespaces`` and install an sshd it never uses.
+
+    Best-effort — a failure here must never break a terminate. ``variables.sh``
+    also confirms the marker against ``/api/codespace/orbital/{name}``, so a leaked
+    secret is a slow path, not a wrong answer.
+    """
+    if not dtUser or not repo:
+        return
+    try:
+        repo_id = (json.loads(await _gh(dtUser, "api", f"repos/{repo}")) or {}).get("id")
+        if not repo_id:
+            return
+        await _gh(dtUser, "api", "-X", "DELETE",
+                  f"/user/codespaces/secrets/ORBITAL_ENVIRONMENT/repositories/{repo_id}")
+        log.info("Cleared ORBITAL_ENVIRONMENT scope user=%s repo=%s", dtUser, repo)
+    except Exception as exc:
+        # Removing the only selected repo can be refused; drop the whole secret then.
+        try:
+            await _gh(dtUser, "api", "-X", "DELETE",
+                      "/user/codespaces/secrets/ORBITAL_ENVIRONMENT")
+            log.info("Deleted ORBITAL_ENVIRONMENT secret user=%s (scope removal failed: %s)",
+                     dtUser, exc)
+        except Exception as exc2:
+            log.warning("Could not clear ORBITAL_ENVIRONMENT for %s on %s: %s / %s",
+                        dtUser, repo, exc, exc2)
+
+
 async def delete_codespace(dtUser: str, name: str) -> None:
     """Delete a learner's Codespace, clear its running record, and DESTROY the learner's
     stored GitHub credential — the token is kept (encrypted, short-lived) only to spin +
@@ -109,6 +143,9 @@ async def delete_codespace(dtUser: str, name: str) -> None:
     meta = await _pool().hgetall(f"job:running:{name}")
     repo, machine = meta.get("repo", ""), meta.get("machine", "")
     await _gh(dtUser, "api", "-X", "DELETE", f"user/codespaces/{name}")  # needs the token
+    # Needs the credential, so it has to happen before the token is destroyed below —
+    # otherwise the marker stays on the learner's account forever.
+    await _clear_orbital_marker(dtUser, repo)
     await _pool().delete(f"job:running:{name}")
     await _pool().delete(f"gh:token:{dtUser}")  # destroy the credential now the Codespace is gone
     log.info("Codespace deleted name=%s user=%s repo=%s machine=%s (credential destroyed)",
@@ -143,6 +180,8 @@ async def reap_codespace_if_idle(dtUser: str, name: str, max_idle_min: int | Non
     if reason:
         try:
             await _gh(dtUser, "api", "-X", "DELETE", f"user/codespaces/{name}")
+            repo = await _pool().hget(f"job:running:{name}", "repo") or ""
+            await _clear_orbital_marker(dtUser, repo)  # before the credential goes
             await _pool().delete(f"gh:token:{dtUser}")  # credential dies with the Codespace
             log.info("Reaped Codespace name=%s user=%s reason=%s", name, dtUser, reason)
         except Exception as exc:
@@ -216,6 +255,24 @@ async def list_machines(repo: str, dtUser: str = "", ref: str | None = None):
     return {"machines": data.get("machines", data)}
 
 
+@router.get("/api/codespace/orbital/{name}")
+async def is_orbital(name: str):
+    """Authoritative answer to "did Orbital create this Codespace?".
+
+    The framework's ``variables.sh`` calls this from *inside* a Codespace to confirm
+    a possibly-stale ``ORBITAL_ENVIRONMENT`` secret before it settles on
+    ``INSTANTIATION_TYPE=orbital_codespaces`` (and installs an sshd for the terminal
+    relay). ``provision()`` writes ``job:running:{name}`` for every Codespace it
+    creates, so its existence is the ground truth the secret cannot provide.
+
+    Unauthenticated on purpose: the caller is a bare post-create shell with no
+    Orbital credential, and the response is one boolean about a name the caller
+    already knows. Nothing is created, mutated, or disclosed — a wrong guess at a
+    Codespace name only ever gets ``false``.
+    """
+    return {"orbital": bool(await _pool().exists(f"job:running:{name}"))}
+
+
 @router.post("/api/codespace/provision")
 async def provision(body: ProvisionBody):
     """Set the 3 DT_* values as the learner's repo-scoped Codespaces secrets, then create a
@@ -233,6 +290,10 @@ async def provision(body: ProvisionBody):
         # Signals to the framework (variables.sh) that this Codespace is orchestrated
         # by Orbital → INSTANTIATION_TYPE=orbital_codespaces → setUpTerminal installs
         # the SSH server so the in-app terminal relay can attach.
+        # This is a repo-scoped USER secret — it cannot be bound to one Codespace, so
+        # it is only a *hint*: variables.sh confirms it against
+        # GET /api/codespace/orbital/{name}, and _clear_orbital_marker() un-scopes it
+        # when the Codespace is deleted or reaped.
         "ORBITAL_ENVIRONMENT": "true",
     }
     for name, value in secrets_map.items():


### PR DESCRIPTION
Opening a Codespace by hand from GitHub ran a 7-minute `apt-get` that the Codespace can never use, and on repos Orbital had touched before it also mislabelled the environment as Orbital-orchestrated.

## Two independent causes

**1. The gate was too wide.** `setUpTerminal` read `orbital_codespaces|github-codespaces)`. It was widened in `d8ac6c7` (2026-07-03) as belt-and-braces against GitHub failing to surface the `ORBITAL_ENVIRONMENT` secret in post-create. That belt already exists in the *other half* of the same commit — `variables.sh` reads the canonical `/workspaces/.codespaces/shared/.env-secrets` before computing the type — so the braces only cost every manual Codespace an install it cannot use.

**2. The Orbital marker is sticky.** `ORBITAL_ENVIRONMENT` is a repo-scoped **user** Codespaces secret. `provision()` sets it; nothing ever removed it. Reproduced on `dynatrace-wwse/enablement-kubernetes-101`:

```
$ echo $INSTANTIATION_TYPE      → orbital_codespaces     # in a hand-opened Codespace
$ gh api /user/codespaces/secrets/ORBITAL_ENVIRONMENT/repositories
  dynatrace-wwse/enablement-kubernetes-101
```

## Why the install was so heavy

`openssh-server`'s hard `Depends` are small and mostly already in the image. Its `Recommends: default-logind | logind | libpam-systemd, …` is what pulls `systemd`, `systemd-sysv`, `systemd-resolved`, `systemd-timesyncd` and `dbus`. Measured in a real creation log: **13:02:36 → 13:09:41 (7m05s)**, plus a rewritten `/etc/nsswitch.conf`, an attempted takeover of `/etc/resolv.conf` and a replaced `/sbin/init`. `--no-install-recommends` removes all of it; the Codespaces agent starts sshd itself, so only the binary and host keys are needed.

## Changes

- `functions.sh` — gate on `orbital_codespaces` only.
- `functions.sh` — `apt-get --no-install-recommends`.
- `variables.sh` — treat the secret as a *hint* and confirm it against `GET /api/codespace/orbital/$CODESPACE_NAME`. Only an explicit "not mine" downgrades; an unreachable ops server keeps `orbital_codespaces` (a stale marker costs one small apt-get, a wrong downgrade kills the in-app terminal for a whole training). Verdict cached per Codespace so no terminal open pays the 5s call twice. `ORBITAL_BASE_URL` overridable.
- `codespace_service.py` — new `GET /api/codespace/orbital/{name}`, answered from the `job:running:{name}` record `provision()` already writes.
- `codespace_service.py` — `_clear_orbital_marker()` un-scopes the secret on delete and on idle-reap.
- Tests + docs.

## Resulting matrix

| Launch path | `ORBITAL_ENVIRONMENT` | `INSTANTIATION_TYPE` | sshd |
|---|---|---|---|
| GitHub UI, repo Orbital never touched | absent | `github-codespaces` | no |
| GitHub UI, repo Orbital used before | stale `true` → confirmed away | `github-codespaces` | no |
| Enablement App → Orbital | `true` | `orbital_codespaces` | yes |
| Sysbox / local / dev container / CI | n/a | `orbital` / `local-docker-container` / … | no |

## Verification

- `bats .devcontainer/test/unit/` — **167/167 pass** (7 new detection cases + 2 new gate cases).
- Live Codespace runs on a test branch of `enablement-kubernetes-101` pinned to this branch: plain launch, stale-marker launch, and an Orbital launch. Results posted below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)