### PR TITLE
feat(deploy): hand the pasted OAuth client to the tenant, so registering is the whole setup

### DIFF
--- a/ops-server/dashboard/app_deploy.py
+++ b/ops-server/dashboard/app_deploy.py
@@ -869,6 +869,11 @@ CENTRAL_TENANT_HOST = "wwse.apps.dynatrace.com"
 COE_TENANT_IDS = {"wwse", "geu80787"}
 REMOTE_GRAIL_SCHEMA = "app:my.dynatrace.enablements:remote-grail"
 REMOTE_GRAIL_SCHEMA_VERSION = "1.1"
+# The tenant's own copy of its account OAuth client, so the app can mint per-learner
+# platform tokens and update itself without Orbital holding anything.
+# settings/schemas/mint-client.schema.json in the app repo.
+MINT_CLIENT_SCHEMA = "app:my.dynatrace.enablements:mint-client"
+MINT_CLIENT_SCHEMA_VERSION = "1.0.0"
 # App-settings (NOT classic settings) schema holding the Orbital service bearer —
 # settings/schemas/orbital-config.schema.json in the app repo. Unprefixed here because
 # the app-settings API resolves it within the Dt-App-Context app.
@@ -909,14 +914,23 @@ def _outbound_hosts_for(tenant_url: str) -> list[str]:
     return OUTBOUND_HOSTS + REALM_OUTBOUND_HOSTS.get(domain, [])
 
 
-async def _ensure_outbound_allowlist(token: str, tenant_url: str) -> str:
+async def _ensure_outbound_allowlist(token: str, tenant_url: str,
+                                     extra_hosts: list[str] | None = None) -> str:
     """If the tenant enforces a JS-runtime outbound allowlist (sprint/dev do, prod usually
     doesn't), add the content-delivery hosts so the app's functions can reach Orbital + GitHub.
     Only ever adds hosts to an existing enforced list — never creates or tightens a restriction.
     Best-effort; needs settings:objects:read+write on the token."""
     base = tenant_url.rstrip("/") + "/platform/classic/environment-api/v2/settings/objects"
     h = {"Authorization": f"Bearer {token}"}
+    # `extra_hosts` is where the realm the app will ACTUALLY authenticate against comes
+    # from: the ssoUrl/apiHost of the client being installed. REALM_OUTBOUND_HOSTS only
+    # knows the realms we happen to have met, so a tenant in an unlisted one would store
+    # a client and then fail every mint at the allowlist — the same chicken-and-egg the
+    # sprint entry was added to fix, one layer up.
     wanted = _outbound_hosts_for(tenant_url)
