### PR TITLE
fix(orbital): stop the reconciler reaping every Codespace record

### DIFF
--- a/ops-server/dashboard/codespace_service.py
+++ b/ops-server/dashboard/codespace_service.py
@@ -420,6 +420,15 @@ async def _append_creation_log(dtUser: str, name: str) -> None:
     actually happened while the repo was provisioning. Fetched once, when the
     Codespace first reaches ready — guarded by a flag on the running hash."""
     key = f"job:running:{name}"
+    # Never resurrect a record that is gone. Redis `hset` CREATES the key, so a
+    # status poll landing after the session was terminated or reaped rebuilt a
+    # partial, TTL-less job:running hash out of the flag writes below — which
+    # then flapped against the master reconciler (recreate → reap → recreate)
+    # and made /api/codespace/orbital/{name} answer true or false depending on
+    # which side of the 15 s loop the question arrived. If the session is over
+    # there is nothing to fetch anyway.
+    if not await _pool().exists(key):
+        return
     if await _pool().hget(key, "creation_log_fetched"):
         return
     # Mark first (best-effort at-most-once; a failed fetch clears the flag below

--- a/ops-server/dashboard/test_codespace_record.py
+++ b/ops-server/dashboard/test_codespace_record.py
@@ -1,0 +1,76 @@
+"""job:running:{codespace} must never be resurrected by a status poll.
+
+Redis `hset` CREATES a missing key. `_append_creation_log` writes flags
+(`creation_log_fetched`, `ssh_ready`, `recovery`) on that hash and is fired
+from `session_status` with `asyncio.ensure_future` whenever GitHub reports the
+Codespace Available — including long after the session was terminated or
+reaped. Without a guard those writes rebuilt a partial, TTL-less record, which
+then flapped against the master reconciler (recreate → reap → recreate) and
+made /api/codespace/orbital/{name} answer true or false depending on which side
+of the 15 s loop the framework's post-create happened to ask on.
+
+Regression cover for 2026-08-10. See also workers/test_dead_worker_candidate.py.
+
+Run: /home/ops/ops-venv/bin/python -m pytest dashboard/test_codespace_record.py -q
+"""
+
+import asyncio
+
+import pytest
+
+from dashboard import codespace_service as cs
+
+
+class _Pool:
+    """Minimal async Redis stand-in that records every mutation."""
+
+    def __init__(self, existing: bool, fields: dict | None = None):
+        self._existing = existing
+        self._fields = dict(fields or {})
+        self.writes: list[tuple] = []
+
+    async def exists(self, key):
+        return 1 if self._existing else 0
+
+    async def hget(self, key, field):
+        return self._fields.get(field)
+
+    async def hset(self, key, field=None, value=None, mapping=None):
+        self.writes.append(("hset", key, field, value, mapping))
+        return 1
+
+    async def hdel(self, key, *fields):
+        self.writes.append(("hdel", key, fields))
+        return 1
+
+
+def _run(pool, monkeypatch, name="didactic-goggles-abc"):
+    monkeypatch.setattr(cs, "_pool", lambda: pool)
+    asyncio.run(cs._append_creation_log("someone@example.com", name))
+
+
+def test_no_writes_when_the_record_is_gone(monkeypatch):
+    pool = _Pool(existing=False)
+    _run(pool, monkeypatch)
+    assert pool.writes == [], f"resurrected job:running with {pool.writes}"
+
+
+def test_no_writes_when_already_fetched(monkeypatch):
+    pool = _Pool(existing=True, fields={"creation_log_fetched": "1"})
+    _run(pool, monkeypatch)
+    assert pool.writes == []
+
+
+def test_live_record_is_marked_before_fetching(monkeypatch):
+    """A tracked, unfetched session still takes the at-most-once flag — the
+    guard must not disable the normal path."""
+    pool = _Pool(existing=True)
+    # Fail the token lookup so the function stops right after the flag write
+    # instead of shelling out to `gh` in a unit test.
+    async def _boom(*a, **k):
+        raise RuntimeError("no token in tests")
+    monkeypatch.setattr(cs, "get_user_token", _boom)
+    monkeypatch.setattr(cs, "_pool", lambda: pool)
+    with pytest.raises(RuntimeError):
+        asyncio.run(cs._append_creation_log("someone@example.com", "cs-live"))
+    assert ("hset", "job:running:cs-live", "creation_log_fetched", "1", None) in pool.writes

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -85,6 +85,31 @@ APP_PROXY_PORT_COUNT = int(os.environ.get("APP_PROXY_PORT_COUNT", "100"))
 _MASTER_K3D_LB_PORT = 30080
 
 
+def _dead_worker_candidate(rec: dict, job_id: str, active_jobs) -> bool:
+    """Could this ``job:running`` record belong to a worker that no longer exists?
+
+    Pure and cheap on purpose: the terminate reconciler calls it for every key in
+    a 15 s scan, and only asks Redis whether ``worker:{id}`` is registered when
+    this says yes — the keyspace scan already dominates our Redis budget.
+
+    A **Codespace is never a candidate**, whatever its ``worker_id`` says.
+    ``codespace_service.provision()`` stores ``worker_id="github-codespaces"`` as
+    a display label for the Running tab; no agent ever registers that worker, so
+    without this guard every Codespace record was reaped seconds after it was
+    written (measured 2026-08-10: provisioned 16:15:38, reaped 16:15:46). The
+    record is load-bearing — losing it 404s the in-app terminal
+    (``/api/jobs/{id}/shell-token``), flips ``/api/codespace/orbital/{name}`` to
+    false so the framework skips the relay sshd install, skips the ``ssh_ready``
+    hold so the app announces "ready" with no shell, and disables idle/expiry
+    reaping and History. GitHub owns the Codespace lifecycle; ``_expiry_reaper``
+    is what cleans these up, as its own docstring says.
+    """
+    if rec.get("provider") == "codespace":
+        return False
+    worker_id = rec.get("worker_id", "")
+    return bool(worker_id and worker_id != "master" and job_id not in active_jobs)
+
+
 def _branch_of(job: dict) -> str:
     return job.get("ref") or job.get("head_branch") or "main"
 
@@ -460,8 +485,8 @@ class WorkerManager:
                     # re-provisioning would match a dead session) and inflate the
                     # dashboard. If the owning worker is no longer registered, the
                     # container is unreachable regardless of flags — reap the record.
-                    if (worker_id and worker_id != "master"
-                            and job_id not in self.active_jobs
+                    # Codespaces are excluded — see _dead_worker_candidate.
+                    if (_dead_worker_candidate(rec, job_id, self.active_jobs)
                             and not await self.pool.exists(f"worker:{worker_id}")):
                         log.info("Reconciler: worker %s gone — reaping orphan %s",
                                  worker_id, job_id)

--- a/ops-server/workers/test_dead_worker_candidate.py
+++ b/ops-server/workers/test_dead_worker_candidate.py
@@ -1,0 +1,67 @@
+"""Tests for _dead_worker_candidate — the terminate reconciler's orphan gate.
+
+Regression cover for 2026-08-10: every Codespace record was reaped ~8 s after
+provision because `worker_id="github-codespaces"` is a display label, not a
+registered worker. That took the in-app terminal (shell-token 404), the relay
+sshd install gate (/api/codespace/orbital/{name} → false), the ssh_ready hold,
+idle/expiry reaping and History with it.
+
+Run: /home/ops/ops-venv/bin/python -m workers.test_dead_worker_candidate
+  or pytest workers/test_dead_worker_candidate.py
+"""
+
+import workers.manager as m
+
+
+# ── Codespaces are never reapable, whatever worker_id claims ────────────────────
+
+def test_codespace_is_never_a_candidate():
+    rec = {"provider": "codespace", "worker_id": "github-codespaces"}
+    assert m._dead_worker_candidate(rec, "didactic-goggles-abc", set()) is False
+
+
+def test_codespace_not_reaped_even_when_flagged_terminating():
+    # _expiry_reaper owns codespace cleanup; this gate must stay out of it.
+    rec = {"provider": "codespace", "worker_id": "github-codespaces",
+           "terminating": "1"}
+    assert m._dead_worker_candidate(rec, "cs-1", set()) is False
+
+
+def test_codespace_with_an_odd_worker_id_still_excluded():
+    rec = {"provider": "codespace", "worker_id": "wamd001"}
+    assert m._dead_worker_candidate(rec, "cs-2", set()) is False
+
+
+# ── Real dead-worker orphans must still be reaped ───────────────────────────────
+
+def test_remote_worker_orphan_is_a_candidate():
+    rec = {"provider": "sysbox", "worker_id": "wamd001"}
+    assert m._dead_worker_candidate(rec, "job-1", set()) is True
+
+
+def test_remote_worker_orphan_candidate_when_provider_absent():
+    # Older records predate the provider field — they must not become immune.
+    rec = {"worker_id": "worker-x86_64-spot-0e9b"}
+    assert m._dead_worker_candidate(rec, "job-2", set()) is True
+
+
+def test_master_job_is_not_a_candidate():
+    rec = {"provider": "sysbox", "worker_id": "master"}
+    assert m._dead_worker_candidate(rec, "job-3", set()) is False
+
+
+def test_live_local_task_is_not_a_candidate():
+    rec = {"provider": "sysbox", "worker_id": "wamd001"}
+    assert m._dead_worker_candidate(rec, "job-4", {"job-4": object()}) is False
+
+
+def test_missing_worker_id_is_not_a_candidate():
+    assert m._dead_worker_candidate({"provider": "sysbox"}, "job-5", set()) is False
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok {name}")
+    print("all dead-worker-candidate tests passed")


### PR DESCRIPTION
## The bug

A Codespace has no worker. `codespace_service.provision()` records `worker_id="github-codespaces"` as a display label for the Running tab, and nothing ever registers a matching `worker:{id}` hash — so the terminate reconciler's dead-worker orphan adoption (added in `cc3c09c`, #124, for autoscaled spot workers) matched **every** Codespace and deleted its `job:running` record seconds after it was written.

Measured 2026-08-10 on master:

```
16:15:38 Codespace provisioned name=didactic-goggles-g4gpqr6477jfvgxq …
16:15:46 Reconciler: worker github-codespaces gone — reaping orphan didactic-goggles-…
16:15:46 Reconciler: cleaned orphaned terminated job didactic-goggles-…
```

## Why one stale condition produced four symptoms

That record is load-bearing:

| Symptom | Mechanism |
|---|---|
| in-app terminal 404 | `POST /api/jobs/{id}/shell-token` → `job:running` empty → `404 "job not running"` (`app.py:2914`) |
| no relay sshd, permanently | `/api/codespace/orbital/{name}` → `false` → framework ≥ 1.9.7 `variables.sh` downgrades `orbital_codespaces` → `github-codespaces` → `installCodespaceSSH` never runs |
| "ready" with no shell | `session_status` sees `tracked=False` → skips the `ssh_ready` hold |
| idle/expiry reaping, History, terminate metadata | silently dead since 2026-07-16 |

It also **flapped**: `_append_creation_log`'s flag writes re-created the key (`hset` creates), the reconciler reaped it again 15 s later, and whether the framework saw `orbital=true` depended on which side of that 15 s loop its post-create landed on — which is why some Codespaces worked and some didn't.

## Changes

- `workers/manager.py` — extract the cheap, pure part of the orphan decision into `_dead_worker_candidate()`, which excludes `provider == "codespace"`. Keeping it pure preserves the short-circuit, so the common case still costs no extra Redis round trip (this loop dominates the keyspace scan budget), and makes every branch unit-testable.
- `dashboard/codespace_service.py` — `_append_creation_log()` returns early when `job:running` is gone instead of resurrecting it as a partial, TTL-less hash.
- Tests for both, including that genuine dead-worker orphans **and** records predating the `provider` field are still reaped.

Codespace lifecycle stays with `_expiry_reaper()`, which already owns it and says so in its own docstring.

## Testing

- `pytest dashboard/ workers/ provisioning/` → **543 passed**, 11 of them new.
- 1 pre-existing failure, `test_orbital_seed.py::test_the_seed_warning_states_the_manual_step_and_why_it_is_manual` — verified identical with this branch's changes stashed. Unrelated (warning text was softened without updating the test); not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)