### PR TITLE
fix(grail): keep the session id whole in the cluster name, and verify it nightly

### DIFF
--- a/.devcontainer/test/unit/test_dynakube.bats
+++ b/.devcontainer/test/unit/test_dynakube.bats
@@ -427,6 +427,62 @@ EOF
   [[ "$name" != *"-" ]]
 }
 
+# The contract every lab depends on: `endsWith(k8s.cluster.name, "{{DT_SESSION_ID}}")`.
+# The composed name used to be truncated at the TAIL, which cut the session id off
+# and made that filter return zero records while the data was fine (SPEC-005).
+
+@test "generateDynakube: name ends with the WHOLE session id at every feature cap" {
+  source_functions
+  export RepositoryName="enablement-kubernetes-opentelemetry-openpipeline"
+  # 26 chars — the longest id Orbital can now produce (17 local + '-' + date).
+  export DT_HOSTGROUP="abcdefghijklmnopq-20260812"
+
+  for features in "" "telemetry_ingest: true" "kspm: true" "extensions: true"; do
+    printf '%s\n' "$features" > "$FAKE_REPO/.devcontainer/yaml/dynakube-config.yaml"
+    generateDynakube apponly
+    name_line=$(grep -m1 '^  name: ' "$FAKE_REPO/.devcontainer/yaml/gen/dynakube.yaml")
+    name="${name_line#  name: }"
+    [[ "$name" == *"abcdefghijklmnopq-20260812" ]]
+    [ "${#name}" -le 38 ]
+  done
+}
+
+@test "generateDynakube: the constant 'enablement-' prefix is dropped from the name only" {
+  source_functions
+  export RepositoryName="enablement-kubernetes-101"
+  export DT_HOSTGROUP="tt-n-mk3p9aqz-20260812"
+
+  cat > "$FAKE_REPO/.devcontainer/yaml/dynakube-config.yaml" <<'EOF'
+telemetry_ingest: true
+EOF
+
+  generateDynakube apponly
+
+  run cat "$FAKE_REPO/.devcontainer/yaml/gen/dynakube.yaml"
+  # readable repo half + intact session id, instead of the old "e-tt-n-…"
+  [[ "$output" == *"name: kubernetes-101-tt-n-mk3p9aqz-20260812"* ]]
+  [[ "$output" == *"hostGroup: kubernetes-101-tt-n-mk3p9aqz-20260812"* ]] || true
+  # networkZone keeps the full repo name — repo-scoped identity, unchanged
+  [[ "$output" == *"networkZone: enablement-kubernetes-101"$'\n'* ]]
+}
+
+@test "generateDynakube: an over-long session id warns loudly instead of being cut" {
+  source_functions
+  export RepositoryName="enablement-kubernetes-101"
+  # 45 chars — the shape the old training-test identity produced
+  export DT_HOSTGROUP="training-test-manual-ingest-probe-1786501397-20260812"
+
+  run generateDynakube apponly
+  [[ "$output" == *"does not fit"* ]]
+  [[ "$output" == *"will NOT match"* ]]
+
+  name_line=$(grep -m1 '^  name: ' "$FAKE_REPO/.devcontainer/yaml/gen/dynakube.yaml")
+  name="${name_line#  name: }"
+  # falls back to the repo-scoped name; never ships a half-truncated session id
+  [[ "$name" != *"training-test-manual-ingest"* ]]
+  [ "${#name}" -le 38 ]
+}
+
 @test "generateDynakube: no session id keeps pre-1.9 repo-scoped identity" {
   source_functions
 

--- a/.devcontainer/util/functions.sh
+++ b/.devcontainer/util/functions.sh
@@ -1718,6 +1718,11 @@ generateDynakube() {
   # mixed-case (e.g. Enablement-DTWiz-101), which the DynaKube validating webhook
   # rejects — silently breaking OneAgent injection. Lowercase for the Dynakube name.
   local base_name="$(echo "${RepositoryName:-$(hostname)}" | tr '[:upper:]' '[:lower:]')"
+  # Every training repo is called "enablement-<something>", so those 11 characters
+  # carry no information while eating the name budget below (they used to leave
+  # "e-" or "enablement-kuber" as the visible half). Strip the constant prefix for
+  # the DynaKube/cluster name only — networkZone below keeps the full repo name.
+  local short_name="${base_name#enablement-}"
   local cluster_name="$base_name"
   local session_id="$(getDtSessionId)"
   # The operator's validating webhook enforces a HARD DynaKube name limit
@@ -1729,14 +1734,31 @@ generateDynakube() {
   [[ "${DK_KSPM:-false}" == "true" && name_cap -gt 35 ]] && name_cap=35
   [[ "${DK_EXTENSIONS:-false}" == "true" && name_cap -gt 31 ]] && name_cap=31
   if [[ -n "$session_id" ]]; then
-    # Sacrifice repo chars before the session id.
-    local name_budget=$(( name_cap - ${#session_id} - 1 ))
-    (( name_budget < 1 )) && name_budget=1
-    local repo_part="${base_name:0:$name_budget}"
-    repo_part="${repo_part%-}"
-    cluster_name="${repo_part}-${session_id}"
-    cluster_name="${cluster_name:0:$name_cap}"
-    cluster_name="${cluster_name%-}"
+    # The session id MUST survive whole: every lab filters Grail with
+    # `endsWith(k8s.cluster.name, "{{DT_SESSION_ID}}")`, so a truncated tail
+    # silently returns zero records instead of the learner's own data.
+    # Sacrifice repo chars — and never truncate the composed name afterwards.
+    # Orbital bounds the id to 26 chars (HOSTGROUP_LOCAL_MAX=17 + '-' + date),
+    # which leaves >= 10 repo chars at the fleet cap of 37.
+    if (( ${#session_id} > name_cap )); then
+      # Cannot be satisfied at all — say so instead of shipping a cut id that
+      # makes every Grail check in the training return nothing, silently.
+      printWarn "Session id '$session_id' (${#session_id} chars) does not fit the DynaKube name cap ($name_cap)"
+      printWarn "Grail per-user filters (endsWith k8s.cluster.name) will NOT match — falling back to a repo-scoped cluster name"
+      cluster_name="${base_name:0:$name_cap}"
+      cluster_name="${cluster_name%-}"
+    else
+      local name_budget=$(( name_cap - ${#session_id} - 1 ))
+      local repo_part=""
+      if (( name_budget > 0 )); then
+        repo_part="${short_name:0:$name_budget}"
+        repo_part="${repo_part%-}"
+      fi
+      # No trailing truncation here: repo_part + '-' + session_id is <= name_cap
+      # by construction, so the id always survives intact. A budget of 0 drops
+      # the repo half entirely — the id is what has to survive.
+      cluster_name="${repo_part:+${repo_part}-}${session_id}"
+    fi
   else
     cluster_name="${cluster_name:0:$name_cap}"
     cluster_name="${cluster_name%-}"

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -3239,17 +3239,30 @@ def _new_job_id() -> str:
     return f"{_b36(int(time.time() * 1000))}-{secrets.token_hex(2)}"
 
 
+# Longest email local part kept in a session id. The budget chain, stated once:
+#   17 (local) + 1 ("-") + 8 (YYYYMMDD)  = 26-char session id
+#   26 + 1 + >= 10 repo chars            = the framework's 37-char DynaKube cap
+# The framework appends the id to the cluster name and every lab filters
+# `endsWith(k8s.cluster.name, "{{DT_SESSION_ID}}")`, so an id that does not fit
+# used to get its tail cut and the learner's Grail check returned nothing.
+# Known limit: plain truncation, no hash — two learners whose local parts share
+# the first 17 characters get the same id, and therefore merged telemetry.
+HOSTGROUP_LOCAL_MAX = 17
+
+
 def _dt_hostgroup(user: str) -> str:
     """Per-user Grail-isolation id "<user>-<YYYYMMDD>" (DT_HOSTGROUP).
 
     Derived ONCE at provision time and carried in the job dict + redis meta so
     the worker's .env, the session-status API, and the app's DQL placeholder
     substitution all agree on the same value (no date drift across midnight).
-    Email users keep only the local part; result is RFC-1123-safe.
-    Mirrors workers/manager.py and worker-agent/executor.py.
+    Email users keep only the local part, bounded to HOSTGROUP_LOCAL_MAX;
+    result is RFC-1123-safe. Mirrors workers/manager.py and
+    worker-agent/executor.py (and the app's templateVars.ts fallback).
     """
     user = (user or "").split("@", 1)[0].lower()
     user = re.sub(r"[^a-z0-9-]+", "-", user).strip("-")
+    user = user[:HOSTGROUP_LOCAL_MAX].rstrip("-")
     if not user:
         return ""
     return f"{user}-{datetime.now(timezone.utc):%Y%m%d}"

--- a/ops-server/dashboard/test_hostgroup.py
+++ b/ops-server/dashboard/test_hostgroup.py
@@ -1,0 +1,72 @@
+"""Drift test for _dt_hostgroup — the per-user Grail-isolation id.
+
+The same function is duplicated in three separately-deployed processes
+(dashboard/app.py, workers/manager.py, worker-agent/executor.py) because they
+are three deploy units, and mirrored a fourth time in the app
+(ui/app/training/utils/templateVars.ts). If any copy drifts, the worker's
+DT_HOSTGROUP and the app's {{DT_SESSION_ID}} stop agreeing and every
+`endsWith(k8s.cluster.name, …)` filter in every training silently misses.
+
+AST comparison on purpose: importing manager.py / executor.py drags in redis and
+the whole worker stack, which this must not need. Docstrings are stripped — they
+legitimately differ per process; the logic must not.
+
+Run:  python3 -m pytest dashboard/test_hostgroup.py
+  or: python3 dashboard/test_hostgroup.py
+"""
+import ast
+import pathlib
+
+OPS = pathlib.Path(__file__).resolve().parent.parent
+MIRRORS = [
+    OPS / "dashboard" / "app.py",
+    OPS / "workers" / "manager.py",
+    OPS / "worker-agent" / "executor.py",
+]
+
+
+def _body(path):
+    """AST dump of _dt_hostgroup's statements, docstring stripped."""
+    tree = ast.parse(path.read_text())
+    fn = next((n for n in ast.walk(tree)
+               if isinstance(n, ast.FunctionDef) and n.name == "_dt_hostgroup"), None)
+    assert fn, f"_dt_hostgroup not found in {path}"
+    stmts = fn.body
+    if (stmts and isinstance(stmts[0], ast.Expr)
+            and isinstance(stmts[0].value, ast.Constant)
+            and isinstance(stmts[0].value.value, str)):
+        stmts = stmts[1:]
+    return "\n".join(ast.dump(s) for s in stmts)
+
+
+def test_all_three_mirrors_are_identical():
+    bodies = {p.name: _body(p) for p in MIRRORS}
+    first = next(iter(bodies.values()))
+    for name, body in bodies.items():
+        assert body == first, f"{name} has drifted from the other _dt_hostgroup mirrors"
+
+
+def test_every_mirror_bounds_the_local_part():
+    # 17 (local) + 1 + 8 (YYYYMMDD) = 26, which still leaves >= 10 repo chars
+    # under the framework's 37-char DynaKube name cap.
+    for p in MIRRORS:
+        src = p.read_text()
+        assert "HOSTGROUP_LOCAL_MAX = 17" in src, f"{p.name} lost the bound"
+        assert 'user[:HOSTGROUP_LOCAL_MAX].rstrip("-")' in src, f"{p.name} does not apply the bound"
+
+
+def test_app_mirror_matches():
+    ts = (OPS.parent.parent / "dynatrace-app-enablements" / "ui" / "app" / "training"
+          / "utils" / "templateVars.ts")
+    if not ts.exists():          # the app repo is not always checked out beside us
+        return
+    src = ts.read_text()
+    assert "HOSTGROUP_LOCAL_MAX = 17" in src
+    assert "slice(0, HOSTGROUP_LOCAL_MAX)" in src
+
+
+if __name__ == "__main__":
+    test_all_three_mirrors_are_identical()
+    test_every_mirror_bounds_the_local_part()
+    test_app_mirror_matches()
+    print("ok — _dt_hostgroup mirrors agree")

--- a/ops-server/tools/test_training_test_runner.py
+++ b/ops-server/tools/test_training_test_runner.py
@@ -21,8 +21,13 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from training_test_runner import (  # noqa: E402
     FILE_MARK,
+    evaluate_dql,
+    extract_dql_checks,
     extract_from_docs,
+    short_tag,
     split_doc_dump,
+    substitute_placeholders,
+    runner_user_id,
     validate_question,
 )
 
@@ -85,6 +90,22 @@ expect:
 """
 
 
+DOC_WITH_DQL = """# Section with a Grail assertion
+<!-- LAB_QUESTION
+type: dql-verification
+question: Verify your cluster's container logs are reaching Grail
+buttonText: Check logs in Grail
+dql: |
+  fetch logs, from:now()-15m
+  | filter endsWith(k8s.cluster.name, "{{DT_SESSION_ID}}")
+  | limit 1
+expect:
+  operator: not-empty
+hint: "Logs take ~1-2 minutes to reach Grail."
+-->
+"""
+
+
 # ── pure-logic units ────────────────────────────────────────────────────────
 
 def test_extract_from_docs_good():
@@ -118,6 +139,55 @@ def test_validate_question_rules():
     assert "unknown question type" in validate_question({"type": "nope", "question": "q"})
     assert "exit-zero|contains|not-empty|gt" in validate_question(
         {"type": "shell-verification", "command": "c", "expect": {"operator": "gte", "value": "1"}})
+
+
+def test_short_tag_and_user_id_fit_the_hostgroup_budget():
+    # Orbital bounds the email local part to 17 chars (HOSTGROUP_LOCAL_MAX); a
+    # longer test identity loses its tail inside the DynaKube name and every
+    # endsWith(k8s.cluster.name, "{{DT_SESSION_ID}}") in the training misses.
+    assert short_tag("nightly-20260506-020000") == "n"
+    assert short_tag("manual") == "m"
+    assert short_tag("") == "m"
+    assert short_tag("enablement-kubernetes-101") == "enab"
+
+    uid = runner_user_id("nightly-20260506-020000", 1786501397.0)
+    local = uid.split("@")[0]
+    assert uid.endswith("@orbital.internal")
+    assert local.startswith("tt-n-")
+    assert len(local) <= 17, local
+    # unique per run — the one-session-per-user guard must not dedupe onto a stale session
+    assert runner_user_id("manual", 1786501397.0) != runner_user_id("manual", 1786501398.0)
+
+
+def test_extract_dql_checks():
+    checks = extract_dql_checks([("01.md", DOC_WITH_DQL)])
+    assert len(checks) == 1
+    fname, label, dql, expect = checks[0]
+    assert (fname, label) == ("01.md", "Check logs in Grail")
+    assert dql.startswith("fetch logs")
+    assert expect == {"operator": "not-empty"}
+    # a block the importer would drop is not executed as a Grail check
+    assert extract_dql_checks([("02.md", DOC_BROKEN_QUIZ)]) == []
+
+
+def test_substitute_placeholders():
+    q = 'fetch logs | filter endsWith(k8s.cluster.name, "{{DT_SESSION_ID}}") | limit 1'
+    out = substitute_placeholders(q, {"DT_SESSION_ID": "tt-n-mk3p9aqz-20260812"})
+    assert '"tt-n-mk3p9aqz-20260812"' in out
+    # unknown placeholders stay literal rather than collapsing to "" — an empty
+    # endsWith matches EVERY cluster and would pass on a classmate's data
+    assert "{{JOB_ID}}" in substitute_placeholders("{{JOB_ID}}", {})
+
+
+def test_evaluate_dql_mirrors_the_app():
+    assert evaluate_dql([{"c": 1}], {"operator": "not-empty"}) is True
+    assert evaluate_dql([], {"operator": "not-empty"}) is False
+    assert evaluate_dql([], {"operator": "gt", "value": 0}) is False
+    assert evaluate_dql([{"count": 5}], {"operator": "gt", "value": 2}) is True
+    assert evaluate_dql([{"count": 1}], {"operator": "gt", "value": 2}) is False
+    assert evaluate_dql([{"ns": "todoapp"}], {"operator": "contains", "value": "todo"}) is True
+    assert evaluate_dql([{"a": 1, "ns": "todoapp"}],
+                        {"operator": "eq", "field": "ns", "value": "todoapp"}) is True
 
 
 def test_split_doc_dump():

--- a/ops-server/tools/training_test_runner.py
+++ b/ops-server/tools/training_test_runner.py
@@ -43,10 +43,17 @@ Environment (all optional):
   TRAINING_TEST_API_TOKEN           alternative: existing token with apiTokens.write
   TRAINING_TEST_REQUIRE_MINT=1      fail the run if token minting did not happen
   TRAINING_TEST_READY_TIMEOUT_S     provisioning wait cap (default 1500)
+  TRAINING_TEST_DQL_TOKEN           dt0s16 platform token (read scopes) for the SAME tenant
+                                    as TRAINING_TEST_TENANT_URL — lets the runner execute the
+                                    trainings' dql-verification blocks. Unset -> DQL SKIPPED.
+                                    (QA read usage; never a deploy credential.)
+  TRAINING_TEST_REQUIRE_DQL=1       turn a DQL SKIPPED into a run failure
+  TRAINING_TEST_DQL_SETTLE_S        how long to retry Grail checks before the verdict (default 180)
 """
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -66,6 +73,8 @@ EXEC_TIMEOUT_S = 120        # instant checks / setup commands
 WAIT_TIMEOUT_S = 660        # LAB_WAIT-gated verifies (covers framework waitForPod 60x10s)
 SOLVE_TIMEOUT_S = 840       # solution commands via exec-start (operator deploys)
 SOLVE_POLL_S = int(os.environ.get("TRAINING_TEST_SOLVE_POLL_S", "5"))
+DQL_SETTLE_S = int(os.environ.get("TRAINING_TEST_DQL_SETTLE_S", "180"))
+DQL_POLL_S = int(os.environ.get("TRAINING_TEST_DQL_POLL_S", "20"))
 FILE_MARK = "===TT_FILE:"
 
 QUIZ_TYPES = ("multiple-choice", "dql-verification", "instructor-code", "shell-verification")
@@ -134,6 +143,81 @@ def orbital_bearer() -> str:
         except Exception:
             tok = ""
     return tok.split(",")[0].strip()  # comma-separated for rotation; send the first
+
+
+def _b36(n: int) -> str:
+    """base36 of an int — same compact, sortable encoding as Orbital's job ids."""
+    digits = "0123456789abcdefghijklmnopqrstuvwxyz"
+    if n <= 0:
+        return "0"
+    out = []
+    while n:
+        n, r = divmod(n, 36)
+        out.append(digits[r])
+    return "".join(reversed(out))
+
+
+def short_tag(run_tag: str) -> str:
+    """Compress the caller's run tag to 1-4 characters.
+
+    The whole test identity has to fit Orbital's HOSTGROUP_LOCAL_MAX (17), which
+    is what keeps the session id inside the framework's DynaKube name cap and
+    therefore keeps `endsWith(k8s.cluster.name, "{{DT_SESSION_ID}}")` matching.
+    The long tags callers pass (workers/manager.py forwards nightly_run_id, e.g.
+    "nightly-20260506-020000") used to blow the budget on their own.
+    """
+    t = re.sub(r"[^a-z0-9]+", "", (run_tag or "").lower())
+    if t.startswith("nightly"):
+        return "n"
+    if t.startswith("manual") or not t:
+        return "m"
+    return t[:4]
+
+
+def runner_user_id(run_tag: str, when: float) -> str:
+    """Test identity: "tt-<tag>-<b36 epoch-ms>@orbital.internal" (<= 17 chars local).
+
+    Unique per run — the one-session-per-user guard must never dedupe onto a
+    stale session, and each run needs its own per-user Grail isolation id.
+    """
+    return f"tt-{short_tag(run_tag)}-{_b36(int(when * 1000))}@orbital.internal"
+
+
+def substitute_placeholders(text: str, session_vars: dict) -> str:
+    """Substitute {{DT_SESSION_ID}} / {{DT_TENANT}} / {{JOB_ID}} exactly like the
+    app does (ui/app/training/utils/templateVars.ts). Unknown placeholders are
+    left literal — the app leaves them literal too, and a silent "" here would
+    turn `endsWith(k8s.cluster.name, "")` into a filter that matches every
+    cluster and passes on a classmate's data.
+    """
+    def repl(m):
+        return session_vars.get(m.group(1), m.group(0))
+    return re.sub(r"\{\{\s*([A-Z][A-Z0-9_]*)\s*\}\}", repl, text or "")
+
+
+def run_dql(tenant_url: str, token: str, query: str, timeout_s: int = 60):
+    """Execute a DQL query against the tenant's platform query API.
+
+    Returns (records, error). `records` is a list on success, None on failure.
+    Classic dt0c01 tokens are rejected here ("Could not parse JWT") — this needs
+    a gen3 dt0s16 platform token with read scopes (QA read usage only).
+    """
+    url = f"{tenant_url.rstrip('/')}/platform/storage/query/v1/query:execute"
+    body = json.dumps({"query": query, "requestTimeoutMilliseconds": 30000}).encode()
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as r:
+            d = json.load(r)
+    except urllib.error.HTTPError as e:
+        return None, f"HTTP {e.code}: {e.read().decode('utf-8', 'replace')[:200]}"
+    except Exception as e:
+        return None, f"{type(e).__name__}: {str(e)[:200]}"
+    state = d.get("state")
+    if state and state != "SUCCEEDED":
+        return None, f"query state={state}"
+    return (d.get("result") or {}).get("records", []) or [], ""
 
 
 class Orbital:
@@ -220,6 +304,33 @@ class Orbital:
 
 
 # ── content extraction ──────────────────────────────────────────────────────
+
+def extract_dql_checks(files):
+    """files: list of (fname, text) -> [(fname, label, dql, expect)] in doc order.
+
+    The learner's Grail assertions. Kept out of extract_from_docs' 4-tuple on
+    purpose: shell checks run inside the session, these run against the tenant
+    after an ingest settle window, so they have their own lifecycle.
+    """
+    out = []
+    for fname, text in files:
+        for kind, body in BLOCK_RE.findall(text):
+            if kind != "LAB_QUESTION":
+                continue
+            try:
+                doc = parse_block(body)
+            except Exception:
+                continue
+            if not isinstance(doc, dict) or doc.get("type") != "dql-verification":
+                continue
+            if validate_question(doc):       # structurally broken — already reported as a quiz problem
+                continue
+            out.append((fname,
+                        doc.get("buttonText") or doc.get("question") or "",
+                        doc.get("dql") or "",
+                        doc.get("expect") if isinstance(doc.get("expect"), dict) else {"operator": "not-empty"}))
+    return out
+
 
 def extract_from_docs(files):
     """files: list of (fname, text). Returns (setups, solutions, checks, quizzes),
@@ -360,6 +471,102 @@ def with_wait(cmd):
     return f"export LAB_WAIT=1; {cmd}"
 
 
+def evaluate_dql(records, expect):
+    """Port of the app's evaluateDqlResult (ui/app/utils/dqlUtils.ts).
+
+    DQL blocks use their own expect grammar (not-empty | eq | gte | gt |
+    contains, with an optional `field`), which is NOT the shell grammar that
+    evaluate() speaks — so the learner's button and this runner must agree here.
+    """
+    op = (expect or {}).get("operator")
+    if op == "not-empty":
+        return len(records) > 0
+    if not records:
+        return False
+    first = records[0]
+    if not isinstance(first, dict) or not first:
+        return False
+    field = expect.get("field")
+    target = first.get(field) if field else first[next(iter(first))]
+    if target is None:
+        return False
+    val = expect.get("value")
+    try:
+        if op == "eq":
+            return str(target) == str(val)
+        if op == "gte":
+            return float(target) >= float(val)
+        if op == "gt":
+            return float(target) > float(val)
+    except (TypeError, ValueError):
+        return False
+    if op == "contains":
+        return str(val) in str(target)
+    return False
+
+
+def run_dql_checks(dql_checks, session_vars, tenant_url, token):
+    """Execute the trainings' Grail assertions, retrying until ingest settles.
+
+    Returns (failures, skipped) — both lists of human-readable strings. A check
+    that cannot be executed is SKIPPED, never a pass: silence is exactly what
+    let a broken `endsWith` filter ride a green nightly for weeks.
+    """
+    failures, skipped = [], []
+    if not dql_checks:
+        return failures, skipped
+
+    header(f"== GRAIL CHECKS ({len(dql_checks)}) ==")
+    if not token or not tenant_url:
+        why = ("TRAINING_TEST_DQL_TOKEN not set" if not token else "no tenant URL")
+        for fname, label, _dql, _exp in dql_checks:
+            log(f"  [dql] {YELLOW}SKIPPED{RESET} [{fname}] {label} — {why}")
+            skipped.append(f"{fname}: {label} ({why})")
+        return failures, skipped
+
+    session_id = session_vars.get("DT_SESSION_ID", "")
+    if not session_id:
+        # endsWith(k8s.cluster.name, "") matches EVERY cluster — a check that
+        # "passes" on a classmate's data is worse than one that never ran.
+        for fname, label, _dql, _exp in dql_checks:
+            log(f"  [dql] {YELLOW}SKIPPED{RESET} [{fname}] {label} — session has no dtSessionId")
+            skipped.append(f"{fname}: {label} (no dtSessionId)")
+        return failures, skipped
+
+    pending = [(f, lbl, substitute_placeholders(q, session_vars), exp) for f, lbl, q, exp in dql_checks]
+    deadline = time.time() + DQL_SETTLE_S
+    attempt = 0
+    while pending:
+        attempt += 1
+        still = []
+        for fname, label, query, expect in pending:
+            records, err = run_dql(tenant_url, token, query)
+            if records is None:
+                log(f"  [dql] {YELLOW}SKIPPED{RESET} [{fname}] {label} — {err}")
+                skipped.append(f"{fname}: {label} ({err})")
+                continue
+            if evaluate_dql(records, expect):
+                log(f"  [dql] {tag(True, 'PASS')} [{fname}] {label} -> {len(records)} record(s)"
+                    f" expect={expect.get('operator')} {expect.get('value', '')}"
+                    + (f" (attempt {attempt})" if attempt > 1 else ""))
+            else:
+                still.append((fname, label, query, expect))
+        pending = still
+        if not pending or time.time() >= deadline:
+            break
+        log(f"  [dql] {len(pending)} check(s) not satisfied yet — telemetry still settling, "
+            f"retrying in {DQL_POLL_S}s (up to {DQL_SETTLE_S}s)")
+        time.sleep(DQL_POLL_S)
+
+    for fname, label, query, expect in pending:
+        log(f"  [dql] {tag(False, 'PASS')} [{fname}] {label} -> no records after {DQL_SETTLE_S}s "
+            f"(expect={expect.get('operator')} {expect.get('value', '')})")
+        for ln in query.strip().splitlines():
+            relay("        |", ln)
+        failures.append(f"{fname}: Grail check '{label}' returned nothing")
+    return failures, skipped
+
+
 # ── phases ──────────────────────────────────────────────────────────────────
 
 def doc_title(content):
@@ -434,7 +641,7 @@ def main():
 
     # 2. Provision — unique user per run so the one-session-per-user guard never
     #    dedupes onto a stale session, and per-user Grail isolation gets a fresh id.
-    user_id = f"training-test+{args.run_tag}-{int(started)}@orbital.internal"
+    user_id = runner_user_id(args.run_tag, started)
     payload = {"trainingId": training["id"], "userId": user_id}
     if args.ref:
         payload["ref"] = args.ref
@@ -497,9 +704,11 @@ def main():
         files = [(n, t) for n, t in files if n != MKDOCS_MARK]
         files, training_key = order_by_nav(files, mkdocs_text)
         setups, solutions, checks, quizzes = extract_from_docs(files)
+        dql_checks = extract_dql_checks(files)
         titles = {fname: doc_title(content) for fname, content in files}
         step(4, f"docs: {len(files)} files -> {len(setups)} setup cmds, "
-             f"{len(solutions)} solutions, {len(checks)} shell checks, {len(quizzes)} question blocks")
+             f"{len(solutions)} solutions, {len(checks)} shell checks, "
+             f"{len(dql_checks)} Grail checks, {len(quizzes)} question blocks")
         # The learner's path — sections (docs) strictly in doc order. Each
         # section is exercised exactly as a learner walks it: setup -> solution
         # (blocking, LAB_WAIT) -> solution verify -> the section's checks ->
@@ -613,6 +822,23 @@ def main():
             if not ok:
                 failures.append(f"section {i} ({fname}): " + "; ".join(sec_fail[:3]))
 
+        # 5b. The learner's Grail assertions — executed against the real tenant,
+        #     BEFORE the session is torn down, with a settle window because log
+        #     and trace ingest lands in Grail a minute or more after the
+        #     container produced it. A shape-only check here is what let a
+        #     broken endsWith() filter ride a green nightly.
+        dql_fail, dql_skipped = run_dql_checks(
+            dql_checks,
+            {"DT_SESSION_ID": prov.get("dtSessionId", ""),
+             "DT_TENANT": tenant,
+             "JOB_ID": job_id},
+            tenant,
+            os.environ.get("TRAINING_TEST_DQL_TOKEN", ""),
+        )
+        failures.extend(dql_fail)
+        if dql_skipped and os.environ.get("TRAINING_TEST_REQUIRE_DQL") == "1":
+            failures.append(f"TRAINING_TEST_REQUIRE_DQL=1 but {len(dql_skipped)} Grail check(s) were skipped")
+
         # 6. Training verdict — one line per section, in learner order.
         n_ok = sum(1 for _f, _t, ok, _e, _d in section_results if ok)
         log("")
@@ -621,6 +847,11 @@ def main():
             log(f"  {i}. {tag(ok, 'PASS')}  {fname}"
                 f"{' — ' + title if title else ''}  ({dur_s}s)"
                 + ("" if ok else f"  {RED}[{'; '.join(sec_fail[:2])}]{RESET}"))
+        if dql_checks:
+            n_dql_ok = len(dql_checks) - len(dql_fail) - len(dql_skipped)
+            log(f"  Grail: {n_dql_ok}/{len(dql_checks)} passed"
+                + (f", {len(dql_fail)} failed" if dql_fail else "")
+                + (f", {YELLOW}{len(dql_skipped)} skipped (NOT counted as passed){RESET}" if dql_skipped else ""))
 
     finally:
         # 7. Always release the environment — a leaked session burns a worker
@@ -637,7 +868,7 @@ def main():
         log(f"{RED}{BOLD}TRAINING_TEST: FAILURE{RESET}")
         return 1
     log(f"\n{GREEN}RESULT: all steps passed end-to-end in {dur}s "
-        f"(provision -> mint -> steps -> solutions -> quizzes -> terminate){RESET}")
+        f"(provision -> mint -> steps -> solutions -> quizzes -> grail -> terminate){RESET}")
     log(f"{GREEN}{BOLD}TRAINING_TEST: SUCCESS{RESET}")
     return 0
 

--- a/ops-server/worker-agent/executor.py
+++ b/ops-server/worker-agent/executor.py
@@ -60,17 +60,31 @@ from .config import (
 log = logging.getLogger("ops-worker-agent")
 
 
+# Longest email local part kept in a session id. The budget chain, stated once:
+#   17 (local) + 1 ("-") + 8 (YYYYMMDD)  = 26-char session id
+#   26 + 1 + >= 10 repo chars            = the framework's 37-char DynaKube cap
+# The framework appends the id to the cluster name and every lab filters
+# `endsWith(k8s.cluster.name, "{{DT_SESSION_ID}}")`, so an id that does not fit
+# used to get its tail cut and the learner's Grail check returned nothing.
+# Known limit: plain truncation, no hash — two learners whose local parts share
+# the first 17 characters get the same id, and therefore merged telemetry.
+HOSTGROUP_LOCAL_MAX = 17
+
+
 def _dt_hostgroup(user: str) -> str:
     """Per-user Grail-isolation id "<user>-<YYYYMMDD>", written as DT_HOSTGROUP.
 
     The framework's generateDynakube consumes it (getDtSessionId) so each
     session gets a unique DynaKube name + hostGroup inside a shared tenant —
     100 students can run the same training against one tenant and each filters
-    Grail to their own cluster. Email users keep only the local part; result is
-    RFC-1123-safe. (Duplicated in workers/manager.py — separate deploy unit.)
+    Grail to their own cluster. Email users keep only the local part, bounded to
+    HOSTGROUP_LOCAL_MAX; result is RFC-1123-safe. (Duplicated in
+    workers/manager.py — separate deploy unit — and in dashboard/app.py; the app
+    mirrors it once more in ui/app/training/utils/templateVars.ts.)
     """
     user = (user or "").split("@", 1)[0].lower()
     user = re.sub(r"[^a-z0-9-]+", "-", user).strip("-")
+    user = user[:HOSTGROUP_LOCAL_MAX].rstrip("-")
     if not user:
         return ""
     return f"{user}-{datetime.now(timezone.utc):%Y%m%d}"

--- a/ops-server/worker-agent/test_executor_env.py
+++ b/ops-server/worker-agent/test_executor_env.py
@@ -80,6 +80,22 @@ def test_hostgroup_explicit_wins_over_derived():
     assert env["DT_HOSTGROUP"] == "alice-20260101"
 
 
+def test_hostgroup_long_local_part_is_bounded():
+    # 17 local + '-' + YYYYMMDD = 26, so the framework can always append the
+    # whole id to the DynaKube name (cap 37) and endsWith() keeps matching.
+    env = _write(user="maria.jose.rodriguez.fernandez@dynatrace.com")
+    assert len(env["DT_HOSTGROUP"]) == 26
+    assert env["DT_HOSTGROUP"].startswith("maria-jose-rodrig")
+
+
+def test_hostgroup_shared_prefix_collides_by_design():
+    # Documented limit of plain truncation (no hash): two learners sharing the
+    # first 17 characters of their local part get the same id and merged data.
+    a = _write(user="maria.jose.rodriguez.fernandez@dynatrace.com")
+    b = _write(user="maria.jose.rodriguez.gomez@dynatrace.com")
+    assert a["DT_HOSTGROUP"] == b["DT_HOSTGROUP"]
+
+
 if __name__ == "__main__":
     for name, fn in sorted(globals().items()):
         if name.startswith("test_") and callable(fn):

--- a/ops-server/workers/manager.py
+++ b/ops-server/workers/manager.py
@@ -142,17 +142,31 @@ def _new_job_id() -> str:
     return f"{_b36(int(time.time() * 1000))}-{secrets.token_hex(2)}"
 
 
+# Longest email local part kept in a session id. The budget chain, stated once:
+#   17 (local) + 1 ("-") + 8 (YYYYMMDD)  = 26-char session id
+#   26 + 1 + >= 10 repo chars            = the framework's 37-char DynaKube cap
+# The framework appends the id to the cluster name and every lab filters
+# `endsWith(k8s.cluster.name, "{{DT_SESSION_ID}}")`, so an id that does not fit
+# used to get its tail cut and the learner's Grail check returned nothing.
+# Known limit: plain truncation, no hash — two learners whose local parts share
+# the first 17 characters get the same id, and therefore merged telemetry.
+HOSTGROUP_LOCAL_MAX = 17
+
+
 def _dt_hostgroup(user: str) -> str:
     """Per-user Grail-isolation id "<user>-<YYYYMMDD>", written as DT_HOSTGROUP.
 
     The framework's generateDynakube consumes it (getDtSessionId) so each
     session gets a unique DynaKube name + hostGroup inside a shared tenant —
     100 students can run the same training against one tenant and each filters
-    Grail to their own cluster. Email users keep only the local part; result is
-    RFC-1123-safe. (Duplicated in worker-agent/executor.py — separate deploy unit.)
+    Grail to their own cluster. Email users keep only the local part, bounded to
+    HOSTGROUP_LOCAL_MAX; result is RFC-1123-safe. (Duplicated in
+    worker-agent/executor.py — separate deploy unit — and in dashboard/app.py;
+    the app mirrors it once more in ui/app/training/utils/templateVars.ts.)
     """
     user = (user or "").split("@", 1)[0].lower()
     user = re.sub(r"[^a-z0-9-]+", "-", user).strip("-")
+    user = user[:HOSTGROUP_LOCAL_MAX].rstrip("-")
     if not user:
         return ""
     return f"{user}-{datetime.now(timezone.utc):%Y%m%d}"

--- a/ops-server/workers/test_manager_env.py
+++ b/ops-server/workers/test_manager_env.py
@@ -89,6 +89,24 @@ def test_hostgroup_explicit_wins_over_derived(tmp_path):
     assert env["DT_HOSTGROUP"] == "alice-20260101"
 
 
+def test_hostgroup_long_local_part_is_bounded(tmp_path):
+    # The id is appended to the DynaKube name (cap 37) and every lab filters
+    # endsWith(k8s.cluster.name, "{{DT_SESSION_ID}}") — an id that does not fit
+    # gets its tail cut and the learner's Grail check silently returns nothing.
+    env = _write(tmp_path, user="maria.jose.rodriguez.fernandez@dynatrace.com")
+    assert len(env["DT_HOSTGROUP"]) == 26          # 17 local + '-' + YYYYMMDD
+    assert env["DT_HOSTGROUP"].startswith("maria-jose-rodrig")
+
+
+def test_hostgroup_shared_prefix_collides_by_design(tmp_path):
+    # Documented limit of plain truncation (no hash): two learners whose local
+    # parts share the first 17 characters get the SAME id, and therefore merged
+    # telemetry. Pinned here so it is a known trade-off, not a surprise.
+    a = _write(tmp_path / "a", user="maria.jose.rodriguez.fernandez@dynatrace.com")
+    b = _write(tmp_path / "b", user="maria.jose.rodriguez.gomez@dynatrace.com")
+    assert a["DT_HOSTGROUP"] == b["DT_HOSTGROUP"]
+
+
 if __name__ == "__main__":
     import tempfile
     for name, fn in sorted(globals().items()):


### PR DESCRIPTION
## Why

Per-user Grail isolation rests on one string. Orbital derives `DT_HOSTGROUP = "<email-local>-<YYYYMMDD>"`, the framework appends it to the DynaKube/cluster name, and every lab filters `endsWith(k8s.cluster.name, "{{DT_SESSION_ID}}")`.

`generateDynakube` composed `<repo>-<session>` and then truncated to the operator's name cap — cutting the **tail**, which is exactly the session id the filter depends on.

Proven on SRO 2026-08-12: `dtSessionId=training-test-manual-ingest-probe-1786501397-20260812` ingested **634 log records** under cluster name `e-training-test-manual-ingest-probe-1`; the lab's own query returned **0**. The learner sees an empty result and no error.

The nightly test could not catch it: `dql-verification` blocks were only shape-checked, so both k8s-101 runs reported `TRAINING_TEST: SUCCESS` while all three Grail assertions returned nothing.

## What changed

**1 — the id fits by construction** (no hash; simpler than SPEC-005 proposed)

| Where | Change |
|---|---|
| `dashboard/app.py`, `workers/manager.py`, `worker-agent/executor.py` | `HOSTGROUP_LOCAL_MAX = 17` in all three `_dt_hostgroup` mirrors → `17 + '-' + 8` = **26-char id**, leaving ≥10 repo chars under the fleet's 37-char cap |
| `util/functions.sh` `generateDynakube` | drops the constant `enablement-` prefix from the **name** (`networkZone` keeps the full repo name), budgets the repo half, **no truncation afterwards**; an unfittable id warns twice and falls back to a repo-scoped name instead of shipping a cut one |
| `tools/training_test_runner.py` | runner identity `training-test+<run-tag>-<epoch>@…` (45+ chars — the string above) → `tt-<n\|m\|tag>-<base36 epoch-ms>@orbital.internal` (13) |

```
before: e-training-test-manual-ingest-probe-1     id destroyed
after:  kubernetes-101-tt-n-mk3p9aqz-20260812     37 chars, id intact
        kube-abcdefghijklmnopq-20260812           cap 31, worst-case id, still intact
```

**2 — the nightly test executes the DQL**

Substitutes the placeholders, runs each query against the tenant, evaluates with a port of the app's `evaluateDqlResult` (DQL grammar is `eq/gte/gt/contains/not-empty` + `field` — *not* the shell-verification grammar, so reusing `evaluate()` would have misjudged everything but `not-empty`). Runs after the last section and **before** terminate, polling up to 180 s so ingest settles. Refuses to run a query whose `{{DT_SESSION_ID}}` resolved empty — `endsWith(…, "")` matches every cluster.

Reporting is fail-closed: no `TRAINING_TEST_DQL_TOKEN` → `SKIPPED`, never `PASS`. `TRAINING_TEST_REQUIRE_DQL=1` promotes a skip to a failure.

## Accepted limit

Plain truncation, no hash: two learners whose local parts share the first 17 characters get the same session id and therefore merged telemetry. Documented in each mirror and pinned by a test so it stays visible rather than surprising.

## Tests

`bats test/unit/test_dynakube.bats` **42/42** — new: id survives whole at every feature cap (38/37/35/31), `enablement-` stripped from the name only, over-long id warns instead of being cut.
`pytest workers/test_manager_env.py dashboard/test_hostgroup.py` **12** — `test_hostgroup.py` is new and compares the three `_dt_hostgroup` ASTs so a mirror cannot drift silently.
`python3 -m worker-agent.test_executor_env` **9** · `tools/test_training_test_runner.py` **all pass**.
Companion app change (4th mirror, `computeDtSessionId`) shipped in **v1.0.324**.

## Deploy note

`_dt_hostgroup` runs in three processes — master **and both workers** need the pull **plus a `systemctl restart`**; a pull alone deploys nothing. Fleet repos only pick up `functions.sh` when they bump the framework tag.

Requires `TRAINING_TEST_DQL_TOKEN` (a gen3 `dt0s16` for the test tenant, QA-read usage) in `/home/ops/.env`, or the Grail checks stay `SKIPPED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)