+    for extra in extra_hosts or []:
+        if extra and extra not in wanted:
+            wanted = wanted + [extra]
     try:
         async with httpx.AsyncClient(timeout=20) as c:
             r = await c.get(base, headers=h, params={
@@ -1020,6 +1034,68 @@ async def _ensure_remote_grail(token: str, tenant_url: str) -> str:
     except Exception as exc:
         log.warning("remote-grail for %s: %s", tenant_url, exc)
         return f"remote-grail error: {exc}"
+
+
+async def _store_mint_client(token: str, tenant_url: str, client_id: str, client_secret: str,
+                             account_urn: str, sso_url: str, api_host: str) -> str:
+    """Write the pasted account OAuth client into the TENANT'S OWN `mint-client` settings
+    object, so from here on the app mints its own per-learner tokens and its own install
+    bearer. Orbital keeps nothing: the secret is in memory for this one call and is deleted
+    by the caller immediately after.
+
+    This is the step whose absence made every new tenant half-broken. It looks impossible if
+    you go through the app-settings API — `app-settings:objects:write` is genuinely not in
+    the OAuth client scope catalog. But app settings and classic settings are the SAME
+    objects (measured on ydi9582h: the app's `remote-grail` object has an identical objectId
+    through both APIs), and the classic door opens with `settings:objects:write`, which every
+    account client can hold. `_ensure_remote_grail` has been walking through that door on
+    every deploy the whole time.
+
+    Idempotent, and re-registering a tenant deliberately overwrites: the admin just supplied
+    this client, so it is the freshest statement of intent.
+
+    Best-effort — returns a human-readable status; never raises, and never logs the secret.
+    """
+    base = tenant_url.rstrip("/") + "/platform/classic/environment-api/v2/settings/objects"
+    h = {"Authorization": f"Bearer {token}"}
+    value = {"clientId": client_id, "clientSecret": client_secret,
+             "accountUrn": account_urn, "ssoUrl": sso_url, "apiHost": api_host}
+    try:
+        async with httpx.AsyncClient(timeout=20) as c:
+            # A freshly installed app's schemas are not queryable the instant the install
+            # returns — same race the orbital-config seeding hits. Retry before concluding
+            # the tenant cannot hold a client.
+            r = None
+            for pause in (0, 5, 10):
+                if pause:
+                    await asyncio.sleep(pause)
+                r = await c.get(base, headers=h, params={
+                    "schemaIds": MINT_CLIENT_SCHEMA, "scopes": "environment",
+                    "fields": "objectId"})
+                if r.status_code == 200:
+                    break
+            if r is None or r.status_code == 403:
+                return "skipped (token lacks settings:objects:read/write)"
+            if r.status_code != 200:
+                return f"skipped (settings read HTTP {r.status_code})"
+            items = r.json().get("items", [])
+            if items:
+                pr = await c.put(f"{base}/{items[0]['objectId']}",
+                                 headers={**h, "Content-Type": "application/json"},
+                                 json={"value": value})
+                if pr.status_code in (200, 201, 204):
+                    return "updated (app mints + self-updates on its own)"
+                return f"update failed (HTTP {pr.status_code}: {pr.text[:120]})"
+            cr = await c.post(base, headers={**h, "Content-Type": "application/json"}, json=[{
+                "schemaId": MINT_CLIENT_SCHEMA, "schemaVersion": MINT_CLIENT_SCHEMA_VERSION,
+                "scope": "environment", "value": value,
+            }])
+            if cr.status_code in (200, 201):
+                return "stored (app mints + self-updates on its own)"
+            return f"create failed (HTTP {cr.status_code}: {cr.text[:120]})"
+    except Exception as exc:
+        log.warning("mint-client store for %s: %s", tenant_url, exc)
+        return f"mint-client error: {exc}"
 
 
 def _orbital_service_token() -> str | None:
@@ -1607,6 +1683,9 @@ async def deploy_with_token_status(deploy_id: str):
 # Design + threat model: ops-server/docs/tenant-credentials.md.
 
 MINT_SCOPE = "platform-token:tokens:write platform-token:tokens:manage"
+# Environment-scoped, and NOT covered by MINT_SCOPE: DynaKube's per-session ActiveGate
+# token. Mirrors AG_SCOPE in the app's api/mintCredentials.function.ts.
+AG_SCOPE = "environment-api:activegate-tokens:write"
 # Realm SSO token endpoints + Account Management API hosts per domain class
 # (classify_tenant → prod/sprint/dev). Overridable per request for unusual realms.
 SSO_TOKEN_URL_BY_DOMAIN = {
@@ -1711,28 +1790,74 @@ async def deploy_with_oauth(body: dict, x_auth_user: str | None = Header(default
     allowlist = ""
     remote_grail = ""
     orbital_cfg = ""
+    mint_client = "skipped (deploy failed)"
+    mint_ready = False
+    mint_st = 0
+    api_host = ACCOUNT_API_BY_DOMAIN.get(domain, ACCOUNT_API_BY_DOMAIN["prod"])
+    # The app authenticates this client against these two hosts on every mint and every
+    # self-update. If the tenant enforces an outbound allowlist and they are not on it,
+    # storing the client succeeds and everything that uses it fails.
+    realm_hosts = [h for h in (urlparse(sso_url).hostname, urlparse(api_host).hostname) if h]
     if res["status"] != "error":
-        allowlist = await _ensure_outbound_allowlist(token, tenant)
+        allowlist = await _ensure_outbound_allowlist(token, tenant, extra_hosts=realm_hosts)
         remote_grail = await _ensure_remote_grail(token, tenant)
         orbital_cfg = await _ensure_orbital_config(token, tenant)
+
+        # 2. Can this client mint platform tokens? Storing one that cannot would install a
+        #    credential that fails at the first hands-on launch instead of here.
+        mint_bearer, mint_st, _ = await _oauth_bearer(sso_url, cid, csec, account_urn, MINT_SCOPE)
+        mint_ready = mint_bearer is not None
+        if mint_bearer:
+            del mint_bearer
+
+        # 2b. DynaKube mints an ActiveGate token per session, and a platform token cannot
+        #     carry that scope — it is environment-scoped and separate. Without it every
+        #     Kubernetes training dies at ActiveGate with an error that looks nothing like
+        #     a credential problem. mintCredentials checks this before storing when a human
+        #     pastes the client; check it here too, for the path where nobody does.
+        ag_bearer, ag_st, _ = await _oauth_bearer(
+            sso_url, cid, csec, f"urn:dtenvironment:{tenant_id}", AG_SCOPE)
+        ag_ready = ag_bearer is not None
+        if ag_bearer:
+            del ag_bearer
+        if mint_ready and not ag_ready:
+            scope_warnings.append(
+                f"ActiveGate tokens NOT available (SSO HTTP {ag_st}): grant "
+                f"{AG_SCOPE} on this environment, or Kubernetes trainings will fail when "
+                f"DynaKube starts. Everything else works without it.")
+
+        # 3. Hand the client to the TENANT — the step that makes it self-sufficient. From
+        #    here the app mints its own per-learner tokens and its own install bearer for
+        #    "Update now", so this tenant never needs Orbital to hold a credential for it.
+        if mint_ready:
+            mint_client = await _store_mint_client(
+                token, tenant, cid, csec, account_urn, sso_url, api_host)
+        else:
+            mint_client = "skipped (client cannot mint platform tokens)"
     del token
+    del csec  # discard the secret — never persisted
     if res["status"] == "error":
         await _audit(user, tenant_id, "deploy", "deploy-error", via="oauth-bootstrap",
                      client_id=cid, rc=res.get("rc"))
         raise HTTPException(502, f"Deploy failed (exit {res.get('rc')}): {res.get('output','')}")
 
-    # 2. Mint probe — can this client mint platform tokens? (Advisory only: tells the admin
-    #    the client is ready to paste INTO the app. We store nothing either way.)
-    mint_bearer, mint_st, _ = await _oauth_bearer(sso_url, cid, csec, account_urn, MINT_SCOPE)
-    mint_ready = mint_bearer is not None
-    if mint_bearer:
-        del mint_bearer
-    del csec  # discard the secret — never persisted
     if not mint_ready:
         scope_warnings.append(
-            f"token minting NOT available (SSO HTTP {mint_st}): the client lacks the account "
-            f"permissions platform-token:tokens:write + platform-token:tokens:manage. Grant them "
-            f"before configuring the client inside the app, or hands-on labs can't mint per-user tokens.")
+            f"ACTION REQUIRED — token minting NOT available (SSO HTTP {mint_st}): the client "
+            f"lacks the account permissions platform-token:tokens:write + "
+            f"platform-token:tokens:manage. On an environment that still allows classic API "
+            f"tokens the app will mint those with its own identity and labs will work; on an "
+            f"environment where classic creation has been retired (it is rolled out per "
+            f"environment) every hands-on launch will refuse. Grant the two permissions and "
+            f"register the tenant again.")
+    elif not mint_client.startswith(("stored", "updated")):
+        scope_warnings.append(
+            f"ACTION REQUIRED — the OAuth client could NOT be stored on this tenant "
+            f"({mint_client}). Until it is, this tenant cannot mint per-learner platform "
+            f"tokens and cannot update itself from inside the app. Grant the client "
+            f"settings:objects:read + settings:objects:write on this environment and register "
+            f"the tenant again, or paste the client by hand in the app under "
+            f"Settings → Training Token Minting.")
 
     reg = await _register_in_content_service(user, tenant)
     profile = (reg or {}).get("profile")
@@ -1747,11 +1872,11 @@ async def deploy_with_oauth(body: dict, x_auth_user: str | None = Header(default
     await _audit(user, tenant_id, "deploy", res["status"], via="oauth-bootstrap", client_id=cid,
                  **{k: res[k] for k in ("from", "to") if res.get(k)}, url=url, profile=profile,
                  allowlist=allowlist, remote_grail=remote_grail, orbital_config=orbital_cfg,
-                 mint_ready=mint_ready, warnings=warnings)
+                 mint_ready=mint_ready, mint_client=mint_client, warnings=warnings)
     return {"ok": True, "tenant": tenant_id, "status": res["status"], "from": res.get("from"),
             "version": res.get("to"), "url": url, "profile": profile, "allowlist": allowlist,
             "remote_grail": remote_grail, "orbital_config": orbital_cfg,
-            "mintReady": mint_ready, "warnings": warnings}
+            "mintReady": mint_ready, "mintClient": mint_client, "warnings": warnings}
 
 
 @router.get("/api/deploy/audit")

--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -3404,9 +3404,15 @@ async function goRegisterOauth(action) {
             else {
                 const v = j.version || '?';
                 const s = j.status === 'up-to-date' ? `already up-to-date (v${v})` : j.status === 'upgraded' ? `upgraded v${j.from} → v${v}` : `installed v${v}`;
-                const mint = j.mintReady
-                    ? ' · <strong style="color:#2da44e">mint scopes verified</strong> — now paste this client into the app (Admin → Token minting)'
-                    : ' · <strong style="color:#d29922">mint scopes MISSING</strong> (grant platform-token:tokens:write/manage before configuring the app)';
+                // The single fact that decides whether this tenant is finished or not:
+                // did the client land in the tenant's own settings? "mint scopes verified"
+                // alone used to read as done when nothing had been configured at all.
+                const stored = /^(stored|updated)/.test(j.mintClient || '');
+                const mint = !j.mintReady
+                    ? ' · <strong style="color:#d29922">mint scopes MISSING</strong> (grant platform-token:tokens:write + :manage on the account, then register again)'
+                    : stored
+                        ? ' · <strong style="color:#2da44e">token minting configured</strong> — this tenant now mints its own tokens and updates itself'
+                        : ` · <strong style="color:#d29922">client NOT stored on the tenant</strong> (${escapeHtml(j.mintClient || 'unknown')}) — paste it in the app under Settings → Training Token Minting`;
                 m.innerHTML = `✓ ${s} — <a href="${escapeHtml(j.url || '#')}" target="_blank">open app</a>` + mint
                     + (j.profile ? ` · content profile ${escapeHtml(j.profile)}` : '')
                     + ((j.warnings || []).length ? `<br><span class="content-hint">⚠ ${j.warnings.map(escapeHtml).join('<br>⚠ ')}</span>` : '');

--- a/ops-server/dashboard/templates/index.html
+++ b/ops-server/dashboard/templates/index.html
@@ -772,7 +772,7 @@
         <section id="view-register" class="view">
             <div class="content-card">
                 <h3 style="margin:0 0 8px">Account OAuth client <span style="font-size:0.72rem;background:#1f6feb;color:#fff;border-radius:10px;padding:2px 8px;vertical-align:middle">bootstrap install only</span></h3>
-                <p class="content-hint" style="margin:0 0 8px"><strong>Bootstrap installed, Node stored.</strong> Orbital uses the OAuth client once to deploy the app, then discards it. After install, configure the same client inside the app (Admin → Token minting); the app then mints per-user platform tokens and self-updates — Orbital never holds credentials.</p>
+                <p class="content-hint" style="margin:0 0 8px"><strong>Paste it once. Nothing is stored here.</strong> Orbital uses the OAuth client to deploy the app, writes it into <em>your tenant's own</em> settings, and then discards it — it is never written to Orbital's disk, database or logs. From that moment the app is self-sufficient: it mints its own per-learner tokens and updates itself, on any tenant in any account, with no credential of yours living on this server.</p>
 
                 <h4 style="font-size:0.82rem;font-weight:600;color:var(--text);margin:12px 0 6px">How to create the OAuth client</h4>
                 <p class="content-hint" style="margin:0 0 6px">In your tenant's account: <a href="https://myaccount.dynatrace.com" target="_blank">myaccount.dynatrace.com</a> → Identity &amp; access management → OAuth clients → New. Add <strong>every</strong> scope below — the install is refused if any is missing, because a partly-scoped client produces an app that installs and then fails at runtime.</p>
@@ -785,7 +785,7 @@
                         <tr><td><code>app-engine:apps:delete</code></td><td>uninstall — needed for the <em>Undeploy</em> button below</td></tr>
                         <tr><td><code>app-settings:objects:read</code></td><td>check whether this tenant already has its Orbital token, so the install can tell you whether the manual step below is still outstanding. Optional — without it that check reports “could not verify” instead of a definite answer.</td></tr>
                         <tr><td><code>settings:objects:read</code></td><td>read the outbound allowlist before changing it</td></tr>
-                        <tr><td><code>settings:objects:write</code></td><td>enable training-telemetry forwarding, and add the hosts below to the outbound allowlist if your tenant enforces one</td></tr>
+                        <tr><td><code>settings:objects:write</code></td><td>enable training-telemetry forwarding, add the hosts below to the outbound allowlist if your tenant enforces one, and — the important one — store this client in your own tenant so the app can mint and self-update without Orbital keeping anything</td></tr>
                         <tr><td><code>environment-api:activegate-tokens:write</code></td><td>mint the per-session tokens a lab environment needs</td></tr>
                         <tr><td colspan="2" style="padding-top:8px"><strong style="color:var(--accent)">Account</strong></td></tr>
                         <tr><td><code>platform-token:tokens:write</code></td><td>mint per-user platform tokens after install</td></tr>
@@ -794,9 +794,9 @@
                 </table>
                 <p class="content-hint" style="margin:0 0 8px">Orbital checks the client against your tenant <em>before</em> installing anything and names any scope that is missing, so a wrong client costs you a message rather than a broken install.</p>
 
-                <h4 style="font-size:0.82rem;font-weight:600;color:var(--text);margin:12px 0 6px">One manual step after install</h4>
-                <p class="content-hint" style="margin:0 0 8px">Open the app → <strong>Admin → Orbital Server Configuration</strong> and paste your Orbital token. <strong>Once per tenant</strong> — it is stored in the app's own settings and survives every later upgrade, so you never repeat it.</p>
-                <p class="content-hint" style="margin:0 0 8px">This one step cannot be automated: the app's settings are written with an <em>app</em> permission (<code>app-settings:objects:write</code>), which is held by the app itself and is not offered in the OAuth client scope list — so no client can be created that seeds it for you. Until it is set, <strong>workshops and live sessions fail immediately</strong>, and hands-on labs keep working only while Orbital's compatibility window is open. The deploy result tells you if the step is still outstanding.</p>
+                <h4 style="font-size:0.82rem;font-weight:600;color:var(--text);margin:12px 0 6px">After install: nothing, if the client is complete</h4>
+                <p class="content-hint" style="margin:0 0 8px">The install writes the client into your tenant's own <strong>Settings → Training Token Minting</strong> and the app takes it from there — per-learner tokens, and its own updates. The deploy result says <code>stored</code> when that worked; if it says anything else it also says which permission is missing, and you can paste the same client on that Settings page by hand.</p>
+                <p class="content-hint" style="margin:0 0 8px">Why the app must mint at all: creating classic API tokens is being retired per environment, so a tenant that mints them happily today can stop tomorrow while a sibling tenant in the same account carries on. A client with the two <code>platform-token</code> account permissions is what makes that transition a non-event.</p>
 
                 <h4 style="font-size:0.82rem;font-weight:600;color:var(--text);margin:12px 0 6px">Outbound allowlist (if your tenant enforces it)</h4>
                 <p class="content-hint" style="margin:0 0 6px">These hosts are added to your app-function allowlist during install:</p>

--- a/ops-server/dashboard/test_mint_client_store.py
+++ b/ops-server/dashboard/test_mint_client_store.py
@@ -1,0 +1,219 @@
+"""The bootstrap deploy hands the pasted OAuth client to the TENANT, and keeps nothing.
+
+Why this file exists, and why it contradicts a comment you may still find nearby:
+
+    Writing the app's own settings was believed impossible from a deploy credential,
+    because `app-settings:objects:write` is not offered in the OAuth client scope
+    catalog (still true — 400 invalid_request even for the COE master client). The
+    conclusion drawn from that — "a new tenant needs a human to paste the client into
+    the app" — was wrong. App settings and classic settings are the SAME objects:
+    measured 2026-08-10 on ydi9582h, the app's `remote-grail` object comes back with
+    an identical objectId through
+
+        GET /platform/classic/environment-api/v2/settings/objects?schemaIds=app:my.dynatrace.enablements:remote-grail
+        GET /platform/app-settings/v2/objects?schema-id=remote-grail
+
+    and the classic door opens with `settings:objects:write`, which every account
+    OAuth client can hold. `_ensure_remote_grail` had been using that door on every
+    deploy the whole time.
+
+So: `_store_mint_client` writes through the classic API, and after it a brand-new
+tenant in a brand-new account mints its own per-learner tokens and updates itself.
+
+Run: /home/ops/ops-venv/bin/python -m pytest dashboard/test_mint_client_store.py -q
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from dashboard import app_deploy as dep
+
+
+class _Resp:
+    def __init__(self, status, payload=None, text=""):
+        self.status_code = status
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class _Client:
+    """httpx.AsyncClient stand-in. `calls` records every request in order."""
+
+    def __init__(self, get_resp, post_resp=None, put_resp=None):
+        self._get, self._post, self._put = get_resp, post_resp, put_resp
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url, headers=None, params=None):
+        self.calls.append(("GET", url, params, None))
+        return self._get
+
+    async def post(self, url, headers=None, json=None):
+        self.calls.append(("POST", url, None, json))
+        return self._post
+
+    async def put(self, url, headers=None, json=None):
+        self.calls.append(("PUT", url, None, json))
+        return self._put
+
+
+CLIENT = dict(client_id="dt0s02.ABCDEFGH", client_secret="dt0s02.ABCDEFGH.SECRETVALUE",
+              account_urn="urn:dtaccount:11111111-2222-3333-4444-555555555555",
+              sso_url="https://sso-sprint.dynatracelabs.com/sso/oauth2/token",
+              api_host="https://api-hardening.internal.dynatracelabs.com")
+
+
+async def _no_wait(*_a, **_k):
+    """Retry backoff, minus the wall-clock. Patching asyncio.sleep with something that
+    itself calls asyncio.sleep recurses forever — do not be clever here."""
+    return None
+
+
+def _store(monkeypatch, client):
+    monkeypatch.setattr(dep.httpx, "AsyncClient", lambda *a, **k: client)
+    monkeypatch.setattr(dep.asyncio, "sleep", _no_wait)
+    return asyncio.run(dep._store_mint_client("deploy-bearer", "https://new.example.com", **CLIENT))
+
+
+def test_creates_the_object_when_the_tenant_has_none(monkeypatch):
+    c = _Client(_Resp(200, {"items": []}), post_resp=_Resp(200, []))
+    out = _store(monkeypatch, c)
+    assert out.startswith("stored")
+    method, url, _, body = c.calls[-1]
+    assert method == "POST"
+    assert url.endswith("/platform/classic/environment-api/v2/settings/objects")
+    assert body[0]["schemaId"] == dep.MINT_CLIENT_SCHEMA
+    assert body[0]["schemaVersion"] == dep.MINT_CLIENT_SCHEMA_VERSION
+    assert body[0]["scope"] == "environment"
+    # Every field the app needs to authenticate, or loadMintClient() returns null.
+    assert body[0]["value"] == {
+        "clientId": CLIENT["client_id"], "clientSecret": CLIENT["client_secret"],
+        "accountUrn": CLIENT["account_urn"], "ssoUrl": CLIENT["sso_url"],
+        "apiHost": CLIENT["api_host"],
+    }
+
+
+def test_re_registering_overwrites_the_existing_client(monkeypatch):
+    # The admin just pasted this client. It is the freshest statement of intent, so a
+    # re-register must replace what is there rather than leave a stale secret behind.
+    c = _Client(_Resp(200, {"items": [{"objectId": "OBJ-1"}]}), put_resp=_Resp(200))
+    out = _store(monkeypatch, c)
+    assert out.startswith("updated")
+    method, url, _, body = c.calls[-1]
+    assert method == "PUT" and url.endswith("/OBJ-1")
+    assert body["value"]["clientSecret"] == CLIENT["client_secret"]
+
+
+def test_a_client_without_settings_scopes_is_reported_not_crashed(monkeypatch):
+    out = _store(monkeypatch, _Client(_Resp(403)))
+    assert "settings:objects" in out
+    assert out.startswith("skipped")
+
+
+def test_a_failed_write_says_so_instead_of_claiming_success(monkeypatch):
+    c = _Client(_Resp(200, {"items": []}), post_resp=_Resp(400, text="schema unknown"))
+    out = _store(monkeypatch, c)
+    assert out.startswith("create failed")
+    assert "400" in out
+
+
+def test_the_schema_is_retried_while_the_fresh_install_settles(monkeypatch):
+    # An app's schemas are not queryable the instant its install returns. Concluding
+    # "this tenant cannot hold a client" on the first 404 would leave every brand-new
+    # tenant unconfigured — the exact failure this whole change exists to remove.
+    seq = [_Resp(404), _Resp(404), _Resp(200, {"items": []})]
+
+    class _Retry(_Client):
+        async def get(self, url, headers=None, params=None):
+            self.calls.append(("GET", url, params, None))
+            return seq.pop(0)
+
+    c = _Retry(None, post_resp=_Resp(201, []))
+    out = _store(monkeypatch, c)
+    assert out.startswith("stored")
+    assert sum(1 for m, *_ in c.calls if m == "GET") == 3
+
+
+def test_the_secret_never_reaches_redis_or_the_audit(monkeypatch):
+    # Orbital's promise: the client is in memory for one deploy and nowhere else.
+    # The store call is the only place it is used, and it goes to the TENANT.
+    c = _Client(_Resp(200, {"items": []}), post_resp=_Resp(200, []))
+    _store(monkeypatch, c)
+    targets = {url for _, url, _, _ in c.calls}
+    assert all(u.startswith("https://new.example.com/") for u in targets)
+    # And nothing carries the secret except the settings write body.
+    carrying = [b for _, _, _, b in c.calls if b and CLIENT["client_secret"] in json.dumps(b)]
+    assert len(carrying) == 1
+
+
+@pytest.mark.parametrize("status", ["stored (app mints + self-updates on its own)",
+                                    "updated (app mints + self-updates on its own)"])
+def test_success_statuses_are_the_ones_the_route_checks_for(status):
+    # The route decides whether to raise ACTION REQUIRED by prefix. Keep them in sync.
+    assert status.startswith(("stored", "updated"))
+
+
+# ── the realm the client authenticates against must be reachable ──────────────
+
+def test_the_pasted_clients_own_realm_is_added_to_the_outbound_allowlist(monkeypatch):
+    # A tenant in a realm REALM_OUTBOUND_HOSTS has never met would otherwise store the
+    # client happily and then fail every mint at the allowlist — the client's own
+    # ssoUrl/apiHost are the authoritative answer, so they travel with it.
+    seen = {}
+
+    class _AL:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, headers=None, params=None):
+            return _Resp(200, {"items": [{"objectId": "AL-1", "value": {
+                "allowedOutboundConnections": {"enforced": True, "hostList": []}}}]})
+
+        async def put(self, url, headers=None, json=None):
+            seen["hosts"] = json["value"]["allowedOutboundConnections"]["hostList"]
+            return _Resp(200)
+
+    monkeypatch.setattr(dep.httpx, "AsyncClient", lambda *a, **k: _AL())
+    out = asyncio.run(dep._ensure_outbound_allowlist(
+        "bearer", "https://t.sprint.apps.dynatracelabs.com",
+        extra_hosts=["sso-unknown-realm.example.com", "api-unknown-realm.example.com"]))
+    assert out.startswith("added")
+    assert "sso-unknown-realm.example.com" in seen["hosts"]
+    assert "api-unknown-realm.example.com" in seen["hosts"]
+    # and the baseline hosts are still there
+    assert "autonomous-enablements.whydevslovedynatrace.com" in seen["hosts"]
+
+
+def test_a_realm_already_on_the_list_is_not_duplicated(monkeypatch):
+    class _AL:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, headers=None, params=None):
+            return _Resp(200, {"items": [{"objectId": "AL-1", "value": {
+                "allowedOutboundConnections": {
+                    "enforced": True,
+                    "hostList": dep._outbound_hosts_for("https://t.sprint.apps.dynatracelabs.com"),
+                }}}]})
+
+    monkeypatch.setattr(dep.httpx, "AsyncClient", lambda *a, **k: _AL())
+    out = asyncio.run(dep._ensure_outbound_allowlist(
+        "bearer", "https://t.sprint.apps.dynatracelabs.com",
+        extra_hosts=["sso-sprint.dynatracelabs.com"]))
+    assert out == "allowlist already complete"

--- a/ops-server/dashboard/test_orbital_seed.py
+++ b/ops-server/dashboard/test_orbital_seed.py
@@ -113,17 +113,30 @@ def test_no_orbital_token_configured_skips_before_any_call(monkeypatch):
     assert called["n"] == 0
 
 
-def test_the_seed_warning_states_the_manual_step_and_why_it_is_manual():
-    # An earlier version of this claimed seeding was automatic. It is not: an app
-    # function invoked by an external bearer runs with the CALLER's permissions,
-    # so routing the write through the app hits the same ungrantable scope.
-    # Telling an admin the install handled it would leave them with a tenant that
-    # 401s and no reason to look at settings.
-    w = dep._scope_warnings("", "", "skipped (something)")[0]
-    assert "ONE-TIME manual step" in w
-    assert "Orbital Server Configuration" in w
-    assert "cannot be automated" in w
-    assert "CALLER's permissions" in w
+def test_an_unseeded_orbital_config_is_no_longer_worth_warning_about():
+    # History, because this assertion has now been inverted twice and the reasons
+    # are not interchangeable:
+    #
+    #   1. Originally the warning claimed seeding was automatic. It was not — an app
+    #      function invoked by an external bearer runs with the CALLER's permissions,
+    #      so routing the write through the app hit the same ungrantable
+    #      app-settings:objects:write.
+    #   2. So the warning became an ACTION REQUIRED manual step.
+    #   3. Then the app started shipping its own Orbital bearer
+    #      (api/_orbital-baked-token.ts), which is the last rung of getOrbitalToken().
+    #      An unseeded tenant provisions labs and runs workshops perfectly well, so
+    #      ACTION REQUIRED was crying wolf on every single deploy.
+    #
+    # The status string is still reported verbatim in the deploy result and the audit
+    # row; it just no longer raises a warning nobody needs to act on.
+    assert dep._scope_warnings("", "", "skipped (something)") == []
+
+
+def test_a_token_orbital_itself_rejects_is_still_worth_warning_about():
+    # The one orbital-config outcome that is a real defect, and it points at THIS
+    # server rather than at the tenant admin, who can do nothing about it.
+    w = dep._scope_warnings("", "", "seed refused: Orbital did not accept the token")[0]
+    assert "ACTION REQUIRED" in w
 
 
 

--- a/ops-server/docs/tenant-credentials.md
+++ b/ops-server/docs/tenant-credentials.md
@@ -11,26 +11,50 @@ Which scopes?** — for every operation Orbital performs on a target tenant.
 
 ---
 
-## END STATE (2026-07-31) — the app holds the credential, Orbital stores NOTHING
+## END STATE (2026-08-10) — one paste, then the tenant is self-sufficient
 
-The design has moved to **app-held minting**. Read this first; the sections below are the
-per-generation reference.
+The design has moved to **app-held minting**, and as of 2026-08-10 the configuration step is
+automatic. Read this first; the sections below are the per-generation reference.
 
-1. **Bootstrap (once):** the tenant admin pastes an account OAuth client in Orbital's
-   Register Tenant tab. Orbital mints one deploy bearer, installs the app, and **discards
-   every credential** — the client is never written to Redis, disk, or logs. (Enforced by a
-   test: `test_oauth_bootstrap_stores_nothing`.)
-2. **Configure (once):** the admin pastes the same client **into the app** (Admin → Token
-   minting → the `mintCredentials` app function). It is stored in the app's own **app-state**
-   on that tenant (admin-ACL, function-readable, tenant-local). The app verifies the client
-   can mint (account platform-token scope + environment ActiveGate scope) before storing.
+1. **Register (once, the only human action):** the tenant admin pastes an account OAuth client
+   in Orbital's Register Tenant tab. Orbital mints one deploy bearer, installs the app, writes
+   the outbound allowlist (**including the client's own SSO/account-API hosts**, so an unfamiliar
+   realm is reachable) and remote-grail, **hands the client to the tenant** (step 2), and then
+   **discards every credential** — nothing is written to Redis, disk, or logs. (Enforced by
+   `test_oauth_bootstrap_stores_nothing` and `test_the_secret_never_reaches_redis_or_the_audit`.)
+2. **Configure (automatic, inside step 1):** `_store_mint_client` writes the client into the
+   app's own **`mint-client` settings object** on that tenant — through the *classic* settings
+   API with `settings:objects:write`, the same door `_ensure_remote_grail` has always used.
+   `clientSecret` is a `secret`-typed property: masked to every external reader, plaintext only
+   to the app. Before storing, Orbital probes the account mint scopes and the environment
+   ActiveGate scope and warns on each independently.
+
+   > This step used to be a manual second paste, documented as impossible to automate because
+   > `app-settings:objects:write` is not grantable to any OAuth client. That scope is indeed
+   > ungrantable — and it is the wrong door. App settings and classic settings are the **same
+   > objects**: measured on ydi9582h, the app's `remote-grail` object returns an identical
+   > `objectId` through `/platform/classic/environment-api/v2/settings/objects?schemaIds=app:my.dynatrace.enablements:remote-grail`
+   > and `/platform/app-settings/v2/objects?schema-id=remote-grail`.
+
+   The legacy `mint:oauth-client` app-state key is still **read** as a fallback, so tenants
+   configured the old way (ydi, COE, SRO) keep working with no migration. Settings is also the
+   more durable home: an app uninstall **destroys** app-state and **keeps** settings.
 3. **Steady state:** the **app** — not Orbital — mints per-user platform tokens (account API,
    env-scoped, short-TTL, tagged) and DynaKube ActiveGate tokens for each training session,
    and revokes them at session end. Orbital only ever receives the resulting token **values**
    (`ArenaProvisionRequest.dtEnv`). **Orbital holds no tenant credential at any point.**
+   A tenant that *cannot* mint now **refuses to provision** and reports the SSO/scope error,
+   instead of shipping an empty `DT_OPERATOR_TOKEN` that fails minutes later in the operator
+   install.
 4. **Self-update:** the app mints a short-lived, install-scoped bearer from its stored client
    and hands only that to Orbital, which builds + deploys the new version and discards it. The
-   client secret never leaves the tenant; app-state persists across versions.
+   client secret never leaves the tenant; settings persist across versions.
+
+   > Until 2026-08-10 the app posted `token: ''` unconditionally, which means "Orbital, use the
+   > client *you* hold". Orbital holds three, so "Update now" worked on exactly COE, SRO and
+   > ydi and answered every other tenant with an honest 400 (measured on bfs7010h,
+   > `deploy:job:wESlPSHDPJ5ChO2j`). The tokenless post is still the fallback when a tenant has
+   > no stored client, so those three are unaffected.
 
 **Why this is safe:** a full Orbital compromise exposes **no** tenant credential — there is
 nothing at rest to steal. The secret lives only on its own tenant, reachable only by an admin
@@ -73,25 +97,31 @@ At call time Orbital does `client_credentials` against the realm SSO with the ri
 `resource`: the **account (`urn:dtaccount:…`)** for both deploy and minting. Orbital
 already has this machinery (COE auto-deploy + sprint mint, both proven live).
 
-### Self-serve rollout (implemented 2026-07-31)
+### Self-serve rollout (`POST /api/deploy/oauth`, current as of 2026-08-10)
 
-The Register Tenant tab now has an **Account OAuth client** form (`POST /api/deploy/oauth`):
-the tenant admin pastes tenant URL + client id + secret + `urn:dtaccount:<uuid>`, Orbital
+The Register Tenant tab has an **Account OAuth client** form: the tenant admin pastes tenant
+URL + client id + secret + `urn:dtaccount:<uuid>`, and Orbital
 
 1. mints a deploy bearer (`app-engine:apps:install app-engine:apps:run` + `settings:objects:*`,
-   falling back to the minimal set and warning when the client lacks settings),
-2. deploys/upgrades the app, sets remote-grail + outbound allowlist, registers content,
-3. probes the mint scopes (`platform-token:tokens:write platform-token:tokens:manage`) —
-   when granted and "enable token minting" is checked, stores the client **Fernet-encrypted**
-   in Redis (`deploy:mintclient:{tenant_id}`).
+   falling back down a scope ladder and warning when the client lacks settings),
+2. deploys/upgrades the app, sets remote-grail + outbound allowlist (with the **client's own**
+   `ssoUrl`/`apiHost` added, so an unfamiliar realm is reachable), registers content,
+3. probes the account mint scopes (`platform-token:tokens:write platform-token:tokens:manage`)
+   and the environment ActiveGate scope (`environment-api:activegate-tokens:write`), warning
+   on each independently,
+4. **writes the client into the tenant's own `mint-client` settings object**
+   (`_store_mint_client`) and then drops every credential it held.
 
-Arena/training provisioning (`_tenant_platform_provisioner` in `dashboard/app.py`) prefers
-that registered client over the per-domain `MINT_*` env clients, so any tenant registered
-this way mints + revokes short-lived per-user platform tokens (scopes from the repo's
-`dt-tokens.yaml`, classic→platform translation in `provisioning/token_specs.py`) with no
-Orbital config change. Realm SSO + Account-API hosts default by domain
-(`SSO_TOKEN_URL_BY_DOMAIN` / `ACCOUNT_API_BY_DOMAIN` in `app_deploy.py`), overridable per
-request (`ssoUrl` / `apiHost`).
+Realm SSO + Account-API hosts default by domain (`SSO_TOKEN_URL_BY_DOMAIN` /
+`ACCOUNT_API_BY_DOMAIN` in `app_deploy.py`), overridable per request (`ssoUrl` / `apiHost`).
+
+**Orbital does not mint, and does not store a mint client.** PR #144 removed the last paths
+that did: `_gen3_platform_provisioner`, the `api_arena_provision` fallback branch, the
+cross-tenant workshop shortcut, `_sweep_leaked_platform_tokens`, `GET /api/deploy/mint-clients`
+and `PlatformTokenProvisioner`. The `deploy:mintclient:{tenant_id}` Redis key no longer exists.
+Every training token on a registered tenant is minted **by the app, with the tenant's own
+client**, using scopes from the repo's `dt-tokens.yaml` (classic→platform translation in
+`provisioning/token_specs.py`).
 
 ### Why the client needs NO Grail / data scopes
 
@@ -126,11 +156,16 @@ platform-token notes below are the fallback/legacy reference.
 
 ---
 
-## THREAT MODEL — what an Orbital compromise means for a registered tenant
+## THREAT MODEL — the OAuth client is account-admin in effect, wherever it lives
 
-**Read this before rolling out to customer/prospect tenants.** When a tenant enables token
-minting, Orbital holds that tenant's account OAuth client (Fernet-encrypted in Redis, key
-`GH_OAUTH_ENC_KEY` in `/home/ops/.env`). Be honest about the blast radius.
+**Read this before rolling out to customer/prospect tenants.**
+
+> **Orbital no longer holds it.** Since 2026-08-10 the client is stored on the **tenant** (a
+> `secret`-typed property of the app's own `mint-client` settings object) and Orbital keeps
+> nothing at rest — so the "Orbital compromise" half of this model is now moot, and what
+> remains is the blast radius of the *permission itself*, which is unchanged and still the
+> reason to be careful about who is asked to create one. The Orbital-held variant below is
+> retained because it describes the risk the permission carries in any home.
 
 ### The dangerous scope is `platform-token:tokens:write`, and it is effectively account-admin
 
@@ -156,32 +191,41 @@ comparatively bounded; **the account mint permission is the crown jewel.** Delet
 client in myaccount instantly revokes all of it — that is the customer's kill switch.
 
 ### Mitigations in place
-- Client stored Fernet-encrypted (not plaintext); never logged; API returns client_id only.
+- **The client lives only on its own tenant** (`mint-client` settings, `secret`-typed property:
+  masked to every external reader, plaintext only to the app). Orbital holds it for the duration
+  of one deploy call and never writes it anywhere — asserted by
+  `test_the_secret_never_reaches_redis_or_the_audit`. A full Orbital compromise yields **no**
+  tenant credential.
+- The secret never leaves the tenant afterwards; it only ever exits as **ephemeral,
+  purpose-scoped bearers** (mint / install).
 - Minted **session** tokens are env-scoped (`urn:dtenvironment:{env_id}`) + short-lived
   (4h) + tagged `enablement` + revoked on terminate — the *legitimate* use is tightly bound.
 - nginx allows the deploy endpoints signed-out but they only *use* a supplied credential;
-  the stored client is reachable only via provisioning code, not any read endpoint.
+  there is no read endpoint that returns one.
+- **Kill switch:** deleting the OAuth client in myaccount instantly revokes everything above.
 
 ### Mitigations NOT yet in place (do before customer GA)
-- **Encryption key + Redis on the same host** — an attacker with Orbital root gets both the
-  ciphertext and `GH_OAUTH_ENC_KEY`. A KMS / HSM-held key, or a per-tenant key the customer
-  controls, would stop plaintext extraction from a host compromise.
 - **No scope ceiling on the account side** — ask Dynatrace whether a mint client can be
   capped to a *fixed scope allowlist* (mint only these N scopes) and *fixed environment*.
   If yes, that collapses the blast radius from "account admin" to "can mint operator/ingest
-  on one env." **This is the single most important ask.**
+  on one env." **This is the single most important ask**, and it is now the only structural
+  one left: moving the client to the tenant removed the others.
 - **Egress/anomaly monitoring** on the mint path (alert on scopes/resources outside the
   enablement set).
+- **At-rest honesty:** a value the app must itself use to authenticate cannot be
+  envelope-encrypted against a tenant admin — the app would need the key, which then lives on
+  the same tenant. The boundary is the settings ACL plus "Orbital holds nothing", not
+  client-side crypto. We deliberately ship no key-in-bundle theatre.
 
-### The lower-blast-radius alternative — app-held client, not Orbital-held
-Move the OAuth client into the **app's own encrypted app-state on the tenant**; app functions
-call SSO + Account API directly and pass minted token *values* to Orbital (the
-`ArenaProvisionRequest.dtEnv` path already exists). Then **Orbital holds no tenant
-credential** — a single Orbital compromise exposes *nothing*; each tenant's secret lives only
-in that tenant. Trade-off: the secret sits in tenant app-state (whoever can invoke the admin
-app functions there can use it) and app functions need `sso.dynatrace.com` + the account API
-host on their outbound allowlist. This is arguably the correct end-state for customer tenants;
-the Orbital-held model is fine for tenants we own (COE/SRO/sprint).
+### Implemented 2026-08-10 — app-held client (was "the lower-blast-radius alternative")
+The OAuth client now lives in the **app's own `mint-client` settings object on the tenant**;
+app functions call SSO + the Account API directly and pass minted token *values* to Orbital
+(`ArenaProvisionRequest.dtEnv`). **Orbital holds no tenant credential** — a single Orbital
+compromise exposes nothing. Residual trade-off, unchanged from when this was a proposal:
+whoever can invoke the admin app functions on that tenant can use the client, and app functions
+need the realm SSO + account API host on their outbound allowlist (which
+`_ensure_outbound_allowlist` now adds automatically from the pasted client). This is the model
+for **all** tenants, ours included.
 
 ---
 
@@ -202,55 +246,50 @@ token with `storage:events:write` + `storage:bizevents:read` + `storage:buckets:
    token-create scope it uses for hands-on labs (operator/ingest tokens).
 4. *(optional)* **Read documents** — only if you want Orbital to verify imported content.
 
-## What to create — by tenant generation
+## What to create — one answer, all generations
 
-### Gen2 / classic-token tenants (most prod: `*.apps.dynatrace.com`, e.g. geu80787, sro97894)
-**A Platform token created IN the target tenant** (Settings → Platform tokens), scopes:
+**An account OAuth client with the scope set in `dynatrace-app-enablements/docs/tenant-onboarding.md`.**
+Register it once, and the tenant covers both mint paths and its own updates. There is no
+gen2/gen3 decision to make any more, because the client works on both and the app picks the
+path the environment allows.
 
-| Scope | For |
-|---|---|
-| `app-engine:apps:install` | install / upgrade |
-| `app-engine:apps:run` | run app functions |
-| `app-engine:apps:delete` | undeploy only |
-| `settings:objects:read` + `settings:objects:write` | remote-grail config + outbound allowlist (classic settings API) |
-| `api-tokens:tokens:read` + `api-tokens:tokens:write` | grant the app its `environment-api:api-tokens:write` self-mint scope at install (so hands-on labs can mint operator/ingest tokens) |
-| `document:documents:read` *(optional)* | content verification |
+### Which mint path the app takes, and what needs the client
 
-The app then **self-mints** training tokens with its own installed identity — classic
-API-token creation still works on these tenants.
+| Path | Credential | Client needed? |
+|---|---|---|
+| Classic `dt0c01` | the app's **own installed AppEngine identity** (manifest scope `environment-api:api-tokens:write`) | **no** |
+| Platform `dt0s16` | stored client → account bearer → `POST {apiHost}/iam/v1/accounts/{uuid}/platform-tokens` | **yes** |
+| ActiveGate `dt0g02` | stored client → env-scoped bearer | **yes** |
+| Self-update | stored client → env-scoped install bearer | **yes** |
 
-> ⚠️ **`environment-api:api-tokens:write` is now DEPRECATED** (shown as deprecated in the
-> OAuth-client scope picker). That is the scope the app's self-mint relies on. So the gen2
-> path above is on borrowed time — as classic token creation is retired tenant-by-tenant
-> (sprint already, prod following), **the Account Management platform-token path becomes
-> the direction for ALL generations**, not just gen3. Treat the gen2 self-mint as legacy;
-> prioritise the Account Management mint (below) as the long-term mechanism.
+Classic minting needing no client is why an unconfigured tenant looks *half* working — a
+training starts, but gen3 minting and "Update now" both fail. That asymmetry is the fingerprint
+of a tenant with no stored client.
 
-### Gen3 / migrated tenants (sprint: `*.sprint.apps.dynatracelabs.com`, e.g. ydi9582h; rolling out to prod)
-Classic API-token **creation is disabled** here (Settings API returns 400 "only available
-in Account Management" — see `dynatrace-app-enablements/docs/sprint-mint-platform-tokens-spike.md`).
-So token minting can't go through the tenant. You need **two** things:
+### Classic-token retirement is per ENVIRONMENT, not per domain or per account
 
-1. **The same per-tenant Platform token as gen2** (deploy + settings) — *minus* the
-   `api-tokens` scopes (no effect here).
-2. **An account-level OAuth client** (myaccount.dynatrace.com → Identity & access
-   management → OAuth clients, in the tenant's **account**) authorized for **token
-   management**, used against the Account Management API (`api.dynatrace.com`) to mint
-   platform tokens for trainings. Orbital holds it **encrypted** (like B) and brokers
-   mint/revoke. **Exact account scope: confirm in the OAuth-client UI** — it's in the
-   `account-*` family (the create-client picker lists e.g. `account-idm-read/write`,
-   `account-uac-read/write`); grant the token/identity-management one. Hand Orbital:
-   `client_id`, `client_secret`, account `urn:dtaccount:<uuid>`. (The exact create
-   endpoint/body is finalized once this client exists — the IAM base
-   `api.dynatrace.com/iam/v1/accounts` is confirmed reachable.)
+Measured 2026-08-10, in the **same** sprint account: `ydi9582h` created a `dt0c01` normally,
+while `pvf2584h` answered
+`400 "Creation of new tokens is now only available in Account Management."`
+So "sprint = gen3, prod = gen2" is not a rule you can rely on, and neither is anything derived
+from the account. Treat every environment as possibly retired: register the OAuth client and the
+question stops mattering. (Background:
+`dynatrace-app-enablements/docs/sprint-mint-platform-tokens-spike.md`.)
 
-## How Orbital uses A at Register Tenant
-`/api/deploy/token` (paste token) or `/api/deploy/start` (SSO): deploy → then
-`_ensure_outbound_allowlist` + `_ensure_remote_grail` (both need `settings:objects:write`).
-If the token lacks `settings:objects:write`, the deploy still succeeds but those steps are
-**skipped** and reported in the deploy response/audit `warnings[]` (see app_deploy.py).
+`environment-api:api-tokens:write` — the scope the classic self-mint relies on — is shown as
+DEPRECATED in the scope picker, so the classic path is on borrowed time everywhere. The Account
+Management platform-token path is the long-term mechanism for **all** generations.
+
+## How Orbital uses the credential at Register Tenant
+`/api/deploy/oauth` (client, preferred) or `/api/deploy/token` (paste, fallback): deploy → then
+`_ensure_outbound_allowlist` + `_ensure_remote_grail` + `_store_mint_client` (all three need
+`settings:objects:write`). If the credential lacks it, the deploy still succeeds but those steps
+are **skipped** and reported in the response/audit `warnings[]` — and for `_store_mint_client`
+that is raised as **ACTION REQUIRED**, since the tenant is then not self-sufficient.
 
 ## Quick decision
-- **Prod `.apps.dynatrace.com`** → one tenant Platform token (gen2 scope set). Done.
-- **Sprint/dev `.sprint|dev.apps.dynatracelabs.com`** → tenant Platform token (deploy +
-  settings) **plus** an account OAuth client for minting (gen3).
+- **Any tenant, any domain, any generation** → one account OAuth client, registered through
+  `/api/deploy/oauth`. Done.
+- **Admin cannot create an OAuth client** → the platform-token paste flow in
+  `dynatrace-app-enablements/docs/tenant-onboarding.md` § Fallback. Installs and updates by
+  paste, classic minting works, gen3 minting and self-update do not.


### PR DESCRIPTION
`/api/deploy/oauth` installed the app and then dropped the client, leaving the tenant unable to mint gen3 tokens or update itself until a human pasted the same client a second time into the app's own settings.

That second step was documented as impossible to automate, on the grounds that `app-settings:objects:write` is not grantable to any OAuth client. **It is not grantable — and it is also the wrong door.** App settings and classic settings address the same objects: measured on ydi9582h, the app's `remote-grail` object returns an identical `objectId` through

```
GET /platform/classic/environment-api/v2/settings/objects?schemaIds=app:my.dynatrace.enablements:remote-grail
GET /platform/app-settings/v2/objects?schema-id=remote-grail
```

and the classic door opens with `settings:objects:write`, which the deploy credential already holds and already uses for remote-grail.

So `_store_mint_client` writes the client into the tenant's own `mint-client` settings object, inside the window where the secret is still in memory, and it is discarded immediately after as before. **Orbital stores nothing** — `test_the_secret_never_reaches_redis_or_the_audit` asserts the only request carrying the secret is the settings write, and that it goes to the tenant.

Companion PR: `dynatrace-app-enablements` #73 (the app side that reads the object). **Merge this one first.**

## Also here, because they are the difference between "stored" and "actually works"

- **The client's own realm travels with it.** `_ensure_outbound_allowlist` takes the `ssoUrl`/`apiHost` derived from what was pasted, so a tenant in a realm `REALM_OUTBOUND_HOSTS` has never met can reach its own SSO — instead of storing a client happily and then failing every mint at the allowlist.
- **ActiveGate scope probe (step 2b)** mirrors the check the app performs before accepting a client, so a client that cannot mint AG tokens is reported at register time rather than when DynaKube starts mid-training.
- The result carries `mintClient`, and the UI raises **ACTION REQUIRED** when the client could not be stored — the one case that still needs a human.
- The schema GET retries `(0, 5, 10)` s: an app's schemas are not queryable the instant its install returns, and concluding "this tenant cannot hold a client" on the first 404 would leave every brand-new tenant unconfigured, which is the exact failure this change exists to remove.

## Register Tenant copy

Loses its "one manual step that cannot be automated" section, because it now isn't one. `test_orbital_seed`'s case asserting that warning is replaced — the old one had been **failing on main since `9e65650`** and asserted a premise this change removes.

## Tests

`test_mint_client_store.py` (10): create / update / 403 / failed-write / retry / secret-containment / status-prefix, plus two allowlist realm-propagation cases. **524 pass** in `dashboard/`.

## Deploy note

Master **and both workers** (`ops-dashboard` owns these files, so restart it), then bump `APP_DEPLOY_REF` to the app tag — it is read at import, so that also needs the restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)