### PR TITLE
fix(arena): stop masking dtSessionId on the session-status routes

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -4471,9 +4471,18 @@ async def api_arena_session_status(job_id: str, request: Request):
     else:
         status = "provisioning"
 
-    # Anonymous callers get the learner identity masked (the app's bearer /
-    # signed-in members get full values — the app needs them for the UI + DQL
-    # session-id substitution).
+    # Anonymous callers get the learner IDENTITY (the email) masked; the app's
+    # bearer / signed-in members get it in full.
+    #
+    # `dtSessionId` is deliberately EXEMPT from masking. It is the per-user
+    # Grail-isolation id the learner's own DQL must match on
+    # (`endsWith(k8s.cluster.name, "<id>")`), and the app polls this endpoint
+    # WITHOUT the bearer — `session-tick` skips the app-settings token lookup
+    # for latency. Masking it rewrote every {{DT_SESSION_ID}} filter to
+    # `endsWith(..., "se***")`: a query that can never match, failing silently
+    # with an empty result rather than an error. It also leaks nothing the
+    # caller does not already hold — reaching this endpoint requires the
+    # unguessable job id, which grants a root shell via `wsUrl` anyway.
     full = _has_full_access(request)
 
     # Resume outcome. Section TITLES only — never the commands that were
@@ -4499,8 +4508,7 @@ async def api_arena_session_status(job_id: str, request: Request):
         "userId":     meta.get("arena_user", "") if full
                       else masking.mask_email(meta.get("arena_user", "")),
         "expiresAt":  meta.get("expires_at", ""),
-        "dtSessionId": meta.get("dt_hostgroup", "") if full
-                       else masking.mask_email(meta.get("dt_hostgroup", "")),
+        "dtSessionId": meta.get("dt_hostgroup", ""),
         **resume_fields,
     }
 
@@ -4545,8 +4553,8 @@ async def api_arena_user_session(userId: str, trainingId: str, request: Request,
                     "userId":     meta.get("arena_user", "") if full
                                   else masking.mask_email(meta.get("arena_user", "")),
                     "expiresAt":  meta.get("expires_at", ""),
-                    "dtSessionId": meta.get("dt_hostgroup", "") if full
-                                   else masking.mask_email(meta.get("dt_hostgroup", "")),
+                    # Never masked — see the note on the session-status route.
+                    "dtSessionId": meta.get("dt_hostgroup", ""),
                 }
         if cursor == 0:
             break


### PR DESCRIPTION
## Problem

The app's session poll (`session-tick`) reaches `GET /api/arena/sessions/{id}` **without** the service bearer — it deliberately skips the app-settings token lookup, which costs ~0.6 s in a fresh isolate on every poll. So `_has_full_access()` was `False` and `dtSessionId` came back through `mask_email()` as `"se***"`.

`dtSessionId` is the per-user Grail-isolation id (`<user>-<yyyymmdd>`, same string as `DT_HOSTGROUP`) that a learner's own DQL has to match on. The masked form is truthy, so it overwrote the real provision-time id in the client's session record and got persisted to localStorage. Every `{{DT_SESSION_ID}}` filter in a lab became:

```dql
| filter endsWith(k8s.cluster.name, "se***")
```

which cannot match anything — and fails as an *empty result*, not an error, so `dql-verification` checks stayed red with no diagnostic.

## Fix

Return `dtSessionId` unmasked on both session-status routes (`api_arena_session_status`, `api_arena_user_session`).

It leaks nothing the caller does not already hold: reaching either route requires the unguessable job id, which grants a root shell via `wsUrl` anyway. `userId` masking is unchanged — that one is a real email address.

## Test

- `dashboard/test_masking.py` + `dashboard/test_live_auth.py` → 31 pass
- App-side guard (`isMaskedSessionId`) ships separately in dynatrace-app-enablements so the two halves can deploy in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)