### PR TITLE
Workshops & Delivery — Orbital admin, trainer registry, owner gate, tenant binding, per-learner env controls

### DIFF
--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -402,17 +402,6 @@ async def startup():
     except Exception as exc:
         log.warning("content sync start failed (continuing without): %s", exc)
 
-    # Seed the trainer registry from OPS_TRAINER_SEED so a fresh install (or a
-    # Redis wipe) has someone who can schedule a workshop. Only seeds when the
-    # registry is EMPTY, so entries removed through the UI stay removed — the
-    # exception being a registry emptied completely, which is exactly the
-    # lock-yourself-out case this guards against.
-    try:
-        from dashboard import trainer_registry as _tr
-        await _tr.seed(pool, _tr.seed_emails(os.environ.get("OPS_TRAINER_SEED", "")))
-    except Exception as exc:
-        log.warning("trainer registry seed failed (continuing without): %s", exc)
-
 
 @app.on_event("shutdown")
 async def shutdown():

--- a/ops-server/dashboard/app.py
+++ b/ops-server/dashboard/app.py
@@ -402,6 +402,17 @@ async def startup():
     except Exception as exc:
         log.warning("content sync start failed (continuing without): %s", exc)
 
+    # Seed the trainer registry from OPS_TRAINER_SEED so a fresh install (or a
+    # Redis wipe) has someone who can schedule a workshop. Only seeds when the
+    # registry is EMPTY, so entries removed through the UI stay removed — the
+    # exception being a registry emptied completely, which is exactly the
+    # lock-yourself-out case this guards against.
+    try:
+        from dashboard import trainer_registry as _tr
+        await _tr.seed(pool, _tr.seed_emails(os.environ.get("OPS_TRAINER_SEED", "")))
+    except Exception as exc:
+        log.warning("trainer registry seed failed (continuing without): %s", exc)
+
 
 @app.on_event("shutdown")
 async def shutdown():
@@ -673,6 +684,93 @@ async def _require_arena_auth(request: Request) -> None:
 # (content delivery). Both endpoints are auth-gated → entries returned unmasked.
 
 from dashboard import tenant_registry  # noqa: E402
+
+# Who may SCHEDULE a workshop (dashboard/trainer_registry.py). Separate from
+# both workshop membership and the app's content-instructor gate — see that
+# module's header for why the three are deliberately not the same list.
+from dashboard import trainer_registry  # noqa: E402
+
+
+# ── Workshops & Delivery admin ───────────────────────────────────────────────
+# These routes back the ops dashboard's "Workshops & Delivery" tab. They are
+# _require_writer, NOT _require_service_or_writer, and that difference is the
+# whole security model: the app ships a baked service bearer that every install
+# holds, so accepting it here would let any tenant's app read every other
+# tenant's roster. _require_writer demands X-Auth-User, which only nginx sets
+# after an oauth2-proxy auth_request — hence a real, signed-in org member.
+#
+# A consequence worth stating rather than rediscovering: on these routes
+# _sees_full_identities() is True by construction, so payloads are returned
+# UNMASKED on purpose. Do not add masking here; add it if a route ever loses
+# the writer gate.
+
+@app.get("/api/workshops/admin/trainers")
+async def api_workshops_admin_trainers(request: Request):
+    """Every registered trainer, with attribution."""
+    await _require_writer(request)
+    entries = await trainer_registry.list_entries(pool)
+    return {"trainers": entries, "count": len(entries)}
+
+
+@app.post("/api/workshops/admin/trainers")
+async def api_workshops_admin_trainer_add(request: Request):
+    """Add (or re-attribute) a trainer. Idempotent: re-adding keeps the
+    original addedAt/addedBy, because a re-add is not a new grant."""
+    role = await _require_writer(request)
+    body = await request.json()
+    try:
+        entry = await trainer_registry.add_entry(
+            pool, body.get("email"),
+            name=body.get("name") or "",
+            added_by=role.get("user") or "",
+            note=body.get("note") or "")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"ok": True, "trainer": entry}
+
+
+@app.delete("/api/workshops/admin/trainers/{email}")
+async def api_workshops_admin_trainer_remove(request: Request, email: str):
+    """Remove a trainer. 404 when they were not registered, so the UI can tell
+    "already gone" from "removed just now"."""
+    await _require_writer(request)
+    removed = await trainer_registry.remove_entry(pool, email)
+    if not removed:
+        raise HTTPException(status_code=404, detail="not a registered trainer")
+    return {"ok": True, "removed": live_sessions.normalize_email(email)}
+
+
+@app.get("/api/workshops/admin/schedule")
+async def api_workshops_admin_schedule(request: Request, state: str = "",
+                                       limit: int = 500):
+    """Every workshop on every tenant, ordered by when it HAPPENS.
+
+    Ordering is done here rather than by a second Redis zset. `live:sessions:index`
+    is scored by createdAt, and a scheduledAt zset would need maintaining at four
+    write sites against a field that is optional AND mutable — while saving only
+    the ZRANGE, not the per-row HGETALL/SCARD/HLEN that actually dominate. If
+    this ever outgrows a sort, _walk_workshop_index() is the one place to change.
+
+    Returned UNMASKED on purpose: _require_writer means a signed-in GitHub org
+    member, for whom _sees_full_identities() is True by construction. Do not add
+    masking here — add it if this route ever loses the writer gate.
+    """
+    await _require_writer(request)
+    wanted_states = {s.strip() for s in (state or "").split(",") if s.strip()}
+    rows = []
+    async for session_id, session in _walk_workshop_index():
+        if wanted_states and session.get("state", "") not in wanted_states:
+            continue
+        _, roster_key, joined_key = _live_keys(session_id)
+        rows.append(live_sessions.shape_admin_row(
+            session_id, session,
+            await pool.smembers(roster_key),
+            await pool.hgetall(joined_key),
+            await pool.hgetall(_live_tenants_key(session_id))))
+    rows.sort(key=lambda r: r.get("scheduledAt") or r.get("createdAt") or "")
+    capped = rows[:max(1, min(limit, 1000))]
+    return {"workshops": capped, "count": len(capped), "total": len(rows),
+            "generatedAt": datetime.now(timezone.utc).isoformat()}
 
 
 @app.post("/api/tenants/register-identity")
@@ -5274,6 +5372,32 @@ async def _arena_exec_run(job_id: str, meta: dict, body: ArenaExecRequest) -> di
     return result
 
 
+async def _revoke_job_tokens(job_id: str, meta: dict) -> None:
+    """Best-effort revocation of the DT tokens a job was provisioned with.
+
+    Only tokens minted from a credential ORBITAL WAS HANDED are revocable here.
+    App-minted tokens are revoked by the app, which holds the only credential
+    that can — which is why every app-side caller of a terminate route must
+    also call reclaimJobTokens. Never raises: a revocation failure must not
+    stop a teardown.
+    """
+    if not (meta.get("dt_token_ids") and meta.get("dt_tenant_url")
+            and (meta.get("dt_auth_token") or meta.get("dt_oauth_client_id"))):
+        return
+    from provisioning import DTTokenProvisioner
+    try:
+        token_ids = json.loads(meta["dt_token_ids"])
+        provisioner = DTTokenProvisioner(
+            tenant_url=meta["dt_tenant_url"],
+            api_token=meta.get("dt_auth_token", ""),
+            oauth_client_id=meta.get("dt_oauth_client_id", ""),
+            oauth_client_secret=meta.get("dt_oauth_client_secret", ""),
+        )
+        asyncio.create_task(provisioner.revoke_tokens(token_ids))
+    except Exception as exc:
+        log.warning("Could not initiate token revocation for %s: %s", job_id, exc)
+
+
 @app.post("/api/arena/sessions/{job_id}/terminate")
 async def api_arena_terminate(job_id: str, request: Request):
     """Terminate a training session from the Arena app (no oauth2-proxy auth required).
@@ -5295,24 +5419,8 @@ async def api_arena_terminate(job_id: str, request: Request):
         )
         raise HTTPException(404, detail)
 
-    # Best-effort: revoke provisioned DT tokens
     meta = await pool.hgetall(f"job:running:{job_id}")
-    # Only tokens minted from a credential the CALLER supplied are revocable here. App-minted
-    # tokens are revoked by the app itself — Orbital holds no tenant credential.
-    if (meta.get("dt_token_ids") and meta.get("dt_tenant_url")
-            and (meta.get("dt_auth_token") or meta.get("dt_oauth_client_id"))):
-        from provisioning import DTTokenProvisioner
-        try:
-            token_ids = json.loads(meta["dt_token_ids"])
-            provisioner = DTTokenProvisioner(
-                tenant_url=meta["dt_tenant_url"],
-                api_token=meta.get("dt_auth_token", ""),
-                oauth_client_id=meta.get("dt_oauth_client_id", ""),
-                oauth_client_secret=meta.get("dt_oauth_client_secret", ""),
-            )
-            asyncio.create_task(provisioner.revoke_tokens(token_ids))
-        except Exception as exc:
-            log.warning("Could not initiate token revocation for %s: %s", job_id, exc)
+    await _revoke_job_tokens(job_id, meta)
 
     # Mark terminating IMMEDIATELY so the UI sees the session gone right away — the
     # worker's container teardown is slow, but session-status/find-session treat a
@@ -5338,10 +5446,72 @@ def _live_keys(session_id: str) -> tuple[str, str, str]:
     return base, f"{base}:roster", f"{base}:joined"
 
 
+LIVE_INDEX_KEY = "live:sessions:index"
+
+
+async def _walk_workshop_index():
+    """Yield (session_id, session_hash) for every indexed workshop, newest first.
+
+    Also SELF-HEALS the index. `live:sessions:index` is ZREM'd on a hard delete
+    (_delete_live_session_keys) but not when an ended workshop's keys reach
+    their TTL, so expired members accumulate without bound. Every caller
+    already skipped a member whose hash had gone; dropping it here makes that
+    skip permanent instead of paying for it on every list call forever.
+    """
+    for session_id in await pool.zrevrange(LIVE_INDEX_KEY, 0, -1):
+        session = await pool.hgetall(f"live:session:{session_id}")
+        if not session:
+            await pool.zrem(LIVE_INDEX_KEY, session_id)
+            continue
+        yield session_id, session
+
+
 def _live_tenants_key(session_id: str) -> str:
-    """Hash email -> normalized tenant URL the learner joined FROM (cross-
-    tenant workshops). Entries absent for pre-fix joins — always optional."""
+    """Hash email -> normalized tenant URL that will PROVISION this learner.
+
+    Written only through _bind_tenant(). Historically this was "the tenant the
+    learner joined from", updated on every join; it is now a deliberate,
+    first-write-wins binding — see live_sessions' tenant-binding section."""
     return f"live:session:{session_id}:tenants"
+
+
+def _live_boundat_key(session_id: str) -> str:
+    """Hash email -> ISO8601 of when the provisioning tenant was bound.
+
+    A parallel hash rather than re-encoding :tenants, so every existing reader
+    of that hash (provision-all, provision-ack, readiness, detail) keeps
+    working byte-for-byte. Absent for bindings made before this existed —
+    bind_outcome keys off the tenant, never the timestamp, for that reason.
+    """
+    return f"live:session:{session_id}:boundat"
+
+
+async def _bind_tenant(session_id: str, email: str, tenant: str, *,
+                       rebind: bool = False) -> tuple[str, str]:
+    """THE one place a provisioning tenant is written. Returns (outcome, tenant).
+
+    First write wins unless `rebind` is set, so walking into a second tenant
+    never silently moves a learner. `rebind=True` means either the learner
+    explicitly asked, or provision-ack is recording where an environment
+    actually landed — ground truth outranks intent.
+    """
+    email = live_sessions.normalize_email(email)
+    tenant = live_sessions.normalize_tenant(tenant)
+    tkey = _live_tenants_key(session_id)
+    boundat_key = _live_boundat_key(session_id)
+    existing = await pool.hget(tkey, email) or ""
+    outcome = live_sessions.bind_outcome(existing, tenant, rebind=rebind)
+    if outcome in (live_sessions.BIND_BOUND, live_sessions.BIND_REBOUND):
+        await pool.hset(tkey, email, tenant)
+        await pool.hset(boundat_key, email,
+                        datetime.now(timezone.utc).isoformat())
+        await _emit_live_event(
+            session_id,
+            live_sessions.EVENT_BOUND if outcome == live_sessions.BIND_BOUND
+            else live_sessions.EVENT_REBOUND,
+            email=email, tenant=tenant)
+        return outcome, tenant
+    return outcome, live_sessions.normalize_tenant(existing)
 
 
 def _live_provdone_key(session_id: str) -> str:
@@ -5402,6 +5572,16 @@ class LiveSessionJoin(BaseModel):
     # Learner's own tenant URL — stamped SERVER-side by the app function
     # (never trusted from the browser). Optional: legacy callers omit it.
     tenant: str = ""
+
+
+class LiveSessionBind(BaseModel):
+    email: str = ""
+    # Learner's own tenant URL (see LiveSessionJoin.tenant).
+    tenant: str = ""
+    # False (default) = "bind me if I am not bound yet" — the automatic call the
+    # lobby makes on entry. True = the learner explicitly asked to move their
+    # provisioning to the tenant they are looking at right now.
+    rebind: bool = False
 
 
 class LiveSessionTrainerAction(BaseModel):
@@ -5574,11 +5754,8 @@ async def api_live_sessions_list(request: Request, email: str = "", tenant: str 
     # member / no-caller automation.
     full_admin = _sees_full_identities(request, email)
     sessions = []
-    for session_id in await pool.zrevrange("live:sessions:index", 0, -1):
-        sess_key, roster_key, joined_key = _live_keys(session_id)
-        session = await pool.hgetall(sess_key)
-        if not session:
-            continue  # expired after `ended` — tolerate the stale index member
+    async for session_id, session in _walk_workshop_index():
+        _, roster_key, joined_key = _live_keys(session_id)
         roster = await pool.smembers(roster_key)
         if not live_sessions.is_listed(session, roster, email, tenant):
             continue
@@ -5587,7 +5764,13 @@ async def api_live_sessions_list(request: Request, email: str = "", tenant: str 
             session_id, session, roster, joined, email)
         full = full_admin or live_sessions.is_trainer(email, session)
         sessions.append(item if full else masking.mask_live_summary(item))
-    return {"sessions": sessions, "count": len(sessions)}
+    # May this caller SCHEDULE a workshop? The app's boot aggregate already
+    # calls this route, so answering here costs one SISMEMBER and saves the app
+    # a second round-trip on every boot. Never masked: it is the caller's own
+    # fact about themselves, exactly like `myTenant` in shape_detail.
+    caller_is_trainer = await trainer_registry.is_trainer(pool, email)
+    return {"sessions": sessions, "count": len(sessions),
+            "callerIsTrainer": caller_is_trainer}
 
 
 @app.get("/api/live/sessions/past")
@@ -5611,13 +5794,10 @@ async def api_live_sessions_past(request: Request, email: str = "", tenant: str 
         raise HTTPException(status_code=400, detail="a valid email query parameter is required")
     full_admin = _sees_full_identities(request, email)
     sessions = []
-    for session_id in await pool.zrevrange("live:sessions:index", 0, -1):
+    async for session_id, session in _walk_workshop_index():
         if len(sessions) >= max(1, min(limit, 100)):
             break
-        sess_key, roster_key, joined_key = _live_keys(session_id)
-        session = await pool.hgetall(sess_key)
-        if not session:
-            continue  # TTL-expired: the index tolerates stale members
+        _, roster_key, joined_key = _live_keys(session_id)
         roster = await pool.smembers(roster_key)
         if not live_sessions.is_past(session, roster, email, tenant):
             continue
@@ -5673,15 +5853,21 @@ async def api_live_session_detail(session_id: str, request: Request, email: str 
     # needs exactly one: their OWN, so their app can tell "already provisioning
     # here" from "bound somewhere else" — hence hget, not hgetall. Anonymous
     # callers read nothing; there is nobody to answer it for.
+    # boundAt rides exactly the same scoping as tenants — same key shape, same
+    # three cases — so the two never disagree about who may see what.
     if live_sessions.is_trainer(email, session):
         tenants = await pool.hgetall(_live_tenants_key(session_id))
+        bound_at = await pool.hgetall(_live_boundat_key(session_id))
     elif named:
         mine = await pool.hget(_live_tenants_key(session_id), named)
         tenants = {named: mine} if mine else None
+        mine_at = await pool.hget(_live_boundat_key(session_id), named)
+        bound_at = {named: mine_at} if mine_at else None
     else:
         tenants = None
+        bound_at = None
     detail = live_sessions.shape_detail(session_id, session, roster, joined, email,
-                                        provision_done, tenants)
+                                        provision_done, tenants, bound_at)
     # Service bearer alone must not unmask (BUG-MASK-1); the session trainer
     # (caller email == trainerEmail) or a real org member does.
     caller = live_sessions.normalize_email(email)
@@ -5708,11 +5894,12 @@ async def api_live_session_join(session_id: str, body: LiveSessionJoin):
         raise HTTPException(status_code=err[0], detail=err[1])
     first_join = await pool.hsetnx(joined_key, email,
                                    datetime.now(timezone.utc).isoformat())
-    # Cross-tenant workshops: remember which tenant the learner joined FROM
-    # (last join wins — a re-join from another tenant updates it).
-    tenant = live_sessions.normalize_tenant(body.tenant)
-    if tenant:
-        await pool.hset(_live_tenants_key(session_id), email, tenant)
+    # Bind the provisioning tenant, FIRST WRITE WINS. This used to be
+    # last-join-wins, which meant opening the workshop from a second tenant
+    # silently moved a learner who already had (or was about to get) an
+    # environment somewhere else. Changing it is now an explicit act — see
+    # /bind with rebind:true.
+    _, tenant = await _bind_tenant(session_id, email, body.tenant)
     # Audit + the trainer's arrival toast. Only on the FIRST join, or a learner
     # reloading their tab would re-notify the trainer on every refresh.
     if first_join:
@@ -5720,6 +5907,46 @@ async def api_live_session_join(session_id: str, body: LiveSessionJoin):
                                email=email, tenant=tenant)
     return {"state": session.get("state", ""),
             "joinedCount": await pool.hlen(joined_key)}
+
+
+@app.post("/api/live/sessions/{session_id}/bind")
+async def api_live_session_bind(session_id: str, body: LiveSessionBind,
+                                request: Request):
+    """Bind (or explicitly re-bind) the tenant that will provision this learner.
+
+    This is what replaced the "Provision here" button. The lobby calls it
+    automatically on entry with rebind=false, so a learner who clicks nothing
+    is still bound; the button survives only as the rebind=true control shown
+    when they are bound somewhere else.
+
+    Allowed with the room CLOSED and the workshop days away — binding is not
+    attendance and does not touch :joined. Only ended/cancelled refuse.
+
+    Auth: service bearer or signed-in writer (same as join-by-code — learners
+    reach it through the app's authed proxy, which stamps `tenant` server-side).
+    """
+    await _require_service_or_writer(request)
+    email = live_sessions.normalize_email(body.email)
+    if not live_sessions.is_valid_email(email):
+        raise HTTPException(status_code=400, detail="a valid email is required")
+    sess_key, roster_key, _ = _live_keys(session_id)
+    session = await pool.hgetall(sess_key)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+    roster = await pool.smembers(roster_key)
+    err = live_sessions.bind_error(session.get("state", ""), email, roster, session)
+    if err:
+        raise HTTPException(status_code=err[0], detail=err[1])
+    outcome, tenant = await _bind_tenant(session_id, email, body.tenant,
+                                         rebind=bool(body.rebind))
+    return {
+        "tenant": tenant,
+        "boundAt": await pool.hget(_live_boundat_key(session_id), email) or "",
+        "outcome": outcome,
+        # Whether the tenant the caller is sitting in is the bound one. The
+        # lobby renders three different messages off this plus `tenant`.
+        "boundHere": bool(tenant) and tenant == live_sessions.normalize_tenant(body.tenant),
+    }
 
 
 @app.post("/api/live/sessions/{session_id}/start")
@@ -5844,8 +6071,14 @@ async def api_live_session_delete(session_id: str, request: Request, trainerEmai
     session = await pool.hgetall(sess_key)
     if not session:
         raise HTTPException(status_code=404, detail="Session not found or expired")
-    if not live_sessions.is_trainer(trainerEmail, session):
-        raise HTTPException(status_code=403, detail="trainerEmail does not match this session's trainer")
+    # OWNER only — the one authority a co-trainer does not share. Deleting is
+    # irreversible and destroys the roster and audit trail of a workshop
+    # somebody else created; every other trainer action is deliberately shared.
+    if not live_sessions.is_owner(trainerEmail, session):
+        detail = ("only the workshop owner may delete it"
+                  if live_sessions.is_trainer(trainerEmail, session)
+                  else "trainerEmail does not match this session's trainer")
+        raise HTTPException(status_code=403, detail=detail)
     try:
         live_sessions.apply_transition(session.get("state", ""), "delete")
     except ValueError as exc:
@@ -5980,9 +6213,11 @@ async def api_live_session_join_by_code(body: LiveSessionJoinByCode, request: Re
                     session_id, session, roster,
                     await pool.hgetall(joined_key), email)}
     newly_registered = await pool.sadd(roster_key, email)
-    tenant = live_sessions.normalize_tenant(body.tenant)
-    if tenant:
-        await pool.hset(_live_tenants_key(session_id), email, tenant)
+    # Entering a code IS the "provision me here" signal — the learner typed it
+    # while sitting in a tenant. First write wins, so a learner who registers
+    # from one tenant and later pastes the same code in another keeps their
+    # original binding until they explicitly change it.
+    _, tenant = await _bind_tenant(session_id, email, body.tenant)
     if newly_registered:
         await _emit_live_event(session_id, live_sessions.EVENT_REGISTERED,
                                email=email, detail="join code", tenant=tenant)
@@ -6165,9 +6400,11 @@ async def api_live_session_provision_ack(session_id: str,
     # The tenant that actually executed the request IS the learner's binding —
     # persist it so the trainer's board shows where the environment lives, not
     # just where the learner first checked in.
-    ack_tenant = live_sessions.normalize_tenant(body.tenant)
-    if ack_tenant:
-        await pool.hset(_live_tenants_key(session_id), email, ack_tenant)
+    # rebind=True on purpose — the ONE caller allowed to override an existing
+    # binding without the learner asking. Everywhere else binding is first-write-
+    # wins intent; here it is ground truth about where an environment actually
+    # landed, and the board must show the truth.
+    await _bind_tenant(session_id, email, body.tenant, rebind=True)
     failed = status == "failed" or bool(body.error)
     await _emit_live_event(
         session_id,
@@ -6306,6 +6543,57 @@ async def api_live_session_update(session_id: str, body: LiveSessionUpdate, requ
     return live_sessions.shape_detail(session_id, session, roster, joined, body.trainerEmail)
 
 
+async def _workshop_jobs(session_id: str, session: dict,
+                         emails) -> list[tuple[str, str, dict]]:
+    """Running arena jobs belonging to this workshop, for these learners.
+
+    Returns [(redis_key, job_id, meta)].
+
+    Matching prefers `workshop_id`, which every job has carried since it was
+    stamped at provision time. The (arena_user, training_id) fallback exists
+    only for environments started before that, and it is the reason the old
+    cohort-wide terminate could reach a learner's environment from a DIFFERENT
+    workshop of the same training. For a single named learner that would be a
+    real bug — same person, same training, wrong room — so the id match is
+    what makes the per-learner routes safe.
+    """
+    wanted = {live_sessions.normalize_email(e) for e in (emails or ()) if e}
+    training_id = (session.get("trainingId") or "").strip()
+    out: list[tuple[str, str, dict]] = []
+    async for key in pool.scan_iter(match="job:running:enablement-*"):
+        meta = await pool.hgetall(key)
+        if not meta:
+            continue
+        if live_sessions.normalize_email(meta.get("arena_user")) not in wanted:
+            continue
+        job_workshop = (meta.get("workshop_id") or "").strip()
+        if job_workshop:
+            if job_workshop != session_id:
+                continue
+        elif (meta.get("training_id") or "").strip() != training_id:
+            continue
+        out.append((key, meta.get("job_id") or key.rsplit(":", 1)[-1], meta))
+    return out
+
+
+async def _terminate_jobs(jobs) -> tuple[list[str], int]:
+    """Terminate the given jobs, revoking what Orbital can revoke.
+
+    Idempotent: a job already marked terminating is counted as skipped rather
+    than re-published, so a trainer mashing the button does not queue N kills.
+    """
+    terminated, skipped = [], 0
+    for key, job_id, meta in jobs:
+        if meta.get("terminating") == "1":
+            skipped += 1
+            continue
+        await _revoke_job_tokens(job_id, meta)
+        await pool.hset(key, "terminating", "1")
+        await pool.publish("ops:terminate", job_id)
+        terminated.append(job_id)
+    return terminated, skipped
+
+
 @app.post("/api/live/sessions/{session_id}/terminate-all")
 async def api_live_session_terminate_all(session_id: str, body: LiveSessionTrainerAction):
     """Terminate every environment provisioned for this workshop.
@@ -6330,28 +6618,143 @@ async def api_live_session_terminate_all(session_id: str, body: LiveSessionTrain
 
     participants = {live_sessions.normalize_email(e) for e in await pool.smembers(roster_key)}
     participants.add(trainer)
-    training_id = (session.get("trainingId") or "").strip()
 
-    terminated, skipped = [], 0
-    async for key in pool.scan_iter(match="job:running:enablement-*"):
-        meta = await pool.hgetall(key)
-        if not meta:
-            continue
-        if (meta.get("training_id") or "").strip() != training_id:
-            continue
-        if live_sessions.normalize_email(meta.get("arena_user")) not in participants:
-            continue
-        job_id = meta.get("job_id") or key.rsplit(":", 1)[-1]
-        if meta.get("terminating") == "1":
-            skipped += 1
-            continue
-        await pool.hset(key, "terminating", "1")
-        await pool.publish("ops:terminate", job_id)
-        terminated.append(job_id)
+    jobs = await _workshop_jobs(session_id, session, participants)
+    terminated, skipped = await _terminate_jobs(jobs)
     log.info("live: terminate-all %s → %d terminated, %d already terminating",
              session_id, len(terminated), skipped)
     return {"terminated": terminated, "count": len(terminated),
             "alreadyTerminating": skipped}
+
+
+class LiveSessionLearnerEnv(BaseModel):
+    trainerEmail: str = ""
+    # Reprovision only: the tenant to build in. The app stamps its own tenant
+    # server-side; when it differs from the learner's binding the request goes
+    # through the pull channel instead, exactly as provision-all does.
+    tenant: str = ""
+    perUser: dict = {}
+
+
+async def _learner_env_gate(session_id: str, email: str, trainer_email: str):
+    """Shared preamble for the per-learner env routes: resolve + authorize.
+
+    Gate is is_trainer, NOT is_owner — a co-trainer troubleshooting a stuck
+    learner is the case these buttons exist for, and "wait for the owner" is
+    not an answer while a room is running.
+    """
+    email = live_sessions.normalize_email(email)
+    if not live_sessions.is_valid_email(email):
+        raise HTTPException(status_code=400, detail="a valid email is required")
+    sess_key, roster_key, _ = _live_keys(session_id)
+    session = await pool.hgetall(sess_key)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found or expired")
+    if not live_sessions.is_trainer(trainer_email, session):
+        raise HTTPException(status_code=403,
+                            detail="trainerEmail does not match this session's trainer")
+    return email, session, roster_key
+
+
+@app.post("/api/live/sessions/{session_id}/learner/{email}/terminate")
+async def api_live_learner_terminate(session_id: str, email: str,
+                                     body: LiveSessionLearnerEnv,
+                                     request: Request):
+    """Terminate ONE learner's environment for this workshop.
+
+    Until now the only tool was terminate-all, so "this one student's tenant is
+    wrong" cost the whole cohort their environments. Freeing a single learner is
+    also what lets them be re-bound and provisioned somewhere else.
+
+    Scoped by workshop_id (see _workshop_jobs), so a learner's environment from
+    a different workshop of the same training is never touched. Idempotent.
+    """
+    await _require_service_or_writer(request)
+    email, session, _ = await _learner_env_gate(session_id, email, body.trainerEmail)
+    jobs = await _workshop_jobs(session_id, session, {email})
+    terminated, skipped = await _terminate_jobs(jobs)
+    if terminated:
+        await _emit_live_event(session_id, live_sessions.EVENT_ENV_TERMINATED,
+                               email=email, actor=body.trainerEmail,
+                               detail=",".join(terminated)[:200])
+    log.info("live: learner terminate %s/%s → %d terminated, %d already terminating",
+             session_id, email, len(terminated), skipped)
+    return {"terminated": terminated, "count": len(terminated),
+            "alreadyTerminating": skipped}
+
+
+@app.post("/api/live/sessions/{session_id}/learner/{email}/reprovision")
+async def api_live_learner_reprovision(session_id: str, email: str,
+                                       body: LiveSessionLearnerEnv,
+                                       request: Request):
+    """Terminate this learner's environment and build them a fresh one.
+
+    The recovery path for a provision that half-worked. It deliberately reuses
+    provision-all's single-learner logic rather than a parallel implementation:
+    if the learner is bound to a tenant this caller cannot mint for, the result
+    is `requested` and their own tenant's app picks it up on its next poll —
+    the same pull channel, no new mechanism.
+    """
+    await _require_service_or_writer(request)
+    email, session, _ = await _learner_env_gate(session_id, email, body.trainerEmail)
+    provdone_key = _live_provdone_key(session_id)
+
+    jobs = await _workshop_jobs(session_id, session, {email})
+    terminated, _ = await _terminate_jobs(jobs)
+    if terminated:
+        await _emit_live_event(session_id, live_sessions.EVENT_ENV_TERMINATED,
+                               email=email, actor=body.trainerEmail,
+                               detail=",".join(terminated)[:200])
+
+    bound = await pool.hget(_live_tenants_key(session_id), email) or ""
+    joined = await pool.hgetall(_live_keys(session_id)[2])
+    skip = live_sessions.provision_skip_status(email in joined, bound, body.tenant)
+    if skip:
+        # Their own tenant has to do it. Clear the settled marker and re-arm the
+        # request flag — the learner's app acts on (session, provisionRequestedAt).
+        await pool.hdel(provdone_key, email)
+        await pool.hset(_live_keys(session_id)[0], mapping={
+            "provisionRequestedAt": datetime.now(timezone.utc).isoformat(),
+            "provisionRequestedBy": live_sessions.normalize_email(body.trainerEmail),
+        })
+        await _emit_live_event(session_id, live_sessions.EVENT_PROVISION_REQUESTED,
+                               email=email, actor=body.trainerEmail,
+                               tenant=bound, detail="reprovision")
+        return {"terminated": terminated, "status": "requested", "reason": skip,
+                "tenant": bound,
+                "message": live_sessions.PROVISION_REQUESTED_MESSAGE}
+
+    tenant_for_env = (body.tenant or "").rstrip("/")
+    per = body.perUser.get(email) or body.perUser.get(email.lower()) or {}
+    try:
+        provisioned = await api_arena_provision(ArenaProvisionRequest(
+            trainingId=session.get("trainingId", ""),
+            userId=email,
+            tenantUrl=tenant_for_env,
+            ref=session.get("ref", ""),
+            dtEnv=per.get("dtEnv") or {},
+            dtTokenIds=per.get("dtTokenIds") or [],
+            sessionHours=workshop_session_hours(session),
+        ), request)
+    except HTTPException as exc:
+        await _emit_live_event(session_id, live_sessions.EVENT_PROVISION_FAILED,
+                               email=email, actor=body.trainerEmail,
+                               tenant=tenant_for_env, detail=str(exc.detail))
+        return {"terminated": terminated, "status": "error",
+                "error": str(exc.detail)[:200]}
+    except Exception as exc:
+        await _emit_live_event(session_id, live_sessions.EVENT_PROVISION_FAILED,
+                               email=email, actor=body.trainerEmail,
+                               tenant=tenant_for_env, detail=str(exc))
+        return {"terminated": terminated, "status": "error", "error": str(exc)[:200]}
+
+    status = "already-active" if provisioned.get("deduped") else "queued"
+    await pool.hset(provdone_key, email, status)
+    await _emit_live_event(session_id, live_sessions.EVENT_PROVISION_STARTED,
+                           email=email, tenant=tenant_for_env,
+                           actor=body.trainerEmail, detail=f"reprovision:{status}")
+    return {"terminated": terminated, "status": status,
+            "jobId": provisioned.get("jobId", ""), "tenant": tenant_for_env}
 
 
 @app.get("/api/live/sessions/{session_id}/readiness")
@@ -6447,6 +6850,26 @@ async def api_live_session_readiness(session_id: str, request: Request,
                                 joined_tenants.get(email, ""), tenant,
                                 requested=live_sessions.provision_request_pending(
                                     session, email, provision_done))})
+    # Two fields the board needs that are not derivable client-side:
+    #   attendance     registered | bound | present — the split between "we know
+    #                  where to provision them" and "they are actually here".
+    #   envTenant/     where the environment ACTUALLY runs, and whether that
+    #   tenantMismatch disagrees with the binding. This works because
+    #                  job:running:* is a GLOBAL keyspace: Orbital sees every
+    #                  tenant's jobs, so it can spot a learner who walked into
+    #                  the wrong classroom. Resolution is the trainer's call —
+    #                  nothing is torn down automatically.
+    for row in results:
+        email = row["email"]
+        row["attendance"] = ("trainer" if row.get("role") == "trainer"
+                             else live_sessions.attendance_state(
+                                 email, roster, joined, joined_tenants))
+        meta = running_by_email.get(email)
+        env_tenant = live_sessions.normalize_tenant(meta.get("arena_tenant")) if meta else ""
+        if env_tenant:
+            row["envTenant"] = env_tenant
+        row["tenantMismatch"] = live_sessions.env_tenant_mismatch(
+            env_tenant, row.get("tenant", ""))
     payload = {"results": results}
     # trainerEmail is caller-supplied — anonymous callers who know it must
     # not harvest the roster; they get masked emails (states stay visible).
@@ -6636,6 +7059,7 @@ async def _expire_live_session_keys(session_id: str, session: dict):
     without a pad, chat or join code."""
     sections_key, qa_key, _ = _pad_keys(session_id)
     keys = [*_live_keys(session_id), _live_tenants_key(session_id),
+            _live_boundat_key(session_id),
             _live_provdone_key(session_id), _live_events_key(session_id),
             sections_key, qa_key, *_room_keys(session_id)]
     if session.get("joinCode"):
@@ -6651,6 +7075,7 @@ async def _delete_live_session_keys(session_id: str, session: dict):
     from every list. delete on a missing key is a no-op."""
     sections_key, qa_key, export_key = _pad_keys(session_id)
     keys = [*_live_keys(session_id), _live_tenants_key(session_id),
+            _live_boundat_key(session_id),
             _live_provdone_key(session_id), _live_events_key(session_id),
             sections_key, qa_key, export_key, *_room_keys(session_id),
             # Delete is pre-start only, so a completion record should not exist

--- a/ops-server/dashboard/live_sessions.py
+++ b/ops-server/dashboard/live_sessions.py
@@ -344,10 +344,14 @@ EVENT_PROVISION_STARTED = "provision-started"
 EVENT_PROVISION_FAILED = "provision-failed"
 EVENT_STARTED = "started"
 EVENT_ENDED = "ended"
+EVENT_BOUND = "bound"
+EVENT_REBOUND = "rebound"
+EVENT_ENV_TERMINATED = "env-terminated"
 
 EVENT_KINDS = (
     EVENT_JOINED, EVENT_REGISTERED, EVENT_PROVISION_REQUESTED, EVENT_PROVISION_ACCEPTED,
     EVENT_PROVISION_STARTED, EVENT_PROVISION_FAILED, EVENT_STARTED, EVENT_ENDED,
+    EVENT_BOUND, EVENT_REBOUND, EVENT_ENV_TERMINATED,
 )
 
 # Cap the stream. A 300-seat workshop emits several events per learner, and an
@@ -523,6 +527,23 @@ def is_trainer(email, session) -> bool:
     return bool(e) and e in trainers_of(session)
 
 
+def is_owner(email, session) -> bool:
+    """True only for the workshop's CREATOR — trainers[0].
+
+    The single asymmetry in the trainer team. Co-trainers hold identical
+    authority for delivery — edit, start, open the room, provision, terminate a
+    learner's environment, pace, broadcast, reveal solutions — because a
+    co-trainer who cannot act is not a co-trainer, and "the trainer is not
+    available" is the exact case they exist for. What they cannot do is DELETE
+    the workshop, which is irreversible and destroys other people's work.
+
+    Note this says nothing about who may CREATE workshops: that is the global
+    trainer registry (dashboard/trainer_registry.py), a different list.
+    """
+    e = normalize_email(email)
+    return bool(e) and e == lead_trainer(session)
+
+
 def on_roster(email, roster) -> bool:
     """True when the email is on the roster (stored lowercase)."""
     return normalize_email(email) in set(roster or ())
@@ -547,6 +568,103 @@ def join_error(state, email, roster, session=None):
     if state == "cancelled":
         return 409, "session has been cancelled"
     return None
+
+
+# ── Tenant binding (which tenant will provision this learner) ────────────────
+#
+# Binding used to be a side effect of "Provision here" — a button whose label
+# promised an action it did not perform (it checked you in and recorded your
+# tenant; it started nothing). Most learners never pressed it, which is the
+# root of "the trainer provisioned everyone and this student still has
+# nothing".
+#
+# Binding is now automatic on first lobby entry, and it is deliberately NOT the
+# same fact as attendance:
+#
+#   registered  on the roster                      (:roster)
+#   bound       we know where to provision them     (:tenants + :boundat)
+#   present     actually in an open/running room    (:joined)
+#
+# Binding can happen days before the workshop, so collapsing it into `joined`
+# would report someone who glanced at the lobby on Monday as present at
+# Friday's session, and inflate the seat maths the trainer plans against.
+#
+# FIRST WRITE WINS. A learner who opens the workshop from a second tenant must
+# not be silently moved: they see where they are bound and change it with an
+# explicit click. The single exception is provision-ack, which records where an
+# environment ACTUALLY landed — ground truth beats intent.
+
+BIND_BOUND = "bound"        # nothing was bound; this call bound it
+BIND_KEPT = "kept"          # a binding existed; left alone (first write wins)
+BIND_REBOUND = "rebound"    # explicit change, or ground truth from an ack
+
+
+def bind_error(state, email, roster, session=None):
+    """Return (http_status, detail) blocking a bind, or None when allowed.
+
+    Membership is the same rule as join_error — the trainer team always
+    qualifies, roster members qualify — but the STATE rule is looser on
+    purpose: binding is not attendance, so it is allowed with the room closed
+    and the workshop days away. That is the whole point; it is what lets a
+    learner's tenant be known before anyone opens the classroom.
+
+    Only a finished workshop refuses: there is nothing left to provision.
+    """
+    if not on_roster(email, roster) and not is_trainer(email, session or {}):
+        return 403, "email is not on the session roster"
+    if state == "ended":
+        return 409, "session has ended"
+    if state == "cancelled":
+        return 409, "session has been cancelled"
+    return None
+
+
+def bind_outcome(existing_tenant, new_tenant, rebind=False) -> str:
+    """Decide what a bind request does. Keyed off the TENANT, never a timestamp,
+    so a binding made before `boundAt` existed still counts as a binding."""
+    existing = normalize_tenant(existing_tenant)
+    new = normalize_tenant(new_tenant)
+    if not new:
+        return BIND_KEPT          # nothing usable offered; never clear a binding
+    if not existing:
+        return BIND_BOUND
+    if existing == new:
+        return BIND_KEPT          # already here; not a change worth auditing
+    return BIND_REBOUND if rebind else BIND_KEPT
+
+
+ATTENDANCE_NONE = ""
+ATTENDANCE_REGISTERED = "registered"
+ATTENDANCE_BOUND = "bound"
+ATTENDANCE_PRESENT = "present"
+
+
+def attendance_state(email, roster, joined, tenants) -> str:
+    """How far this learner has got. Highest reached wins, because the states
+    are cumulative: being present implies being bound implies being registered,
+    and reporting the lowest would hide progress the trainer needs to see."""
+    e = normalize_email(email)
+    if not e:
+        return ATTENDANCE_NONE
+    if e in (joined or {}):
+        return ATTENDANCE_PRESENT
+    if (tenants or {}).get(e):
+        return ATTENDANCE_BOUND
+    if e in set(roster or ()):
+        return ATTENDANCE_REGISTERED
+    return ATTENDANCE_NONE
+
+
+def env_tenant_mismatch(env_tenant, bound_tenant) -> bool:
+    """True when a learner's running environment is on a different tenant than
+    the one they are bound to — the "joined the wrong tenant" flag.
+
+    False when either side is unknown: an absent value is not evidence of a
+    mismatch, and flagging one would cry wolf on every un-provisioned learner.
+    """
+    env = normalize_tenant(env_tenant)
+    bound = normalize_tenant(bound_tenant)
+    return bool(env and bound and env != bound)
 
 
 def join_by_code_error(state, email, roster, max_seats):
@@ -737,6 +855,10 @@ def shape_summary(session_id, session, roster, joined, email) -> dict:
         "createdAt":    session.get("createdAt", ""),
         "startedAt":    session.get("startedAt", ""),
         "isTrainer":    is_trainer(e, session),
+        # Owner vs co-trainer. Absent on an older Orbital → the client reads it
+        # as false and hides Delete, which is the safe direction for an
+        # irreversible action during a deploy window.
+        "isOwner":      is_owner(e, session),
         "hasJoined":    e in (joined or {}),
     }
     out.update(_room_and_gate(session))
@@ -745,7 +867,7 @@ def shape_summary(session_id, session, roster, joined, email) -> dict:
 
 
 def shape_detail(session_id, session, roster, joined, email,
-                 provision_done=None, tenants=None) -> dict:
+                 provision_done=None, tenants=None, bound_at=None) -> dict:
     """Full session state (GET /api/live/sessions/{id}).
 
     Everyone gets the scalar fields + joined/roster counts; the roster and
@@ -778,6 +900,8 @@ def shape_detail(session_id, session, roster, joined, email,
         "joinedCount":  len(joined or {}),
         "rosterCount":  len(roster or ()),
         "isTrainer":    is_trainer(email, session),
+        # See shape_summary: absent on an older Orbital → Delete stays hidden.
+        "isOwner":      is_owner(email, session),
         "hasJoined":    normalize_email(email) in (joined or {}),
         "provisionRequested": provision_request_pending(
             session, email, provision_done),
@@ -786,6 +910,15 @@ def shape_detail(session_id, session, roster, joined, email,
         # remount while the flag is still true cannot mint a second token pair.
         "provisionRequestedAt": session.get("provisionRequestedAt", ""),
         "myTenant": (tenants or {}).get(normalize_email(email), ""),
+        # When the caller's tenant was bound. '' for bindings made before this
+        # field existed — the lobby shows its message without a date.
+        "boundAt": (bound_at or {}).get(normalize_email(email), ""),
+        # How the caller's own provision request settled ('' = not settled, or
+        # never requested). Together with myTenant this is the wrong-tenant
+        # signal: bound elsewhere AND settled means an environment exists over
+        # there, so the lobby offers "ask your trainer" instead of a re-bind
+        # button that would strand it. Free — the route already reads provdone.
+        "myProvisionStatus": (provision_done or {}).get(normalize_email(email), ""),
     }
     out.update(_room_and_gate(session))
     out.update(workshop_fields(session, email))
@@ -794,6 +927,12 @@ def shape_detail(session_id, session, roster, joined, email,
         out["joined"] = [{"email": k, "joinedAt": v,
                           "tenant": (tenants or {}).get(k, "")}
                          for k, v in sorted((joined or {}).items())]
+        # Bindings cover people who have NOT checked in — the whole point of
+        # splitting the two — so this is not derivable from `joined`.
+        out["bindings"] = [{"email": k, "tenant": v,
+                            "boundAt": (bound_at or {}).get(k, "")}
+                           for k, v in sorted((tenants or {}).items())]
+        out["seats"] = seat_summary(roster, joined, session.get("maxSeats"))
     return out
 
 
@@ -858,6 +997,82 @@ def failed_job_email(record, roster, training_id, since="") -> str | None:
     if since and record.get("finished_at", "") < since:
         return None
     return email
+
+
+# ── Cross-tenant admin view (Workshops & Delivery tab) ───────────────────────
+#
+# Everything above answers "what may THIS person see about a workshop they are
+# part of". The three functions below answer a different question — "what is
+# every tenant running, and when" — for the ops dashboard, which is gated on a
+# signed-in GitHub org member rather than on workshop membership. They take no
+# caller email, and they are never masked: see the docstring on the route.
+
+def seat_summary(roster, joined, max_seats) -> dict:
+    """Seat accounting for one workshop.
+
+    `seatsOpen` is None when maxSeats is absent, NOT 0. "Unlimited" and "full"
+    are different claims and a dashboard must not render them the same way.
+
+    Seats are counted against the ROSTER (registered), not `joined`: a seat is
+    consumed by registering, which is exactly what the join-by-code seat check
+    enforces. `present` reports check-ins separately.
+    """
+    try:
+        cap = int(max_seats or 0)
+    except (TypeError, ValueError):
+        cap = 0
+    taken = len(roster or ())
+    return {
+        "seatsTaken": taken,
+        "maxSeats": cap,
+        "seatsOpen": max(cap - taken, 0) if cap else None,
+        "present": len(joined or {}),
+    }
+
+
+def schedule_sort_key(session) -> str:
+    """Calendar ordering: when the workshop HAPPENS, falling back to when it was
+    created. Both are ISO8601, so a plain string sort is chronological."""
+    return (session or {}).get("scheduledAt") or (session or {}).get("createdAt") or ""
+
+
+def shape_admin_row(session_id, session, roster, joined, tenants=None) -> dict:
+    """One row of the cross-tenant admin table.
+
+    Deliberately different from shape_summary:
+      * no caller email — this view has no "me", so no isTrainer/hasJoined;
+      * `owner` and `coTrainers` are split out, because the admin table's job is
+        to say who is accountable for a workshop, and the owner is the only one
+        who can delete it (see is_owner);
+      * `ownerTenant` is emitted HERE ONLY. It stays out of workshop_fields on
+        purpose: a learner has no business knowing which tenant a workshop was
+        created from, and this route is org-member-gated.
+    """
+    team = trainers_of(session)
+    return {
+        "sessionId": session_id,
+        "title": session.get("title", ""),
+        "trainingId": session.get("trainingId", ""),
+        "state": session.get("state", ""),
+        "owner": team[0] if team else "",
+        "coTrainers": team[1:],
+        "trainers": team,
+        "ownerTenant": session.get("ownerTenant", ""),
+        "scheduledAt": session.get("scheduledAt", ""),
+        "timezone": session.get("timezone", ""),
+        "durationMinutes": session.get("durationMinutes", ""),
+        "createdAt": session.get("createdAt", ""),
+        "startedAt": session.get("startedAt", ""),
+        "endedAt": session.get("endedAt", ""),
+        "cancelledAt": session.get("cancelledAt", ""),
+        "joinCode": session.get("joinCode", ""),
+        "roomOpen": room_open(session),
+        "registrants": sorted(roster or ()),
+        "joinedCount": len(joined or {}),
+        "boundCount": len(tenants or {}),
+        "editable": session.get("state", "") in ("scheduled", "open"),
+        **seat_summary(roster, joined, session.get("maxSeats")),
+    }
 
 
 def capacity_summary(workers, active_counts, needed) -> dict:

--- a/ops-server/dashboard/masking.py
+++ b/ops-server/dashboard/masking.py
@@ -68,6 +68,12 @@ def mask_live_detail(item: dict) -> dict:
     out = mask_live_summary(item)
     out.pop("roster", None)
     out.pop("joined", None)
+    # Trainer-only, added with the tenant-binding split. `bindings` is strictly
+    # WORSE to leak than `joined`: it maps every learner's email to the tenant
+    # they will run in, and it covers people who never checked in. `seats`
+    # is dropped alongside it because it is part of the same trainer block.
+    out.pop("bindings", None)
+    out.pop("seats", None)
     return out
 
 
@@ -86,7 +92,13 @@ def mask_readiness(payload: dict) -> dict:
                          # Only when the row has one: a row without a tenant
                          # must not gain an empty field it never had.
                          **({"tenant": mask_tenant(row["tenant"])}
-                            if row.get("tenant") else {})}
+                            if row.get("tenant") else {}),
+                         # Same grounds as `tenant`: which tenant someone's
+                         # environment runs in is identifying. `attendance` and
+                         # `tenantMismatch` are not — they say nothing about
+                         # WHICH tenant — so they stay readable.
+                         **({"envTenant": mask_tenant(row["envTenant"])}
+                            if row.get("envTenant") else {})}
                         for row in payload.get("results", [])]}
 
 

--- a/ops-server/dashboard/static/app.js
+++ b/ops-server/dashboard/static/app.js
@@ -100,6 +100,7 @@ function activateTab(view) {
     if (view === 'agentic') loadAgentic();
     if (view === 'framework') loadFramework();
     if (view === 'content') loadContent();
+    if (view === 'workshops') loadWorkshops();
     if (view === 'register') loadRegister();
 }
 
@@ -3433,9 +3434,14 @@ const csProfileOpts = (sel) =>
 
 function wireContent() {
     if (csWired) return; csWired = true;
-    document.querySelectorAll('.content-tab').forEach(t => t.addEventListener('click', () => {
-        document.querySelectorAll('.content-tab').forEach(x => x.classList.toggle('active', x === t));
-        document.querySelectorAll('.content-subview').forEach(v => { v.hidden = (v.id !== 'content-view-' + t.dataset.contentView); });
+    // Scoped to #view-content on purpose. The Workshops & Delivery tab reuses
+    // the same .content-tab/.content-subview classes for their styling, so an
+    // unscoped querySelectorAll here would toggle that tab's sub-views too and
+    // hide every panel on the page.
+    const root = document.getElementById('view-content');
+    root.querySelectorAll('.content-tab').forEach(t => t.addEventListener('click', () => {
+        root.querySelectorAll('.content-tab').forEach(x => x.classList.toggle('active', x === t));
+        root.querySelectorAll('.content-subview').forEach(v => { v.hidden = (v.id !== 'content-view-' + t.dataset.contentView); });
         if (t.dataset.contentView === 'trainings') csLoadSources();
     }));
     document.getElementById('cs-save-profile').addEventListener('click', csSaveProfile);
@@ -3643,6 +3649,346 @@ async function loadContent() {
     } catch (e) {
         document.getElementById('content-profiles').innerHTML = '<p class="content-hint">Failed to load content overview.</p>';
     }
+}
+
+// ── Workshops & Delivery tab ─────────────────────────────────────────────────
+// Orbital is the system of record for workshops (live:session:* in Redis); the
+// enablement app is a proxy over the same /api/live/* routes. This tab is a
+// cross-tenant admin surface over that existing store — the only NEW state is
+// the trainer registry.
+//
+// Writer-gated twice: nginx auth_request on /api/workshops/admin/, and
+// _require_writer in FastAPI. Hiding the tab is a convenience, not the boundary.
+
+const wsState = { workshops: [], trainers: [], month: null, editing: null };
+let wsWired = false;
+
+function wireWorkshops() {
+    if (wsWired) return; wsWired = true;
+    // Scoped to #view-workshops — see the note in wireContent().
+    const root = document.getElementById('view-workshops');
+    root.querySelectorAll('.content-tab').forEach(t => t.addEventListener('click', () => {
+        root.querySelectorAll('.content-tab').forEach(x => x.classList.toggle('active', x === t));
+        root.querySelectorAll('.content-subview').forEach(v => { v.hidden = (v.id !== 'ws-view-' + t.dataset.wsView); });
+        if (t.dataset.wsView === 'trainers') wsLoadTrainers();
+    }));
+    document.getElementById('ws-tr-add').addEventListener('click', wsAddTrainer);
+    document.getElementById('ws-tr-email').addEventListener('keydown', (e) => { if (e.key === 'Enter') wsAddTrainer(); });
+    document.querySelector('#ws-trainers tbody').addEventListener('click', (e) => {
+        const rm = e.target.closest('[data-ws-trdel]');
+        if (rm) wsRemoveTrainer(rm.dataset.wsTrdel);
+    });
+    document.getElementById('ws-reload').addEventListener('click', wsLoadSchedule);
+    document.getElementById('ws-filter-state').addEventListener('change', wsLoadSchedule);
+    document.getElementById('ws-cal-prev').addEventListener('click', () => wsShiftMonth(-1));
+    document.getElementById('ws-cal-next').addEventListener('click', () => wsShiftMonth(1));
+    document.getElementById('ws-cal-today').addEventListener('click', () => { wsState.month = null; wsRenderCalendar(); });
+    document.querySelector('#ws-table tbody').addEventListener('click', (e) => {
+        const row = e.target.closest('[data-ws-open]');
+        if (row) wsOpenEditor(row.dataset.wsOpen);
+    });
+    document.getElementById('ws-calendar').addEventListener('click', (e) => {
+        const chip = e.target.closest('[data-ws-open]');
+        if (chip) wsOpenEditor(chip.dataset.wsOpen);
+    });
+}
+
+async function loadWorkshops() {
+    wireWorkshops();
+    await Promise.all([wsLoadSchedule(), wsLoadTrainers()]);
+}
+
+// ── Trainers ─────────────────────────────────────────────────────────────────
+
+function wsTrainerMsg(text, ok) {
+    const el = document.getElementById('ws-tr-msg');
+    el.textContent = text || '';
+    el.style.color = ok ? 'var(--ok, #4ade80)' : 'var(--danger, #f87171)';
+}
+
+async function wsLoadTrainers() {
+    const tbody = document.querySelector('#ws-trainers tbody');
+    try {
+        const r = await fetch('/api/workshops/admin/trainers', { credentials: 'same-origin' });
+        if (!r.ok) {
+            tbody.innerHTML = '<tr><td colspan="6" class="content-hint">Sign in as an org member to manage trainers.</td></tr>';
+            return;
+        }
+        const j = await r.json();
+        wsState.trainers = j.trainers || [];
+        document.getElementById('ws-tr-count').textContent = `(${wsState.trainers.length})`;
+        tbody.innerHTML = wsState.trainers.length
+            ? wsState.trainers.map(t => `<tr>
+                <td>${escapeHtml(t.email || '')}</td>
+                <td>${escapeHtml(t.name || '')}</td>
+                <td>${escapeHtml(t.addedBy || '')}</td>
+                <td>${escapeHtml((t.addedAt || '').slice(0, 10))}</td>
+                <td>${escapeHtml(t.note || '')}</td>
+                <td><button class="btn btn-small btn-danger" data-action data-ws-trdel="${escapeHtml(t.email || '')}">Remove</button></td>
+              </tr>`).join('')
+            : '<tr><td colspan="6" class="content-hint">No trainers yet. Nobody can schedule a workshop until one is added.</td></tr>';
+    } catch (e) {
+        tbody.innerHTML = '<tr><td colspan="6" class="content-hint">Failed to load trainers.</td></tr>';
+    }
+}
+
+async function wsAddTrainer() {
+    const email = document.getElementById('ws-tr-email').value.trim();
+    if (!email) { wsTrainerMsg('An email is required.', false); return; }
+    wsTrainerMsg('', true);
+    const r = await fetch('/api/workshops/admin/trainers', {
+        method: 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            email,
+            name: document.getElementById('ws-tr-name').value.trim(),
+            note: document.getElementById('ws-tr-note').value.trim(),
+        }),
+    });
+    if (r.ok) {
+        ['ws-tr-email', 'ws-tr-name', 'ws-tr-note'].forEach(id => { document.getElementById(id).value = ''; });
+        wsTrainerMsg(`✓ ${email} can now schedule workshops.`, true);
+        wsLoadTrainers();
+    } else {
+        const j = await r.json().catch(() => ({}));
+        wsTrainerMsg('✗ ' + (j.detail || 'add failed'), false);
+    }
+}
+
+async function wsRemoveTrainer(email) {
+    if (!confirm(`Remove ${email}? They will no longer be able to schedule workshops. Existing workshops they run are unaffected.`)) return;
+    const r = await fetch('/api/workshops/admin/trainers/' + encodeURIComponent(email), {
+        method: 'DELETE', credentials: 'same-origin',
+    });
+    if (r.ok) { wsTrainerMsg(`✓ ${email} removed.`, true); wsLoadTrainers(); }
+    else { const j = await r.json().catch(() => ({})); wsTrainerMsg('✗ ' + (j.detail || 'remove failed'), false); }
+}
+
+// ── Workshop schedule: calendar + table + editor ─────────────────────────────
+
+function wsWhen(w) {
+    if (!w.scheduledAt) return { day: (w.createdAt || '').slice(0, 10), label: '— not scheduled —' };
+    const day = w.scheduledAt.slice(0, 10);
+    const time = w.scheduledAt.slice(11, 16);
+    const tz = w.timezone ? ` ${w.timezone}` : '';
+    const dur = w.durationMinutes ? ` · ${w.durationMinutes}m` : '';
+    return { day, label: `${day} ${time}${tz}${dur}` };
+}
+
+function wsSeats(w) {
+    if (!w.maxSeats) return `${w.seatsTaken} / ∞`;
+    return `${w.seatsTaken} / ${w.maxSeats} (${w.seatsOpen} open)`;
+}
+
+function wsTenantLabel(url) {
+    if (!url) return '—';
+    try { return new URL(url).hostname.split('.')[0]; } catch (e) { return url; }
+}
+
+async function wsLoadSchedule() {
+    const cal = document.getElementById('ws-calendar');
+    const tbody = document.querySelector('#ws-table tbody');
+    const state = document.getElementById('ws-filter-state').value;
+    try {
+        const r = await fetch('/api/workshops/admin/schedule' + (state ? `?state=${encodeURIComponent(state)}` : ''),
+                              { credentials: 'same-origin' });
+        if (!r.ok) {
+            cal.innerHTML = '<p class="content-hint">Sign in as an org member to see workshops.</p>';
+            tbody.innerHTML = '';
+            return;
+        }
+        const j = await r.json();
+        wsState.workshops = j.workshops || [];
+        document.getElementById('ws-count').textContent =
+            `(${j.count}${j.total > j.count ? ` of ${j.total}` : ''})`;
+        wsRenderCalendar();
+        wsRenderTable();
+    } catch (e) {
+        cal.innerHTML = '<p class="content-hint">Failed to load workshops.</p>';
+    }
+}
+
+function wsRenderTable() {
+    const tbody = document.querySelector('#ws-table tbody');
+    if (!wsState.workshops.length) {
+        tbody.innerHTML = '<tr><td colspan="8" class="content-hint">No workshops match this filter.</td></tr>';
+        return;
+    }
+    tbody.innerHTML = wsState.workshops.map(w => {
+        const when = wsWhen(w);
+        const co = w.coTrainers.length ? ` +${w.coTrainers.length}` : '';
+        return `<tr data-ws-open="${escapeHtml(w.sessionId)}" style="cursor:pointer">
+            <td>${escapeHtml(when.label)}</td>
+            <td>${escapeHtml(w.title)}<br><span style="opacity:.55;font-size:.75rem">${escapeHtml(w.trainingId)}</span></td>
+            <td>${escapeHtml(w.owner)}${co}</td>
+            <td>${escapeHtml(wsTenantLabel(w.ownerTenant))}</td>
+            <td>${escapeHtml(w.state)}</td>
+            <td>${escapeHtml(wsSeats(w))}</td>
+            <td>${w.registrants.length} reg · ${w.joinedCount} present</td>
+            <td><button class="btn btn-small btn-secondary" data-action data-ws-open="${escapeHtml(w.sessionId)}">Manage</button></td>
+        </tr>`;
+    }).join('');
+}
+
+function wsShiftMonth(delta) {
+    const base = wsState.month ? new Date(wsState.month + '-01T00:00:00Z') : new Date();
+    base.setUTCMonth(base.getUTCMonth() + delta);
+    wsState.month = `${base.getUTCFullYear()}-${String(base.getUTCMonth() + 1).padStart(2, '0')}`;
+    wsRenderCalendar();
+}
+
+function wsRenderCalendar() {
+    const cal = document.getElementById('ws-calendar');
+    const now = new Date();
+    const month = wsState.month
+        || `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+    wsState.month = month;
+    const [y, m] = month.split('-').map(Number);
+    const first = new Date(Date.UTC(y, m - 1, 1));
+    const days = new Date(Date.UTC(y, m, 0)).getUTCDate();
+    // Monday-first grid: JS getUTCDay() is Sunday-first.
+    const lead = (first.getUTCDay() + 6) % 7;
+    document.getElementById('ws-cal-label').textContent =
+        first.toLocaleString('en-GB', { month: 'long', year: 'numeric', timeZone: 'UTC' });
+
+    const byDay = {};
+    wsState.workshops.forEach(w => {
+        const day = wsWhen(w).day;
+        if (day) (byDay[day] = byDay[day] || []).push(w);
+    });
+
+    let cells = '';
+    for (let i = 0; i < lead; i++) cells += '<td style="opacity:.25"></td>';
+    for (let d = 1; d <= days; d++) {
+        const iso = `${month}-${String(d).padStart(2, '0')}`;
+        const chips = (byDay[iso] || []).map(w =>
+            `<div data-ws-open="${escapeHtml(w.sessionId)}" title="${escapeHtml(w.title)} · ${escapeHtml(w.owner)} · ${escapeHtml(wsTenantLabel(w.ownerTenant))}"
+                  style="cursor:pointer;font-size:.68rem;margin-top:2px;padding:1px 4px;border-radius:4px;background:var(--surface-3,#1b2434);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">
+                ${escapeHtml((w.scheduledAt || '').slice(11, 16) || '··')} ${escapeHtml(w.title)}
+             </div>`).join('');
+        cells += `<td style="vertical-align:top;height:64px;padding:4px">
+            <div style="font-size:.7rem;opacity:.6">${d}</div>${chips}</td>`;
+        if ((lead + d) % 7 === 0) cells += '</tr><tr>';
+    }
+    cal.innerHTML = `<table style="width:100%;table-layout:fixed">
+        <thead><tr>${['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+            .map(d => `<th style="font-size:.7rem;opacity:.6">${d}</th>`).join('')}</tr></thead>
+        <tbody><tr>${cells}</tr></tbody></table>`;
+}
+
+// ── Editor ───────────────────────────────────────────────────────────────────
+// Mutations reuse the EXISTING /api/live/* routes rather than adding admin
+// twins. Those routes gate on `trainerEmail` matching the stored team, so the
+// dashboard sends the workshop's own owner — honest about the fact that this
+// seam still trusts a caller-supplied email (see workshop-provisioning-open-items).
+
+function wsCloseEditor() {
+    const el = document.getElementById('ws-editor');
+    if (el) el.remove();
+    wsState.editing = null;
+}
+
+async function wsLiveAction(path, body, method) {
+    const r = await fetch('/api/live/sessions' + path, {
+        method: method || 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body || {}),
+    });
+    if (!r.ok) {
+        const j = await r.json().catch(() => ({}));
+        throw new Error(j.detail || `${r.status}`);
+    }
+    return r.json().catch(() => ({}));
+}
+
+function wsOpenEditor(sessionId) {
+    const w = wsState.workshops.find(x => x.sessionId === sessionId);
+    if (!w) return;
+    wsCloseEditor();
+    wsState.editing = sessionId;
+    const ro = !w.editable;
+    const el = document.createElement('div');
+    el.id = 'ws-editor';
+    el.style = 'position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:900;display:flex;align-items:center;justify-content:center;padding:20px';
+    el.innerHTML = `<div class="content-card" style="max-width:720px;width:100%;max-height:88vh;overflow:auto;margin:0">
+        <div style="display:flex;align-items:baseline;gap:10px">
+            <h3 style="margin:0;flex:1">${escapeHtml(w.title)}</h3>
+            <span style="opacity:.6;font-size:.75rem">${escapeHtml(w.sessionId)}</span>
+            <button class="btn btn-small btn-secondary" id="ws-ed-close">Close</button>
+        </div>
+        <p class="content-hint" style="margin:8px 0 12px">
+            ${escapeHtml(w.trainingId)} · ${escapeHtml(w.state)} · ${escapeHtml(wsTenantLabel(w.ownerTenant))}
+            · owner ${escapeHtml(w.owner)}${w.coTrainers.length ? ` · co-trainers ${escapeHtml(w.coTrainers.join(', '))}` : ''}
+            ${w.joinCode ? ` · code <code>${escapeHtml(w.joinCode)}</code>` : ''}
+        </p>
+        ${ro ? `<p class="content-hint" style="color:var(--warn,#fbbf24)">A ${escapeHtml(w.state)} workshop cannot be edited — the definition is frozen once it starts. Administration actions below still apply.</p>` : ''}
+        <div style="display:grid;grid-template-columns:repeat(2,1fr);gap:8px;margin-bottom:10px">
+            <label style="font-size:.75rem;opacity:.75">Title
+                <input type="text" id="ws-ed-title" value="${escapeHtml(w.title)}" ${ro ? 'disabled' : ''} style="width:100%"></label>
+            <label style="font-size:.75rem;opacity:.75">Scheduled at (ISO8601)
+                <input type="text" id="ws-ed-when" value="${escapeHtml(w.scheduledAt || '')}" placeholder="2026-09-01T09:00:00Z" ${ro ? 'disabled' : ''} style="width:100%"></label>
+            <label style="font-size:.75rem;opacity:.75">Timezone (IANA)
+                <input type="text" id="ws-ed-tz" value="${escapeHtml(w.timezone || '')}" placeholder="Europe/Berlin" ${ro ? 'disabled' : ''} style="width:100%"></label>
+            <label style="font-size:.75rem;opacity:.75">Duration (minutes)
+                <input type="number" id="ws-ed-dur" value="${escapeHtml(String(w.durationMinutes || ''))}" ${ro ? 'disabled' : ''} style="width:100%"></label>
+            <label style="font-size:.75rem;opacity:.75">Max seats
+                <input type="number" id="ws-ed-seats" value="${escapeHtml(String(w.maxSeats || ''))}" ${ro ? 'disabled' : ''} style="width:100%"></label>
+            <label style="font-size:.75rem;opacity:.75">Trainers (comma separated, first is owner)
+                <input type="text" id="ws-ed-trainers" value="${escapeHtml(w.trainers.join(', '))}" ${ro ? 'disabled' : ''} style="width:100%"></label>
+        </div>
+        <label style="font-size:.75rem;opacity:.75">Roster (${w.registrants.length} registered, ${w.joinedCount} present, ${w.boundCount} tenant-bound)
+            <textarea id="ws-ed-roster" rows="5" ${ro ? 'disabled' : ''} style="width:100%">${escapeHtml(w.registrants.join('\n'))}</textarea></label>
+        <div id="ws-ed-msg" style="font-size:12px;min-height:18px;margin:8px 0"></div>
+        <div style="display:flex;gap:8px;flex-wrap:wrap">
+            ${ro ? '' : '<button class="btn btn-small" id="ws-ed-save" data-action>Save changes</button>'}
+            <span style="flex:1"></span>
+            <button class="btn btn-small btn-secondary" id="ws-ed-start" data-action>Start</button>
+            <button class="btn btn-small btn-secondary" id="ws-ed-end" data-action>End</button>
+            <button class="btn btn-small btn-danger" id="ws-ed-cancel" data-action>Cancel workshop</button>
+            <button class="btn btn-small btn-danger" id="ws-ed-delete" data-action>Delete</button>
+        </div>
+    </div>`;
+    document.body.appendChild(el);
+    el.addEventListener('click', (e) => { if (e.target === el) wsCloseEditor(); });
+    document.getElementById('ws-ed-close').addEventListener('click', wsCloseEditor);
+
+    const msg = (text, ok) => {
+        const m = document.getElementById('ws-ed-msg');
+        m.textContent = text;
+        m.style.color = ok ? 'var(--ok,#4ade80)' : 'var(--danger,#f87171)';
+    };
+    const run = async (fn, done) => {
+        try { await fn(); msg(done, true); await wsLoadSchedule(); wsCloseEditor(); }
+        catch (err) { msg('✗ ' + err.message, false); }
+    };
+
+    if (!ro) document.getElementById('ws-ed-save').addEventListener('click', () => run(async () => {
+        await wsLiveAction(`/${sessionId}`, {
+            trainerEmail: w.owner,
+            title: document.getElementById('ws-ed-title').value.trim(),
+            scheduledAt: document.getElementById('ws-ed-when').value.trim(),
+            timezone: document.getElementById('ws-ed-tz').value.trim(),
+            durationMinutes: document.getElementById('ws-ed-dur').value.trim(),
+            maxSeats: document.getElementById('ws-ed-seats').value.trim(),
+            trainers: document.getElementById('ws-ed-trainers').value.split(',').map(s => s.trim()).filter(Boolean),
+            roster: document.getElementById('ws-ed-roster').value.split(/[\s,;]+/).map(s => s.trim()).filter(Boolean),
+        }, 'PATCH');
+    }, '✓ saved'));
+
+    document.getElementById('ws-ed-start').addEventListener('click', () =>
+        run(() => wsLiveAction(`/${sessionId}/start`, { trainerEmail: w.owner }), '✓ started'));
+    document.getElementById('ws-ed-end').addEventListener('click', () => {
+        if (!confirm(`End "${w.title}"? Learner environments are NOT terminated by this — use the app's board for that.`)) return;
+        run(() => wsLiveAction(`/${sessionId}/end`, { trainerEmail: w.owner }), '✓ ended');
+    });
+    document.getElementById('ws-ed-cancel').addEventListener('click', () => {
+        if (!confirm(`Cancel "${w.title}"? Registrants keep their registration but the workshop will not run.`)) return;
+        run(() => wsLiveAction(`/${sessionId}/cancel`, { trainerEmail: w.owner }), '✓ cancelled');
+    });
+    document.getElementById('ws-ed-delete').addEventListener('click', () => {
+        if (!confirm(`DELETE "${w.title}" permanently? This removes the workshop, its roster and its audit trail. This cannot be undone.`)) return;
+        run(() => wsLiveAction(`/${sessionId}`, { trainerEmail: w.owner }, 'DELETE'), '✓ deleted');
+    });
 }
 
 // ── Register Tenant tab (app deploy via platform token / COE auto) ────────────

--- a/ops-server/dashboard/templates/index.html
+++ b/ops-server/dashboard/templates/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/static/images/favicon-32.png">
     <link rel="apple-touch-icon" sizes="180x180" href="/static/images/apple-touch-icon.png">
     <meta name="theme-color" content="#080c14">
-    <link rel="stylesheet" href="/static/style.css?v=26">
+    <link rel="stylesheet" href="/static/style.css?v=27">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css" />
 </head>
 <body>
@@ -55,6 +55,7 @@
             <button class="tab" data-view="framework">Framework</button>
             <button class="tab" data-view="nightly">Nightly</button>
             <button class="tab tab-writer-only" data-view="content" id="tab-content">Content Service</button>
+            <button class="tab tab-writer-only" data-view="workshops" id="tab-workshops">Workshops &amp; Delivery</button>
             <button class="tab" data-view="register" id="tab-register">Register Tenant</button>
             <button class="tab tab-help" id="help-btn" title="Help &amp; keyboard shortcuts (?)">?</button>
         </div>
@@ -824,6 +825,74 @@
             </div>
         </section>
 
+        <!-- Workshops & Delivery — mission control for every tenant's workshops.
+             Writer-gated in nginx AND in FastAPI (_require_writer); the class
+             below only hides the tab, it is not the security boundary. -->
+        <section id="view-workshops" class="view">
+            <nav class="content-subnav">
+                <button class="content-tab active" data-ws-view="schedule">Workshops</button>
+                <button class="content-tab" data-ws-view="trainers">Trainers</button>
+            </nav>
+
+            <!-- Schedule sub-view (calendar + table) -->
+            <div id="ws-view-schedule" class="content-subview">
+                <p class="content-hint">Every workshop across every tenant. Click a row to edit or administer it. Creating workshops stays in the enablement app, where a trainer picks a training from their own tenant's catalogue.</p>
+                <div class="content-card">
+                    <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-bottom:10px">
+                        <button id="ws-cal-prev" class="btn btn-small btn-secondary">‹</button>
+                        <strong id="ws-cal-label" style="min-width:170px;text-align:center">—</strong>
+                        <button id="ws-cal-next" class="btn btn-small btn-secondary">›</button>
+                        <button id="ws-cal-today" class="btn btn-small btn-secondary">Today</button>
+                        <span style="flex:1"></span>
+                        <label style="font-size:12px;opacity:.75">State
+                            <select id="ws-filter-state">
+                                <option value="">all</option>
+                                <option value="scheduled">scheduled</option>
+                                <option value="open">open</option>
+                                <option value="running">running</option>
+                                <option value="ended">ended</option>
+                                <option value="cancelled">cancelled</option>
+                            </select>
+                        </label>
+                        <button id="ws-reload" class="btn btn-small btn-secondary">Reload</button>
+                    </div>
+                    <div id="ws-calendar"><p class="loading">Loading workshops…</p></div>
+                </div>
+                <div class="content-card">
+                    <h3 style="margin:0 0 10px">All workshops <span id="ws-count" style="opacity:.6;font-weight:400"></span></h3>
+                    <table id="ws-table">
+                        <thead><tr>
+                            <th>When</th><th>Title</th><th>Trainer</th><th>Tenant</th>
+                            <th>State</th><th>Seats</th><th>Registrants</th><th></th>
+                        </tr></thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+
+            <!-- Trainers sub-view -->
+            <div id="ws-view-trainers" class="content-subview" hidden>
+                <p class="content-hint">Only people on this list can schedule a workshop, and only they can turn on the tenant-wide solutions toggle. This is not the same as being an admin, and it grants nothing inside a workshop — authority there is workshop membership.</p>
+                <div class="content-card">
+                    <h3 style="margin:0 0 10px">Add a trainer</h3>
+                    <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px">
+                        <input type="email" id="ws-tr-email" placeholder="name@dynatrace.com" style="width:260px">
+                        <input type="text" id="ws-tr-name" placeholder="display name (optional)" style="width:200px">
+                        <input type="text" id="ws-tr-note" placeholder="note (optional)" style="width:200px">
+                        <button id="ws-tr-add" class="btn btn-small" data-action>Add trainer</button>
+                    </div>
+                    <div id="ws-tr-msg" style="font-size:12px;min-height:16px"></div>
+                </div>
+                <div class="content-card">
+                    <h3 style="margin:0 0 10px">Registered trainers <span id="ws-tr-count" style="opacity:.6;font-weight:400"></span></h3>
+                    <table id="ws-trainers">
+                        <thead><tr><th>Email</th><th>Name</th><th>Added by</th><th>Added</th><th>Note</th><th></th></tr></thead>
+                        <tbody><tr><td colspan="6" class="loading">Loading trainers…</td></tr></tbody>
+                    </table>
+                </div>
+            </div>
+        </section>
+
         <section id="view-register" class="view">
             <div class="content-card">
                 <h3 style="margin:0 0 8px">Account OAuth client <span style="font-size:0.72rem;background:#1f6feb;color:#fff;border-radius:10px;padding:2px 8px;vertical-align:middle">bootstrap install only</span></h3>
@@ -1007,6 +1076,6 @@ redis-cli -a $REDIS_PASS HGETALL worker:worker-x86_64-amd002</pre>
 
     <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.js"></script>
-    <script src="/static/app.js?v=30"></script>
+    <script src="/static/app.js?v=31"></script>
 </body>
 </html>

--- a/ops-server/dashboard/test_live_auth.py
+++ b/ops-server/dashboard/test_live_auth.py
@@ -128,3 +128,14 @@ def test_sees_full_identities_anonymous_is_masked():
 def test_sees_full_identities_wrong_bearer_is_masked():
     r = _req({"Authorization": "Bearer wrong"})
     assert a._sees_full_identities(r, "") is False
+
+
+# ---------------------------------------------------------------------------
+# Same principle, applied to the Workshops & Delivery admin routes. Those read
+# EVERY tenant's workshops and rosters unmasked, so they use _require_writer
+# rather than _require_service_or_writer: the baked bearer that every app
+# install carries must not be a way in. Full coverage: test_workshops_admin.py.
+
+def test_service_bearer_cannot_read_workshops_admin():
+    r = client.get("/api/workshops/admin/trainers", headers=BEARER)
+    assert r.status_code == 401

--- a/ops-server/dashboard/test_live_binding.py
+++ b/ops-server/dashboard/test_live_binding.py
@@ -1,0 +1,402 @@
+"""Automatic tenant binding — POST /api/live/sessions/{id}/bind and friends.
+
+Binding answers "which tenant will provision this learner". It replaced the
+"Provision here" button, which was a label promising an action it never
+performed. Two properties are load-bearing and both are asserted here:
+
+  1. Binding is NOT attendance. It is allowed with the room closed and the
+     workshop days away, and it must not write :joined.
+  2. FIRST WRITE WINS. Walking into a second tenant must not silently move a
+     learner who already has, or is about to get, an environment elsewhere.
+     Only an explicit rebind, or provision-ack reporting ground truth, moves it.
+
+Redis is an in-process fake.
+
+Runnable: /home/ops/ops-venv/bin/python -m pytest dashboard/test_live_binding.py
+"""
+
+import json
+
+import dashboard.app as a
+from dashboard import live_sessions as ls
+from dashboard import masking
+from fastapi.testclient import TestClient
+
+client = TestClient(a.app, raise_server_exceptions=False)
+
+BEARER = {"Authorization": "Bearer test-service-token"}
+SID = "ws_bind-1"
+TRAINER = "trainer@dynatrace.com"
+CO = "co@dynatrace.com"
+LEARNER = "learner@customer.com"
+STRANGER = "stranger@customer.com"
+COE = "https://geu80787.apps.dynatrace.com"
+SRO = "https://sro97894.apps.dynatrace.com"
+
+
+class FakeRedis:
+    def __init__(self):
+        self.h, self.s, self.x, self.z = {}, {}, {}, {}
+        self.seq = 0
+
+    async def hgetall(self, key):
+        return dict(self.h.get(key, {}))
+
+    async def hget(self, key, field):
+        return self.h.get(key, {}).get(field)
+
+    async def hset(self, key, field=None, value=None, mapping=None):
+        target = self.h.setdefault(key, {})
+        if mapping:
+            target.update(mapping)
+        else:
+            target[field] = value
+
+    async def hsetnx(self, key, field, value):
+        target = self.h.setdefault(key, {})
+        if field in target:
+            return 0
+        target[field] = value
+        return 1
+
+    async def hdel(self, key, *fields):
+        target = self.h.get(key, {})
+        return sum(1 for f in fields if target.pop(f, None) is not None)
+
+    async def hlen(self, key):
+        return len(self.h.get(key, {}))
+
+    async def smembers(self, key):
+        return set(self.s.get(key, set()))
+
+    async def sadd(self, key, *members):
+        target = self.s.setdefault(key, set())
+        added = sum(1 for m in members if m not in target)
+        target.update(members)
+        return added
+
+    async def srem(self, key, *members):
+        target = self.s.setdefault(key, set())
+        removed = sum(1 for m in members if m in target)
+        target.difference_update(members)
+        return removed
+
+    async def delete(self, *keys):
+        for key in keys:
+            self.h.pop(key, None)
+            self.s.pop(key, None)
+            self.x.pop(key, None)
+
+    async def expire(self, key, ttl):
+        return True
+
+    async def exists(self, key):
+        return 1 if (key in self.h or key in self.s) else 0
+
+    async def xadd(self, key, mapping, maxlen=None, approximate=True):
+        self.seq += 1
+        self.x.setdefault(key, []).append((f"{1000 + self.seq}-0", dict(mapping)))
+        return f"{1000 + self.seq}-0"
+
+    async def xrange(self, key, min="-", max="+", count=None):
+        return list(self.x.get(key, []))
+
+    async def zrevrange(self, key, start, end):
+        return list(self.z.get(key, []))
+
+    async def zrem(self, key, *members):
+        before = len(self.z.get(key, []))
+        self.z[key] = [m for m in self.z.get(key, []) if m not in members]
+        return before - len(self.z[key])
+
+    async def get(self, key):
+        return None
+
+    async def scan_iter(self, match=None, count=None):
+        for key in ():
+            yield key
+
+
+def setup_module(_module):
+    _module._saved_tokens = a.ORBITAL_TOKENS
+    a.ORBITAL_TOKENS = ("test-service-token",)
+
+
+def teardown_module(_module):
+    a.ORBITAL_TOKENS = _module._saved_tokens
+
+
+def _seed(state="scheduled", room_open=""):
+    a.pool = FakeRedis()
+    a.pool.h[f"live:session:{SID}"] = {
+        "title": "Kubernetes 101", "trainingId": "kubernetes-101",
+        "trainers": json.dumps([TRAINER, CO]), "state": state,
+        "roomOpen": room_open, "ownerTenant": COE,
+        "createdAt": "2026-08-13T09:00:00+00:00",
+        "scheduledAt": "2026-09-20T09:00:00+00:00", "maxSeats": "20",
+    }
+    a.pool.s[f"live:session:{SID}:roster"] = {LEARNER}
+    a.pool.z["live:sessions:index"] = [SID]
+
+
+def setup_function(_fn):
+    _fn._saved_pool = a.pool
+    _seed()
+
+
+def teardown_function(_fn):
+    a.pool = _fn._saved_pool
+
+
+def _bind(email, tenant, rebind=False, sid=SID):
+    return client.post(f"/api/live/sessions/{sid}/bind", headers=BEARER,
+                       json={"email": email, "tenant": tenant, "rebind": rebind})
+
+
+def _tenants():
+    return a.pool.h.get(f"live:session:{SID}:tenants", {})
+
+
+def _boundat():
+    return a.pool.h.get(f"live:session:{SID}:boundat", {})
+
+
+def _joined():
+    return a.pool.h.get(f"live:session:{SID}:joined", {})
+
+
+def _event_kinds():
+    return [e[1].get("kind") for e in a.pool.x.get(f"live:session:{SID}:events", [])]
+
+
+# ── Pure decisions ───────────────────────────────────────────────────────────
+
+def test_bind_outcome_truth_table():
+    assert ls.bind_outcome("", COE) == ls.BIND_BOUND
+    assert ls.bind_outcome(COE, COE) == ls.BIND_KEPT          # same tenant
+    assert ls.bind_outcome(COE, SRO) == ls.BIND_KEPT          # first write wins
+    assert ls.bind_outcome(COE, SRO, rebind=True) == ls.BIND_REBOUND
+    assert ls.bind_outcome(COE, "") == ls.BIND_KEPT           # never clear
+    assert ls.bind_outcome("", "") == ls.BIND_KEPT
+    # An explicit rebind to the tenant you are already on is still a no-op.
+    assert ls.bind_outcome(COE, COE, rebind=True) == ls.BIND_KEPT
+
+
+def test_bind_error_allows_a_closed_room_days_early():
+    """The whole point: binding is not attendance."""
+    roster = {LEARNER}
+    for state in ("scheduled", "open", "running"):
+        assert ls.bind_error(state, LEARNER, roster) is None, state
+
+
+def test_bind_error_refuses_finished_workshops():
+    roster = {LEARNER}
+    assert ls.bind_error("ended", LEARNER, roster)[0] == 409
+    assert ls.bind_error("cancelled", LEARNER, roster)[0] == 409
+
+
+def test_bind_error_requires_membership_but_trainers_always_qualify():
+    sess = {"trainers": json.dumps([TRAINER, CO])}
+    assert ls.bind_error("scheduled", STRANGER, {LEARNER}, sess)[0] == 403
+    assert ls.bind_error("scheduled", TRAINER, {LEARNER}, sess) is None
+    assert ls.bind_error("scheduled", CO, {LEARNER}, sess) is None
+
+
+def test_attendance_state_precedence():
+    roster, joined, tenants = {LEARNER}, {LEARNER: "t"}, {LEARNER: COE}
+    assert ls.attendance_state(LEARNER, roster, joined, tenants) == ls.ATTENDANCE_PRESENT
+    assert ls.attendance_state(LEARNER, roster, {}, tenants) == ls.ATTENDANCE_BOUND
+    assert ls.attendance_state(LEARNER, roster, {}, {}) == ls.ATTENDANCE_REGISTERED
+    assert ls.attendance_state(STRANGER, roster, {}, {}) == ls.ATTENDANCE_NONE
+    assert ls.attendance_state("", roster, {}, {}) == ls.ATTENDANCE_NONE
+    # A binding with an empty value is not a binding.
+    assert ls.attendance_state(LEARNER, roster, {}, {LEARNER: ""}) == ls.ATTENDANCE_REGISTERED
+
+
+def test_env_tenant_mismatch_needs_both_sides():
+    assert ls.env_tenant_mismatch(COE, SRO) is True
+    assert ls.env_tenant_mismatch(COE, COE) is False
+    assert ls.env_tenant_mismatch("", SRO) is False
+    assert ls.env_tenant_mismatch(COE, "") is False
+    assert ls.env_tenant_mismatch("", "") is False
+
+
+# ── The route ────────────────────────────────────────────────────────────────
+
+def test_bind_works_on_a_closed_room_days_before_the_workshop():
+    r = _bind(LEARNER, COE)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["outcome"] == ls.BIND_BOUND
+    assert body["tenant"] == COE and body["boundHere"] is True
+    assert body["boundAt"]
+    assert _tenants() == {LEARNER: COE}
+
+
+def test_binding_is_not_attendance():
+    _bind(LEARNER, COE)
+    assert _joined() == {}, "binding must never write the joined hash"
+
+
+def test_second_tenant_is_kept_not_moved():
+    _bind(LEARNER, COE)
+    r = _bind(LEARNER, SRO)
+    assert r.json()["outcome"] == ls.BIND_KEPT
+    assert r.json()["tenant"] == COE
+    assert r.json()["boundHere"] is False, "they are looking at SRO, bound to COE"
+    assert _tenants() == {LEARNER: COE}
+
+
+def test_explicit_rebind_moves_it():
+    _bind(LEARNER, COE)
+    r = _bind(LEARNER, SRO, rebind=True)
+    assert r.json()["outcome"] == ls.BIND_REBOUND
+    assert r.json()["tenant"] == SRO and r.json()["boundHere"] is True
+    assert _tenants() == {LEARNER: SRO}
+
+
+def test_rebinding_updates_the_timestamp():
+    _bind(LEARNER, COE)
+    first = _boundat()[LEARNER]
+    _bind(LEARNER, SRO, rebind=True)
+    assert _boundat()[LEARNER] >= first
+
+
+def test_bind_emits_audit_events_only_on_a_real_change():
+    _bind(LEARNER, COE)
+    _bind(LEARNER, COE)            # same tenant — nothing happened
+    _bind(LEARNER, SRO)            # kept — nothing happened
+    assert _event_kinds() == [ls.EVENT_BOUND]
+    _bind(LEARNER, SRO, rebind=True)
+    assert _event_kinds() == [ls.EVENT_BOUND, ls.EVENT_REBOUND]
+
+
+def test_bind_rejects_a_stranger_and_a_finished_workshop():
+    assert _bind(STRANGER, COE).status_code == 403
+    assert _bind(LEARNER, COE, sid="ws_nope").status_code == 404
+    _seed(state="ended")
+    assert _bind(LEARNER, COE).status_code == 409
+
+
+def test_bind_requires_an_email():
+    r = client.post(f"/api/live/sessions/{SID}/bind", headers=BEARER,
+                    json={"tenant": COE})
+    assert r.status_code == 400
+
+
+def test_bind_is_authenticated():
+    r = client.post(f"/api/live/sessions/{SID}/bind",
+                    json={"email": LEARNER, "tenant": COE})
+    assert r.status_code == 401
+
+
+def test_a_trainer_can_bind_without_being_on_the_roster():
+    """Trainers provision their own environment and are never on their own
+    roster — the same carve-out join_error makes."""
+    assert _bind(TRAINER, COE).json()["outcome"] == ls.BIND_BOUND
+    assert _bind(CO, SRO).json()["outcome"] == ls.BIND_BOUND
+
+
+# ── The other three writers all go through the same funnel ───────────────────
+
+def test_join_binds_but_no_longer_moves_an_existing_binding():
+    _bind(LEARNER, COE)
+    r = client.post(f"/api/live/sessions/{SID}/join", headers=BEARER,
+                    json={"email": LEARNER, "tenant": SRO})
+    assert r.status_code == 200
+    assert _tenants() == {LEARNER: COE}, "join must not silently rebind"
+    assert LEARNER in _joined(), "join still checks in"
+
+
+def test_join_still_binds_when_nothing_was_bound():
+    client.post(f"/api/live/sessions/{SID}/join", headers=BEARER,
+                json={"email": LEARNER, "tenant": SRO})
+    assert _tenants() == {LEARNER: SRO}
+
+
+def test_join_by_code_binds_and_registers_without_checking_in():
+    a.pool.h[f"live:session:{SID}"]["state"] = "open"
+    a.pool.h[f"live:session:{SID}"]["joinCode"] = "ABC123"
+    a.pool.h["live:joincode:ABC123"] = {}       # presence only; route uses get()
+    a.pool.k = {"live:joincode:ABC123": SID}
+
+    async def _get(key):
+        return a.pool.k.get(key)
+    a.pool.get = _get
+
+    r = client.post("/api/live/sessions/join-by-code", headers=BEARER,
+                    json={"code": "ABC123", "email": STRANGER, "tenant": SRO})
+    assert r.status_code == 200
+    assert _tenants() == {STRANGER: SRO}
+    assert _joined() == {}, "registering is not checking in"
+
+
+def test_provision_ack_is_the_one_caller_that_overrides_a_binding():
+    """Ground truth beats intent: the ack says where the environment actually
+    landed, and the trainer's board has to show the truth."""
+    _bind(LEARNER, COE)
+    r = client.post(f"/api/live/sessions/{SID}/provision-ack", headers=BEARER,
+                    json={"email": LEARNER, "tenant": SRO, "status": "queued"})
+    assert r.status_code == 200
+    assert _tenants() == {LEARNER: SRO}
+
+
+# ── Payload shaping + masking ────────────────────────────────────────────────
+
+def _detail(email):
+    return client.get(f"/api/live/sessions/{SID}?email={email}",
+                      headers=BEARER).json()
+
+
+def test_trainer_sees_every_binding_and_the_seat_summary():
+    _bind(LEARNER, COE)
+    detail = _detail(TRAINER)
+    assert detail["bindings"] == [
+        {"email": LEARNER, "tenant": COE, "boundAt": _boundat()[LEARNER]}]
+    assert detail["seats"]["seatsTaken"] == 1
+    assert detail["seats"]["seatsOpen"] == 19
+
+
+def test_bindings_cover_learners_who_never_checked_in():
+    """Not derivable from `joined` — which is exactly why the split exists."""
+    _bind(LEARNER, COE)
+    assert _joined() == {}
+    assert len(_detail(TRAINER)["bindings"]) == 1
+
+
+def test_a_learner_sees_only_their_own_binding():
+    _bind(LEARNER, COE)
+    _bind(TRAINER, SRO)
+    detail = _detail(LEARNER)
+    assert detail["myTenant"] == COE
+    assert detail["boundAt"] == _boundat()[LEARNER]
+    assert "bindings" not in detail and "seats" not in detail
+
+
+def test_my_provision_status_is_caller_scoped():
+    _bind(LEARNER, COE)
+    client.post(f"/api/live/sessions/{SID}/provision-ack", headers=BEARER,
+                json={"email": LEARNER, "tenant": COE, "status": "queued"})
+    assert _detail(LEARNER)["myProvisionStatus"] == "queued"
+    assert _detail(TRAINER)["myProvisionStatus"] == ""
+
+
+def test_masking_drops_bindings_and_seats():
+    """Without this the anonymous read path — which returns a masked 200 by
+    design — would disclose every learner's tenant."""
+    item = {"sessionId": SID, "trainerEmail": TRAINER, "roster": [LEARNER],
+            "joined": [], "seats": {"seatsTaken": 1},
+            "bindings": [{"email": LEARNER, "tenant": COE, "boundAt": "x"}]}
+    out = masking.mask_live_detail(item)
+    assert "bindings" not in out and "seats" not in out
+    assert "roster" not in out and "joined" not in out
+
+
+def test_boundat_is_absent_for_a_pre_existing_binding():
+    """Bindings written before this key existed must still count as bindings —
+    bind_outcome keys off the tenant, never the timestamp."""
+    a.pool.h[f"live:session:{SID}:tenants"] = {LEARNER: COE}   # no :boundat
+    r = _bind(LEARNER, SRO)
+    assert r.json()["outcome"] == ls.BIND_KEPT
+    assert r.json()["tenant"] == COE
+    assert _detail(LEARNER)["boundAt"] == ""

--- a/ops-server/dashboard/test_live_learner_env.py
+++ b/ops-server/dashboard/test_live_learner_env.py
@@ -1,0 +1,370 @@
+"""Per-learner environment controls — terminate / reprovision one learner.
+
+Before these routes the only tool was terminate-all, so "this one student is in
+the wrong tenant" cost the whole cohort their environments.
+
+The assertion that matters most is scoping: a job belonging to a DIFFERENT
+workshop of the SAME training must not be touched. Same person, same training,
+wrong room is a real configuration — the cohort-wide route matches on
+(arena_user, training_id) and would hit it; _workshop_jobs matches on
+workshop_id first, which is what makes a single-learner kill safe.
+
+Gate is is_trainer, not is_owner: a co-trainer troubleshooting a stuck learner
+is exactly what these buttons exist for.
+
+Runnable: /home/ops/ops-venv/bin/python -m pytest dashboard/test_live_learner_env.py
+"""
+
+import json
+
+import dashboard.app as a
+from dashboard import live_sessions as ls
+from dashboard import masking
+from fastapi.testclient import TestClient
+
+client = TestClient(a.app, raise_server_exceptions=False)
+
+BEARER = {"Authorization": "Bearer test-service-token"}
+SID = "ws_env-1"
+OTHER_SID = "ws_env-2"
+TRAINER = "trainer@dynatrace.com"
+CO = "co@dynatrace.com"
+LEARNER = "learner@customer.com"
+OTHER = "other@customer.com"
+STRANGER = "stranger@customer.com"
+COE = "https://geu80787.apps.dynatrace.com"
+SRO = "https://sro97894.apps.dynatrace.com"
+
+
+class FakeRedis:
+    def __init__(self):
+        self.h, self.s, self.k, self.lists = {}, {}, {}, {}
+        self.x, self.z = {}, {}
+        self.published = []
+        self.seq = 0
+
+    async def hgetall(self, key):
+        return dict(self.h.get(key, {}))
+
+    async def hget(self, key, field):
+        return self.h.get(key, {}).get(field)
+
+    async def hset(self, key, field=None, value=None, mapping=None):
+        target = self.h.setdefault(key, {})
+        if mapping:
+            target.update(mapping)
+        else:
+            target[field] = value
+
+    async def hsetnx(self, key, field, value):
+        target = self.h.setdefault(key, {})
+        if field in target:
+            return 0
+        target[field] = value
+        return 1
+
+    async def hdel(self, key, *fields):
+        target = self.h.get(key, {})
+        return sum(1 for f in fields if target.pop(f, None) is not None)
+
+    async def hlen(self, key):
+        return len(self.h.get(key, {}))
+
+    async def smembers(self, key):
+        return set(self.s.get(key, set()))
+
+    async def sadd(self, key, *members):
+        self.s.setdefault(key, set()).update(members)
+
+    async def get(self, key):
+        return self.k.get(key)
+
+    async def exists(self, key):
+        return 1 if (key in self.h or key in self.k) else 0
+
+    async def delete(self, *keys):
+        for key in keys:
+            self.h.pop(key, None)
+
+    async def expire(self, key, ttl):
+        return True
+
+    async def publish(self, channel, message):
+        self.published.append((channel, message))
+
+    async def lrange(self, key, start, end):
+        return list(self.lists.get(key, []))
+
+    async def scan_iter(self, match=None, count=None):
+        prefix = (match or "*").rstrip("*")
+        for key in list(self.h):
+            if key.startswith(prefix):
+                yield key
+
+    async def scan(self, cursor, match=None, count=None):
+        prefix = (match or "*").rstrip("*")
+        return 0, [k for k in self.h if k.startswith(prefix)]
+
+    async def xadd(self, key, mapping, maxlen=None, approximate=True):
+        self.seq += 1
+        self.x.setdefault(key, []).append((f"{1000 + self.seq}-0", dict(mapping)))
+        return f"{1000 + self.seq}-0"
+
+    async def xrange(self, key, min="-", max="+", count=None):
+        return list(self.x.get(key, []))
+
+    async def zrevrange(self, key, start, end):
+        return list(self.z.get(key, []))
+
+    async def zrem(self, key, *members):
+        return 0
+
+
+def setup_module(_module):
+    _module._saved_tokens = a.ORBITAL_TOKENS
+    a.ORBITAL_TOKENS = ("test-service-token",)
+
+
+def teardown_module(_module):
+    a.ORBITAL_TOKENS = _module._saved_tokens
+
+
+def _job(job_id, email, workshop_id, tenant=COE, training="kubernetes-101",
+         terminating=""):
+    a.pool.h[f"job:running:enablement-{job_id}"] = {
+        "job_id": f"enablement-{job_id}", "arena_user": email,
+        "arena_tenant": tenant, "training_id": training,
+        "workshop_id": workshop_id, "terminating": terminating,
+    }
+
+
+def setup_function(_fn):
+    _fn._saved_pool = a.pool
+    _fn._saved_provision = a.api_arena_provision
+    a.pool = FakeRedis()
+    a.pool.h[f"live:session:{SID}"] = {
+        "title": "Kubernetes 101", "trainingId": "kubernetes-101",
+        "trainers": json.dumps([TRAINER, CO]), "state": "running",
+        "ownerTenant": COE, "createdAt": "2026-08-13T09:00:00+00:00",
+    }
+    a.pool.s[f"live:session:{SID}:roster"] = {LEARNER, OTHER}
+    a.pool.h[f"live:session:{SID}:joined"] = {LEARNER: "2026-08-13T10:00:00+00:00"}
+    a.pool.h[f"live:session:{SID}:tenants"] = {LEARNER: COE}
+
+
+def teardown_function(_fn):
+    a.pool = _fn._saved_pool
+    a.api_arena_provision = _fn._saved_provision
+
+
+def _terminate(email, trainer=TRAINER, sid=SID):
+    return client.post(f"/api/live/sessions/{sid}/learner/{email}/terminate",
+                       headers=BEARER, json={"trainerEmail": trainer})
+
+
+def _reprovision(email, trainer=TRAINER, tenant=COE):
+    return client.post(f"/api/live/sessions/{SID}/learner/{email}/reprovision",
+                       headers=BEARER, json={"trainerEmail": trainer,
+                                             "tenant": tenant})
+
+
+def _stub_provision(result=None, raises=None):
+    async def _fake(req, request):
+        if raises:
+            raise raises
+        _fake.calls.append(req)
+        return result or {"jobId": "enablement-new1", "deduped": False}
+    _fake.calls = []
+    a.api_arena_provision = _fake
+    return _fake
+
+
+# ── Terminate ────────────────────────────────────────────────────────────────
+
+def test_terminate_kills_only_that_learners_job():
+    _job("a", LEARNER, SID)
+    _job("b", OTHER, SID)
+    r = _terminate(LEARNER)
+    assert r.status_code == 200
+    assert r.json()["terminated"] == ["enablement-a"]
+    assert a.pool.h["job:running:enablement-a"]["terminating"] == "1"
+    assert a.pool.h["job:running:enablement-b"]["terminating"] == ""
+    assert ("ops:terminate", "enablement-a") in a.pool.published
+
+
+def test_terminate_does_not_touch_another_workshop_of_the_same_training():
+    """The scoping assertion. terminate-all matches (arena_user, training_id)
+    and would kill this; workshop_id is what makes a per-learner kill safe."""
+    _job("mine", LEARNER, SID)
+    _job("elsewhere", LEARNER, OTHER_SID)
+    r = _terminate(LEARNER)
+    assert r.json()["terminated"] == ["enablement-mine"]
+    assert a.pool.h["job:running:enablement-elsewhere"]["terminating"] == ""
+
+
+def test_terminate_falls_back_to_training_for_pre_workshop_id_jobs():
+    _job("legacy", LEARNER, workshop_id="")
+    assert _terminate(LEARNER).json()["terminated"] == ["enablement-legacy"]
+
+
+def test_terminate_is_idempotent():
+    _job("a", LEARNER, SID, terminating="1")
+    r = _terminate(LEARNER)
+    assert r.json() == {"terminated": [], "count": 0, "alreadyTerminating": 1}
+
+
+def test_terminate_with_no_environment_is_a_quiet_success():
+    """Nothing running is not an error — the trainer asked for a state, and
+    that state already holds."""
+    r = _terminate(LEARNER)
+    assert r.status_code == 200 and r.json()["count"] == 0
+
+
+def test_co_trainer_may_terminate_a_learner():
+    _job("a", LEARNER, SID)
+    assert _terminate(LEARNER, trainer=CO).json()["count"] == 1
+
+
+def test_non_trainer_gets_403_and_kills_nothing():
+    _job("a", LEARNER, SID)
+    assert _terminate(LEARNER, trainer=STRANGER).status_code == 403
+    assert a.pool.h["job:running:enablement-a"]["terminating"] == ""
+
+
+def test_terminate_404s_on_an_unknown_workshop():
+    assert _terminate(LEARNER, sid="ws_nope").status_code == 404
+
+
+def test_terminate_requires_authentication():
+    r = client.post(f"/api/live/sessions/{SID}/learner/{LEARNER}/terminate",
+                    json={"trainerEmail": TRAINER})
+    assert r.status_code == 401
+
+
+def test_terminate_emits_an_audit_event():
+    _job("a", LEARNER, SID)
+    _terminate(LEARNER)
+    kinds = [e[1]["kind"] for e in a.pool.x[f"live:session:{SID}:events"]]
+    assert ls.EVENT_ENV_TERMINATED in kinds
+
+
+# ── Reprovision ──────────────────────────────────────────────────────────────
+
+def test_reprovision_terminates_then_builds():
+    _job("old", LEARNER, SID)
+    fake = _stub_provision()
+    r = _reprovision(LEARNER)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["terminated"] == ["enablement-old"]
+    assert body["status"] == "queued" and body["jobId"] == "enablement-new1"
+    assert len(fake.calls) == 1
+    assert fake.calls[0].userId == LEARNER
+    assert a.pool.h[f"live:session:{SID}:provdone"][LEARNER] == "queued"
+
+
+def test_reprovision_reports_already_active_honestly():
+    _stub_provision({"jobId": "enablement-x", "deduped": True})
+    assert _reprovision(LEARNER).json()["status"] == "already-active"
+
+
+def test_reprovision_of_a_foreign_bound_learner_goes_through_the_pull_channel():
+    """The trainer's tenant cannot mint for a learner bound elsewhere. Rather
+    than fail, re-arm the request their own tenant's app polls for."""
+    a.pool.h[f"live:session:{SID}:tenants"][LEARNER] = SRO
+    a.pool.h[f"live:session:{SID}:provdone"] = {LEARNER: "failed"}
+    fake = _stub_provision()
+    body = _reprovision(LEARNER, tenant=COE).json()
+    assert body["status"] == "requested"
+    assert body["tenant"] == SRO
+    assert fake.calls == [], "must not provision into the wrong tenant"
+    assert LEARNER not in a.pool.h[f"live:session:{SID}:provdone"], \
+        "the settled marker must be cleared or their app will ignore the request"
+    assert a.pool.h[f"live:session:{SID}"]["provisionRequestedAt"]
+
+
+def test_reprovision_still_terminates_before_handing_off():
+    a.pool.h[f"live:session:{SID}:tenants"][LEARNER] = SRO
+    _job("old", LEARNER, SID, tenant=SRO)
+    _stub_provision()
+    body = _reprovision(LEARNER, tenant=COE).json()
+    assert body["terminated"] == ["enablement-old"]
+    assert body["status"] == "requested"
+
+
+def test_reprovision_reports_a_provision_failure_instead_of_500ing():
+    from fastapi import HTTPException
+    _stub_provision(raises=HTTPException(status_code=503, detail="no capacity"))
+    body = _reprovision(LEARNER).json()
+    assert body["status"] == "error" and "no capacity" in body["error"]
+    kinds = [e[1]["kind"] for e in a.pool.x[f"live:session:{SID}:events"]]
+    assert ls.EVENT_PROVISION_FAILED in kinds
+
+
+def test_co_trainer_may_reprovision_but_a_stranger_may_not():
+    _stub_provision()
+    assert _reprovision(LEARNER, trainer=CO).status_code == 200
+    assert _reprovision(LEARNER, trainer=STRANGER).status_code == 403
+
+
+def test_reprovision_rejects_a_malformed_email():
+    r = client.post(f"/api/live/sessions/{SID}/learner/not-an-email/reprovision",
+                    headers=BEARER, json={"trainerEmail": TRAINER})
+    assert r.status_code == 400
+
+
+# ── Readiness board: attendance + wrong-tenant flag ──────────────────────────
+
+def _readiness(trainer=TRAINER, tenant=COE):
+    return client.get(f"/api/live/sessions/{SID}/readiness"
+                      f"?trainerEmail={trainer}&tenant={tenant}",
+                      headers=BEARER).json()
+
+
+def _row(payload, email):
+    return next(r for r in payload["results"] if r["email"] == email)
+
+
+def test_readiness_reports_attendance_states():
+    a.pool.h[f"live:session:{SID}:tenants"][OTHER] = SRO   # bound, never present
+    rows = _readiness()
+    assert _row(rows, LEARNER)["attendance"] == ls.ATTENDANCE_PRESENT
+    assert _row(rows, OTHER)["attendance"] == ls.ATTENDANCE_BOUND
+    assert _row(rows, TRAINER)["attendance"] == "trainer"
+
+
+def test_readiness_reports_registered_when_only_on_the_roster():
+    del a.pool.h[f"live:session:{SID}:tenants"][LEARNER]
+    a.pool.h[f"live:session:{SID}:joined"] = {}
+    assert _row(_readiness(), LEARNER)["attendance"] == ls.ATTENDANCE_REGISTERED
+
+
+def test_readiness_flags_a_learner_running_in_the_wrong_tenant():
+    """Orbital sees every tenant's jobs (job:running:* is global), which is why
+    it can spot this at all. Nothing is torn down — the trainer decides."""
+    _job("a", LEARNER, SID, tenant=SRO)          # bound to COE, running on SRO
+    row = _row(_readiness(), LEARNER)
+    assert row["envTenant"] == SRO
+    assert row["tenantMismatch"] is True
+
+
+def test_readiness_does_not_cry_wolf_when_there_is_no_environment():
+    row = _row(_readiness(), LEARNER)
+    assert row["tenantMismatch"] is False
+    assert "envTenant" not in row, "a row without an environment gains no field"
+
+
+def test_readiness_no_mismatch_when_the_environment_matches():
+    _job("a", LEARNER, SID, tenant=COE)
+    assert _row(_readiness(), LEARNER)["tenantMismatch"] is False
+
+
+def test_masking_hides_env_tenant_but_keeps_attendance():
+    payload = {"results": [{"email": LEARNER, "tenant": COE, "envTenant": SRO,
+                            "attendance": "present", "tenantMismatch": True,
+                            "state": "ready"}]}
+    row = masking.mask_readiness(payload)["results"][0]
+    assert row["envTenant"] != SRO and row["tenant"] != COE
+    # Non-identifying: they say nothing about WHICH tenant.
+    assert row["attendance"] == "present" and row["tenantMismatch"] is True
+    assert row["state"] == "ready"

--- a/ops-server/dashboard/test_live_sessions.py
+++ b/ops-server/dashboard/test_live_sessions.py
@@ -397,7 +397,7 @@ def test_shape_summary_learner():
         "trainers": [TRAINER], "trainerEmail": TRAINER,
         "joinedCount": 1, "rosterCount": 2,
         "createdAt": "2026-07-14T09:00:00+00:00", "startedAt": "",
-        "isTrainer": False, "hasJoined": True,
+        "isTrainer": False, "isOwner": False, "hasJoined": True,
         # Always present, never inferred from absence (EPIC-007).
         "roomOpen": False, "gateAhead": False,
     }
@@ -912,3 +912,99 @@ def test_class_pointer_of_reads_the_raw_session_hash():
     assert ls.class_pointer_of({}) == 1
     assert ls.class_pointer_of({"trainerStep": "0"}) == 1
     assert ls.class_pointer_of({"trainerStep": "7"}) == 7
+
+
+# ── Cross-tenant admin view (Workshops & Delivery tab) ───────────────────────
+
+def test_seat_summary_counts_registrations_not_check_ins():
+    """A seat is consumed by REGISTERING — that is what the join-by-code seat
+    check enforces — so `present` has to be reported separately."""
+    s = ls.seat_summary({"a@x.com", "b@x.com"}, {"a@x.com": "t"}, "10")
+    assert s == {"seatsTaken": 2, "maxSeats": 10, "seatsOpen": 8, "present": 1}
+
+
+def test_seat_summary_unlimited_is_none_not_zero():
+    """'Unlimited' and 'full' must not render the same way."""
+    assert ls.seat_summary({"a@x.com"}, {}, "")["seatsOpen"] is None
+    assert ls.seat_summary({"a@x.com"}, {}, None)["seatsOpen"] is None
+    assert ls.seat_summary({"a@x.com"}, {}, "0")["seatsOpen"] is None
+
+
+def test_seat_summary_never_reports_negative_free_seats():
+    # A roster edit can legitimately exceed maxSeats; the dashboard shows 0.
+    assert ls.seat_summary({"a@x.com", "b@x.com"}, {}, "1")["seatsOpen"] == 0
+
+
+def test_seat_summary_tolerates_junk_max_seats():
+    assert ls.seat_summary(set(), {}, "not-a-number")["maxSeats"] == 0
+
+
+def test_schedule_sort_key_prefers_when_it_happens():
+    assert ls.schedule_sort_key({"scheduledAt": "2026-09-01T09:00:00+00:00",
+                                 "createdAt": "2026-08-01T09:00:00+00:00"}) \
+        == "2026-09-01T09:00:00+00:00"
+
+
+def test_schedule_sort_key_falls_back_to_created():
+    assert ls.schedule_sort_key({"createdAt": "2026-08-01T09:00:00+00:00"}) \
+        == "2026-08-01T09:00:00+00:00"
+    assert ls.schedule_sort_key({}) == ""
+    assert ls.schedule_sort_key(None) == ""
+
+
+def _admin_session():
+    return {"title": "Kubernetes 101", "trainingId": "kubernetes-101",
+            "state": "scheduled", "trainers": '["lead@x.com", "co@x.com"]',
+            "ownerTenant": "https://geu80787.apps.dynatrace.com",
+            "createdAt": "2026-08-13T09:00:00+00:00",
+            "scheduledAt": "2026-09-01T09:00:00+00:00",
+            "maxSeats": "20", "joinCode": "ABC123"}
+
+
+def test_shape_admin_row_splits_owner_from_co_trainers():
+    row = ls.shape_admin_row("ws_1", _admin_session(), {"a@x.com"}, {}, {})
+    assert row["owner"] == "lead@x.com"
+    assert row["coTrainers"] == ["co@x.com"]
+    assert row["trainers"] == ["lead@x.com", "co@x.com"]
+
+
+def test_shape_admin_row_emits_owner_tenant():
+    """The ONLY payload that carries ownerTenant. workshop_fields deliberately
+    does not — a learner has no business knowing which tenant created a
+    workshop; this route is GitHub-org-member gated."""
+    row = ls.shape_admin_row("ws_1", _admin_session(), set(), {}, {})
+    assert row["ownerTenant"] == "https://geu80787.apps.dynatrace.com"
+    assert "ownerTenant" not in ls.workshop_fields(_admin_session(), "lead@x.com")
+
+
+def test_shape_admin_row_has_no_caller_identity_fields():
+    """This view has no 'me' — isTrainer/hasJoined would be meaningless."""
+    row = ls.shape_admin_row("ws_1", _admin_session(), set(), {}, {})
+    for absent in ("isTrainer", "hasJoined", "myTenant", "trainerEmail"):
+        assert absent not in row
+
+
+def test_shape_admin_row_sorts_registrants_and_counts_bindings():
+    row = ls.shape_admin_row("ws_1", _admin_session(),
+                             {"b@x.com", "a@x.com"},
+                             {"a@x.com": "t"},
+                             {"a@x.com": "https://sro97894.apps.dynatrace.com"})
+    assert row["registrants"] == ["a@x.com", "b@x.com"]
+    assert row["joinedCount"] == 1
+    assert row["boundCount"] == 1
+
+
+def test_shape_admin_row_editable_mirrors_the_patch_rule():
+    """PATCH refuses anything past `open` — the row must say so rather than
+    letting the dashboard offer an edit that will 409."""
+    for state, editable in (("scheduled", True), ("open", True),
+                            ("running", False), ("ended", False),
+                            ("cancelled", False)):
+        row = ls.shape_admin_row("ws_1", {**_admin_session(), "state": state},
+                                 set(), {}, {})
+        assert row["editable"] is editable, state
+
+
+def test_shape_admin_row_survives_a_teamless_session():
+    row = ls.shape_admin_row("ws_1", {"title": "x"}, set(), {}, {})
+    assert row["owner"] == "" and row["coTrainers"] == []

--- a/ops-server/dashboard/test_trainer_registry.py
+++ b/ops-server/dashboard/test_trainer_registry.py
@@ -3,9 +3,9 @@
 Two halves, same approach as test_tenant_registry.py:
   - pure shaping (no Redis, no FastAPI);
   - the async helpers over an in-process fake, because the interesting
-    behaviour lives there: re-add keeps the original attribution, remove drops
-    the INDEX before the hash, and seed refuses to resurrect people an operator
-    deleted.
+    behaviour lives there: re-add keeps the original attribution, and remove
+    drops the INDEX before the hash so a half-failed delete cannot leave
+    someone still passing the gate.
 
 Runnable:
   - pytest:     python3 -m pytest dashboard/test_trainer_registry.py
@@ -99,16 +99,6 @@ def test_shape_entry_keeps_attribution():
     assert f["note"] == "COE"
 
 
-def test_seed_emails_parses_dedupes_and_drops_junk():
-    raw = f" {SERGIO} , {ASAD},, nonsense , {SERGIO.upper()} "
-    assert tr.seed_emails(raw) == [SERGIO, ASAD]
-
-
-def test_seed_emails_empty_input():
-    assert tr.seed_emails("") == []
-    assert tr.seed_emails(None) == []
-
-
 # ── Async helpers ────────────────────────────────────────────────────────────
 
 def test_add_then_is_trainer():
@@ -193,34 +183,6 @@ def test_list_entries_sorted_and_survives_a_missing_hash():
             ASAD, "orphan@dynatrace.com", SERGIO]
         assert entries[0]["name"] == "Asad"
         assert entries[1] == {"email": "orphan@dynatrace.com"}
-
-    run(go())
-
-
-def test_seed_only_fills_an_empty_registry():
-    fake = FakeRedis()
-
-    async def go():
-        assert await tr.seed(fake, [SERGIO, ASAD]) == 2
-        assert await tr.is_trainer(fake, SERGIO) is True
-        # Operator removes one, restart re-runs the seed: it must NOT come back.
-        await tr.remove_entry(fake, SERGIO)
-        assert await tr.seed(fake, [SERGIO, ASAD]) == 0
-        assert await tr.is_trainer(fake, SERGIO) is False
-        # ...but emptying it completely is the lock-out case seeding exists for.
-        await tr.remove_entry(fake, ASAD)
-        assert await tr.seed(fake, [SERGIO, ASAD]) == 2
-
-    run(go())
-
-
-def test_seed_noop_without_config():
-    fake = FakeRedis()
-
-    async def go():
-        assert await tr.seed(fake, []) == 0
-        assert await tr.seed(fake, None) == 0
-        assert fake.s == {}
 
     run(go())
 

--- a/ops-server/dashboard/test_trainer_registry.py
+++ b/ops-server/dashboard/test_trainer_registry.py
@@ -1,0 +1,235 @@
+"""Trainer registry — dashboard/trainer_registry.py.
+
+Two halves, same approach as test_tenant_registry.py:
+  - pure shaping (no Redis, no FastAPI);
+  - the async helpers over an in-process fake, because the interesting
+    behaviour lives there: re-add keeps the original attribution, remove drops
+    the INDEX before the hash, and seed refuses to resurrect people an operator
+    deleted.
+
+Runnable:
+  - pytest:     python3 -m pytest dashboard/test_trainer_registry.py
+  - standalone: python3 -m dashboard.test_trainer_registry
+"""
+
+import asyncio
+
+from dashboard import trainer_registry as tr
+
+SERGIO = "sergio.hinojosa@dynatrace.com"
+ASAD = "asad.ali@dynatrace.com"
+
+
+class FakeRedis:
+    """Only the set/hash commands the registry uses."""
+
+    def __init__(self):
+        self.h: dict = {}
+        self.s: dict = {}
+
+    async def sismember(self, key, member):
+        return member in self.s.get(key, set())
+
+    async def smembers(self, key):
+        return set(self.s.get(key, set()))
+
+    async def sadd(self, key, *members):
+        self.s.setdefault(key, set()).update(members)
+
+    async def srem(self, key, *members):
+        target = self.s.setdefault(key, set())
+        removed = sum(1 for m in members if m in target)
+        target.difference_update(members)
+        return removed
+
+    async def scard(self, key):
+        return len(self.s.get(key, set()))
+
+    async def hgetall(self, key):
+        return dict(self.h.get(key, {}))
+
+    async def hset(self, key, field=None, value=None, mapping=None):
+        target = self.h.setdefault(key, {})
+        if mapping:
+            target.update(mapping)
+        else:
+            target[field] = value
+
+    async def delete(self, *keys):
+        for key in keys:
+            self.h.pop(key, None)
+
+
+def run(coro):
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
+
+
+# ── Pure shaping ─────────────────────────────────────────────────────────────
+
+def test_registry_key_normalizes():
+    assert tr.registry_key("  Sergio.Hinojosa@Dynatrace.com ") == \
+        f"trainer:registry:{SERGIO}"
+
+
+def test_validate_accepts_and_normalizes():
+    assert tr.validate_trainer_email("  ASAD.Ali@Dynatrace.com  ") == ASAD
+
+
+def test_validate_rejects_non_addresses():
+    for bad in ("", None, "   ", "not-an-email", "sergio"):
+        try:
+            tr.validate_trainer_email(bad)
+        except ValueError:
+            continue
+        raise AssertionError(f"{bad!r} should not validate")
+
+
+def test_shape_entry_drops_empty_fields():
+    f = tr.shape_entry(SERGIO, now="2026-08-13T10:00:00+00:00")
+    assert f == {"email": SERGIO, "addedAt": "2026-08-13T10:00:00+00:00"}
+
+
+def test_shape_entry_keeps_attribution():
+    f = tr.shape_entry("  Asad.Ali@Dynatrace.com ", name="Asad Ali",
+                       added_by="sergiohinojosa", note="COE",
+                       now="2026-08-13T10:00:00+00:00")
+    assert f["email"] == ASAD
+    assert f["name"] == "Asad Ali"
+    assert f["addedBy"] == "sergiohinojosa"
+    assert f["note"] == "COE"
+
+
+def test_seed_emails_parses_dedupes_and_drops_junk():
+    raw = f" {SERGIO} , {ASAD},, nonsense , {SERGIO.upper()} "
+    assert tr.seed_emails(raw) == [SERGIO, ASAD]
+
+
+def test_seed_emails_empty_input():
+    assert tr.seed_emails("") == []
+    assert tr.seed_emails(None) == []
+
+
+# ── Async helpers ────────────────────────────────────────────────────────────
+
+def test_add_then_is_trainer():
+    fake = FakeRedis()
+
+    async def go():
+        await tr.add_entry(fake, "  Sergio.Hinojosa@Dynatrace.com ",
+                           name="Sergio", added_by="sergiohinojosa")
+        assert await tr.is_trainer(fake, SERGIO) is True
+        # Lookup normalizes too — the app sends whatever Dynatrace reports.
+        assert await tr.is_trainer(fake, " SERGIO.HINOJOSA@dynatrace.com ") is True
+        assert await tr.is_trainer(fake, ASAD) is False
+
+    run(go())
+
+
+def test_is_trainer_false_for_empty_and_never_raises():
+    class Broken:
+        async def sismember(self, *_):
+            raise RuntimeError("redis down")
+
+    async def go():
+        assert await tr.is_trainer(FakeRedis(), "") is False
+        # An unreachable registry hides a button; it must not break a page.
+        assert await tr.is_trainer(Broken(), SERGIO) is False
+
+    run(go())
+
+
+def test_readd_keeps_original_attribution():
+    fake = FakeRedis()
+
+    async def go():
+        first = await tr.add_entry(fake, SERGIO, added_by="alice")
+        again = await tr.add_entry(fake, SERGIO, name="Sergio H",
+                                   added_by="bob")
+        assert again["addedAt"] == first["addedAt"]
+        assert again["addedBy"] == "alice", "a re-add is not a new grant"
+        assert again["name"] == "Sergio H", "but details may be corrected"
+
+    run(go())
+
+
+def test_add_rejects_bad_email_before_touching_redis():
+    fake = FakeRedis()
+
+    async def go():
+        try:
+            await tr.add_entry(fake, "nope")
+        except ValueError:
+            assert fake.s == {} and fake.h == {}
+            return
+        raise AssertionError("expected ValueError")
+
+    run(go())
+
+
+def test_remove_returns_whether_they_were_registered():
+    fake = FakeRedis()
+
+    async def go():
+        await tr.add_entry(fake, SERGIO)
+        assert await tr.remove_entry(fake, " SERGIO.hinojosa@Dynatrace.com ") is True
+        assert await tr.is_trainer(fake, SERGIO) is False
+        assert await tr.remove_entry(fake, SERGIO) is False
+        assert await tr.remove_entry(fake, "") is False
+
+    run(go())
+
+
+def test_list_entries_sorted_and_survives_a_missing_hash():
+    fake = FakeRedis()
+
+    async def go():
+        await tr.add_entry(fake, SERGIO, name="Sergio")
+        await tr.add_entry(fake, ASAD, name="Asad")
+        # A half-written entry (index member, no hash) must still be listed so
+        # it can be seen and removed rather than becoming invisible.
+        fake.s[tr.INDEX_KEY].add("orphan@dynatrace.com")
+        entries = await tr.list_entries(fake)
+        assert [e["email"] for e in entries] == [
+            ASAD, "orphan@dynatrace.com", SERGIO]
+        assert entries[0]["name"] == "Asad"
+        assert entries[1] == {"email": "orphan@dynatrace.com"}
+
+    run(go())
+
+
+def test_seed_only_fills_an_empty_registry():
+    fake = FakeRedis()
+
+    async def go():
+        assert await tr.seed(fake, [SERGIO, ASAD]) == 2
+        assert await tr.is_trainer(fake, SERGIO) is True
+        # Operator removes one, restart re-runs the seed: it must NOT come back.
+        await tr.remove_entry(fake, SERGIO)
+        assert await tr.seed(fake, [SERGIO, ASAD]) == 0
+        assert await tr.is_trainer(fake, SERGIO) is False
+        # ...but emptying it completely is the lock-out case seeding exists for.
+        await tr.remove_entry(fake, ASAD)
+        assert await tr.seed(fake, [SERGIO, ASAD]) == 2
+
+    run(go())
+
+
+def test_seed_noop_without_config():
+    fake = FakeRedis()
+
+    async def go():
+        assert await tr.seed(fake, []) == 0
+        assert await tr.seed(fake, None) == 0
+        assert fake.s == {}
+
+    run(go())
+
+
+if __name__ == "__main__":
+    passed = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            passed += 1
+            print(f"  ok  {name}")
+    print(f"\n{passed} passed")

--- a/ops-server/dashboard/test_workshops.py
+++ b/ops-server/dashboard/test_workshops.py
@@ -171,17 +171,57 @@ def test_cancelled_and_ended_sessions_hidden_from_learners():
     assert ls.is_listed(_session(state="running"), roster, "alice@x.com")
 
 
-def test_delete_only_before_started():
-    """delete is legal ONLY in scheduled/open (not started); running/ended/
-    cancelled raise → endpoint returns 409."""
-    assert ls.apply_transition("scheduled", "delete") == ("deleted", True)
-    assert ls.apply_transition("open", "delete") == ("deleted", True)
-    for state in ("running", "ended", "cancelled"):
-        try:
-            ls.apply_transition(state, "delete")
-            raise AssertionError(f"expected ValueError for delete from {state}")
-        except ValueError:
-            pass
+def test_delete_blocked_only_while_running():
+    """delete is legal before it starts AND once it is finished; only `running`
+    raises → endpoint returns 409, because deleting a live room strands its
+    cohort. (This test previously asserted ended/cancelled also raised; the
+    route was deliberately widened to allow cleaning up finished workshops —
+    see api_live_session_delete's docstring — and the assertion went stale.)"""
+    for state in ("scheduled", "open", "ended", "cancelled"):
+        assert ls.apply_transition(state, "delete") == ("deleted", True), state
+    try:
+        ls.apply_transition("running", "delete")
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for delete from running")
+
+
+# ── Owner vs co-trainer ──────────────────────────────────────────────────────
+
+def test_is_owner_is_the_creator_only():
+    """trainers[0] is forced to the creator by validate_trainers on create AND
+    on PATCH, so this needs no migration: every existing workshop already has a
+    correct owner."""
+    sess = _session(trainers='["lead@x.com", "co@x.com"]')
+    assert ls.is_owner("lead@x.com", sess) is True
+    assert ls.is_owner("co@x.com", sess) is False
+    assert ls.is_owner("learner@x.com", sess) is False
+    assert ls.is_owner("", sess) is False
+    assert ls.is_owner("  LEAD@X.com ", sess) is True
+
+
+def test_co_trainer_keeps_every_other_authority():
+    """The whole point of the split: a co-trainer is a trainer everywhere that
+    matters, so exactly one gate distinguishes them."""
+    sess = _session(trainers='["lead@x.com", "co@x.com"]')
+    assert ls.is_trainer("co@x.com", sess) is True
+    assert ls.is_member(sess, set(), "co@x.com") is True
+    # Solutions are role-gated, and a co-trainer holds the role.
+    assert ls.solution_visible(3, sess, ls.is_trainer("co@x.com", sess)) is True
+
+
+def test_is_owner_on_a_teamless_session():
+    assert ls.is_owner("anyone@x.com", {}) is False
+
+
+def test_shapers_expose_is_owner():
+    sess = _session(trainers='["lead@x.com", "co@x.com"]')
+    lead = ls.shape_summary("ws_1", sess, set(), {}, "lead@x.com")
+    co = ls.shape_summary("ws_1", sess, set(), {}, "co@x.com")
+    assert lead["isOwner"] is True and lead["isTrainer"] is True
+    assert co["isOwner"] is False and co["isTrainer"] is True
+    detail = ls.shape_detail("ws_1", sess, set(), {}, "co@x.com")
+    assert detail["isOwner"] is False and detail["isTrainer"] is True
 
 
 # ── joinCode / workshop-field payload gating ─────────────────────────────────

--- a/ops-server/dashboard/test_workshops_admin.py
+++ b/ops-server/dashboard/test_workshops_admin.py
@@ -1,0 +1,390 @@
+"""Workshops & Delivery admin API — /api/workshops/admin/*.
+
+The load-bearing assertion in this file is not the CRUD: it is that a caller
+presenting only the app's SERVICE BEARER is rejected. Every enablement app
+install ships the same baked bearer, so if these routes accepted it, any
+tenant's app could read every other tenant's workshops, rosters and trainers.
+_require_writer demands X-Auth-User, which nginx sets only after oauth2-proxy
+has validated a GitHub org session.
+
+Redis is an in-process fake; _resolve_role is stubbed so no GitHub call is made.
+
+Runnable: /home/ops/ops-venv/bin/python -m pytest dashboard/test_workshops_admin.py
+"""
+
+import json
+
+import dashboard.app as a
+from dashboard import trainer_registry as tr
+from fastapi.testclient import TestClient
+
+client = TestClient(a.app, raise_server_exceptions=False)
+
+BEARER = {"Authorization": "Bearer test-service-token"}
+WRITER = {"X-Auth-User": "sergiohinojosa"}
+SERGIO = "sergio.hinojosa@dynatrace.com"
+ASAD = "asad.ali@dynatrace.com"
+LEARNER = "learner@customer.com"
+COE = "https://geu80787.apps.dynatrace.com"
+
+ADMIN_ROUTES = [
+    ("get", "/api/workshops/admin/trainers"),
+    ("post", "/api/workshops/admin/trainers"),
+    ("delete", f"/api/workshops/admin/trainers/{SERGIO}"),
+]
+
+
+class FakeRedis:
+    def __init__(self):
+        self.h: dict = {}
+        self.s: dict = {}
+        self.z: dict = {}
+
+    async def sismember(self, key, member):
+        return member in self.s.get(key, set())
+
+    async def smembers(self, key):
+        return set(self.s.get(key, set()))
+
+    async def sadd(self, key, *members):
+        self.s.setdefault(key, set()).update(members)
+
+    async def srem(self, key, *members):
+        target = self.s.setdefault(key, set())
+        removed = sum(1 for m in members if m in target)
+        target.difference_update(members)
+        return removed
+
+    async def scard(self, key):
+        return len(self.s.get(key, set()))
+
+    async def hgetall(self, key):
+        return dict(self.h.get(key, {}))
+
+    async def hset(self, key, field=None, value=None, mapping=None):
+        target = self.h.setdefault(key, {})
+        if mapping:
+            target.update(mapping)
+        else:
+            target[field] = value
+
+    async def delete(self, *keys):
+        for key in keys:
+            self.h.pop(key, None)
+
+    async def zrevrange(self, key, start, end):
+        return list(self.z.get(key, []))
+
+    async def zrem(self, key, *members):
+        before = len(self.z.get(key, []))
+        self.z[key] = [m for m in self.z.get(key, []) if m not in members]
+        return before - len(self.z[key])
+
+    async def exists(self, key):
+        return 1 if (key in self.h or key in self.s) else 0
+
+
+def setup_module(_module):
+    _module._saved_tokens = a.ORBITAL_TOKENS
+    _module._saved_role = a._resolve_role
+    a.ORBITAL_TOKENS = ("test-service-token",)
+
+    async def _fake_role(user):
+        return {"role": "writer" if user else "guest", "user": user,
+                "org_role": "member"}
+    a._resolve_role = _fake_role
+
+
+def teardown_module(_module):
+    a.ORBITAL_TOKENS = _module._saved_tokens
+    a._resolve_role = _module._saved_role
+
+
+def setup_function(_fn):
+    _fn._saved_pool = a.pool
+    a.pool = FakeRedis()
+
+
+def teardown_function(_fn):
+    a.pool = _fn._saved_pool
+
+
+# ── The gate ─────────────────────────────────────────────────────────────────
+
+def _call(verb, path, headers=None):
+    """TestClient.get/delete take no json= — only POST carries a body."""
+    kwargs = {"headers": headers} if headers else {}
+    if verb == "post":
+        kwargs["json"] = {"email": SERGIO}
+    return getattr(client, verb)(path, **kwargs)
+
+
+def test_anonymous_gets_401_on_every_admin_route():
+    for verb, path in ADMIN_ROUTES:
+        r = _call(verb, path)
+        assert r.status_code == 401, f"{verb} {path} -> {r.status_code}"
+
+
+def test_service_bearer_alone_cannot_read_workshops_admin():
+    """The whole security model: the baked app bearer is NOT enough here."""
+    for verb, path in ADMIN_ROUTES:
+        r = _call(verb, path, headers=BEARER)
+        assert r.status_code == 401, f"{verb} {path} -> {r.status_code}"
+
+
+def test_empty_x_auth_user_is_treated_as_anonymous():
+    # nginx clears the header on un-gated paths; an empty value must not pass.
+    r = client.get("/api/workshops/admin/trainers", headers={"X-Auth-User": ""})
+    assert r.status_code == 401
+
+
+def test_non_org_member_gets_403():
+    saved = a._resolve_role
+
+    async def _guest(user):
+        return {"role": "guest", "user": user, "org_role": ""}
+    a._resolve_role = _guest
+    try:
+        r = client.get("/api/workshops/admin/trainers", headers=WRITER)
+        assert r.status_code == 403
+    finally:
+        a._resolve_role = saved
+
+
+# ── CRUD ─────────────────────────────────────────────────────────────────────
+
+def test_trainer_crud_round_trip():
+    assert client.get("/api/workshops/admin/trainers",
+                      headers=WRITER).json() == {"trainers": [], "count": 0}
+
+    r = client.post("/api/workshops/admin/trainers", headers=WRITER,
+                    json={"email": "  Sergio.Hinojosa@Dynatrace.com ",
+                          "name": "Sergio", "note": "COE"})
+    assert r.status_code == 200
+    assert r.json()["trainer"]["email"] == SERGIO
+    # addedBy is taken from the signed-in identity, never from the body.
+    assert r.json()["trainer"]["addedBy"] == "sergiohinojosa"
+
+    client.post("/api/workshops/admin/trainers", headers=WRITER,
+                json={"email": ASAD})
+    listed = client.get("/api/workshops/admin/trainers", headers=WRITER).json()
+    assert listed["count"] == 2
+    assert [t["email"] for t in listed["trainers"]] == [ASAD, SERGIO]
+
+    r = client.delete(f"/api/workshops/admin/trainers/{SERGIO}", headers=WRITER)
+    assert r.status_code == 200 and r.json()["removed"] == SERGIO
+    assert client.get("/api/workshops/admin/trainers",
+                      headers=WRITER).json()["count"] == 1
+
+
+def test_add_rejects_a_non_address():
+    r = client.post("/api/workshops/admin/trainers", headers=WRITER,
+                    json={"email": "not-an-email"})
+    assert r.status_code == 400
+
+
+def test_remove_unknown_is_404():
+    r = client.delete(f"/api/workshops/admin/trainers/{ASAD}", headers=WRITER)
+    assert r.status_code == 404
+
+
+def test_added_by_cannot_be_forged_through_the_body():
+    client.post("/api/workshops/admin/trainers", headers=WRITER,
+                json={"email": ASAD, "addedBy": "someone-else"})
+    entry = client.get("/api/workshops/admin/trainers",
+                       headers=WRITER).json()["trainers"][0]
+    assert entry["addedBy"] == "sergiohinojosa"
+
+
+# ── callerIsTrainer rides the existing list route ────────────────────────────
+
+def _seed_workshop():
+    a.pool.h["live:session:ws_x"] = {
+        "title": "Kubernetes 101", "trainingId": "kubernetes-101",
+        "trainers": json.dumps([SERGIO]), "state": "open",
+        "createdAt": "2026-08-13T09:00:00+00:00", "ownerTenant": COE,
+    }
+    a.pool.s["live:session:ws_x:roster"] = {LEARNER}
+    a.pool.z["live:sessions:index"] = ["ws_x"]
+
+
+def test_caller_is_trainer_true_for_a_registered_trainer():
+    _seed_workshop()
+    client.post("/api/workshops/admin/trainers", headers=WRITER,
+                json={"email": SERGIO})
+    body = client.get(f"/api/live/sessions?email={SERGIO}",
+                      headers=BEARER).json()
+    assert body["callerIsTrainer"] is True
+
+
+def test_caller_is_trainer_false_for_a_learner():
+    _seed_workshop()
+    client.post("/api/workshops/admin/trainers", headers=WRITER,
+                json={"email": SERGIO})
+    body = client.get(f"/api/live/sessions?email={LEARNER}",
+                      headers=BEARER).json()
+    assert body["callerIsTrainer"] is False
+    # Being a workshop trainer is NOT the same thing as being registered: the
+    # learner still sees their workshop, they just cannot schedule one.
+    assert body["count"] == 1
+
+
+def test_caller_is_trainer_false_when_registry_is_empty():
+    _seed_workshop()
+    body = client.get(f"/api/live/sessions?email={SERGIO}",
+                      headers=BEARER).json()
+    assert body["callerIsTrainer"] is False
+
+
+# ── Owner-only delete, over HTTP ─────────────────────────────────────────────
+# The one authority a co-trainer does not share. Everything else about the
+# trainer team is deliberately flat — see live_sessions.is_owner.
+
+def _seed_team_workshop():
+    a.pool.h["live:session:ws_team"] = {
+        "title": "Team", "trainingId": "k8s", "state": "scheduled",
+        "trainers": json.dumps([SERGIO, ASAD]), "ownerTenant": COE,
+        "createdAt": "2026-08-13T09:00:00+00:00",
+    }
+    a.pool.z["live:sessions:index"] = ["ws_team"]
+
+
+def test_co_trainer_cannot_delete_the_workshop():
+    _seed_team_workshop()
+    r = client.request("DELETE", "/api/live/sessions/ws_team", headers=BEARER,
+                       json={"trainerEmail": ASAD})
+    assert r.status_code == 403
+    assert "owner" in str(r.json().get("detail", "")).lower()
+    assert "live:session:ws_team" in a.pool.h, "nothing may be deleted on a 403"
+
+
+def test_owner_can_delete_the_workshop():
+    _seed_team_workshop()
+    r = client.request("DELETE", "/api/live/sessions/ws_team", headers=BEARER,
+                       json={"trainerEmail": SERGIO})
+    assert r.status_code == 200 and r.json()["deleted"] == "ws_team"
+    assert "live:session:ws_team" not in a.pool.h
+    assert a.pool.z["live:sessions:index"] == []
+
+
+def test_a_stranger_still_gets_the_generic_trainer_error():
+    """A non-trainer must not learn that an owner/co-trainer split exists —
+    they get the same message as before."""
+    _seed_team_workshop()
+    r = client.request("DELETE", "/api/live/sessions/ws_team", headers=BEARER,
+                       json={"trainerEmail": LEARNER})
+    assert r.status_code == 403
+    assert "owner" not in str(r.json().get("detail", "")).lower()
+
+
+# ── Cross-tenant schedule ────────────────────────────────────────────────────
+
+SRO = "https://sro97894.apps.dynatrace.com"
+
+
+def _seed_many():
+    """Three workshops on two tenants, deliberately indexed newest-created
+    first so a correct scheduledAt sort has to reorder them."""
+    a.pool.h["live:session:ws_late"] = {
+        "title": "Late", "trainingId": "k8s", "state": "scheduled",
+        "trainers": json.dumps([SERGIO, ASAD]), "ownerTenant": COE,
+        "createdAt": "2026-08-13T09:00:00+00:00",
+        "scheduledAt": "2026-09-20T09:00:00+00:00", "maxSeats": "10",
+    }
+    a.pool.s["live:session:ws_late:roster"] = {LEARNER, "b@x.com"}
+    a.pool.h["live:session:ws_late:joined"] = {LEARNER: "2026-08-13T10:00:00+00:00"}
+    a.pool.h["live:session:ws_late:tenants"] = {LEARNER: COE}
+
+    a.pool.h["live:session:ws_early"] = {
+        "title": "Early", "trainingId": "dtwiz", "state": "open",
+        "trainers": json.dumps([ASAD]), "ownerTenant": SRO,
+        "createdAt": "2026-08-12T09:00:00+00:00",
+        "scheduledAt": "2026-09-01T09:00:00+00:00",
+    }
+    a.pool.s["live:session:ws_early:roster"] = set()
+
+    # No scheduledAt at all — must fall back to createdAt, not vanish.
+    a.pool.h["live:session:ws_unsched"] = {
+        "title": "Unscheduled", "trainingId": "k8s", "state": "ended",
+        "trainers": json.dumps([SERGIO]), "ownerTenant": COE,
+        "createdAt": "2026-07-01T09:00:00+00:00",
+    }
+    a.pool.s["live:session:ws_unsched:roster"] = {LEARNER}
+    a.pool.z["live:sessions:index"] = ["ws_late", "ws_early", "ws_unsched"]
+
+
+def test_schedule_requires_a_writer():
+    assert client.get("/api/workshops/admin/schedule").status_code == 401
+    assert client.get("/api/workshops/admin/schedule",
+                      headers=BEARER).status_code == 401
+
+
+def test_schedule_returns_every_tenant_sorted_by_when_it_happens():
+    _seed_many()
+    body = client.get("/api/workshops/admin/schedule", headers=WRITER).json()
+    assert [w["sessionId"] for w in body["workshops"]] == [
+        "ws_unsched", "ws_early", "ws_late"]
+    assert {w["ownerTenant"] for w in body["workshops"]} == {COE, SRO}
+    assert body["count"] == 3 and body["total"] == 3
+
+
+def test_schedule_splits_owner_from_co_trainers():
+    _seed_many()
+    row = next(w for w in client.get("/api/workshops/admin/schedule",
+                                     headers=WRITER).json()["workshops"]
+               if w["sessionId"] == "ws_late")
+    assert row["owner"] == SERGIO
+    assert row["coTrainers"] == [ASAD]
+    assert row["trainers"] == [SERGIO, ASAD]
+
+
+def test_schedule_seat_math_and_unlimited():
+    _seed_many()
+    rows = {w["sessionId"]: w for w in
+            client.get("/api/workshops/admin/schedule",
+                       headers=WRITER).json()["workshops"]}
+    assert rows["ws_late"]["seatsTaken"] == 2
+    assert rows["ws_late"]["seatsOpen"] == 8
+    assert rows["ws_late"]["present"] == 1
+    assert rows["ws_late"]["boundCount"] == 1
+    # No maxSeats: "unlimited" must not be reported as "zero free".
+    assert rows["ws_early"]["maxSeats"] == 0
+    assert rows["ws_early"]["seatsOpen"] is None
+
+
+def test_schedule_marks_which_rows_are_editable():
+    _seed_many()
+    rows = {w["sessionId"]: w for w in
+            client.get("/api/workshops/admin/schedule",
+                       headers=WRITER).json()["workshops"]}
+    # PATCH refuses anything past `open`, so the editor must say so up front.
+    assert rows["ws_late"]["editable"] is True
+    assert rows["ws_early"]["editable"] is True
+    assert rows["ws_unsched"]["editable"] is False
+
+
+def test_schedule_state_filter():
+    _seed_many()
+    body = client.get("/api/workshops/admin/schedule?state=open,scheduled",
+                      headers=WRITER).json()
+    assert [w["sessionId"] for w in body["workshops"]] == ["ws_early", "ws_late"]
+
+
+def test_schedule_self_heals_a_stale_index_member():
+    _seed_many()
+    a.pool.z["live:sessions:index"].append("ws_expired")  # hash already TTL'd
+    body = client.get("/api/workshops/admin/schedule", headers=WRITER).json()
+    assert body["count"] == 3
+    assert "ws_expired" not in a.pool.z["live:sessions:index"], \
+        "an index member with no hash must be dropped, not re-scanned forever"
+
+
+def test_registry_membership_is_independent_of_workshop_membership():
+    """A registered trainer with no workshops still gets the flag — that is
+    what enables + New workshop on a brand-new trainer's first visit."""
+    async def _add():
+        await tr.add_entry(a.pool, ASAD)
+    import asyncio
+    asyncio.get_event_loop_policy().new_event_loop().run_until_complete(_add())
+    body = client.get(f"/api/live/sessions?email={ASAD}", headers=BEARER).json()
+    assert body["callerIsTrainer"] is True and body["count"] == 0

--- a/ops-server/dashboard/trainer_registry.py
+++ b/ops-server/dashboard/trainer_registry.py
@@ -76,18 +76,6 @@ def shape_entry(email: str, *, name: str = "", added_by: str = "",
     return fields
 
 
-def seed_emails(raw) -> list[str]:
-    """Parse OPS_TRAINER_SEED — a comma-separated list. Invalid entries are
-    dropped rather than raising: a typo in an env var must not stop boot."""
-    out, seen = [], set()
-    for chunk in (raw or "").split(","):
-        normalized = normalize_email(chunk)
-        if is_valid_email(normalized) and normalized not in seen:
-            seen.add(normalized)
-            out.append(normalized)
-    return out
-
-
 # ── Async Redis helpers ──────────────────────────────────────────────────────
 
 async def is_trainer(pool, email) -> bool:
@@ -143,23 +131,3 @@ async def remove_entry(pool, email) -> bool:
     removed = bool(await pool.srem(INDEX_KEY, normalized))
     await pool.delete(registry_key(normalized))
     return removed
-
-
-async def seed(pool, emails) -> int:
-    """Idempotent boot seed. Only ever ADDS — an operator who removed someone
-    through the UI must not have them reappear on the next restart... except
-    for a genuinely empty registry, which is the case this exists for (fresh
-    install, or a Redis wipe). Returns the number of entries created."""
-    wanted = [e for e in (emails or []) if is_valid_email(e)]
-    if not wanted:
-        return 0
-    if await pool.scard(INDEX_KEY):
-        return 0
-    created = 0
-    for email in wanted:
-        await pool.hset(registry_key(email), mapping=shape_entry(
-            email, added_by="seed", note="seeded at startup"))
-        await pool.sadd(INDEX_KEY, email)
-        created += 1
-    log.info("trainer registry seeded with %d entries", created)
-    return created

--- a/ops-server/dashboard/trainer_registry.py
+++ b/ops-server/dashboard/trainer_registry.py
@@ -1,0 +1,165 @@
+"""Global trainer registry — who is allowed to SCHEDULE workshops.
+
+Until now there was no such list anywhere. A workshop's `trainers` field is
+per-workshop MEMBERSHIP (live_sessions.py) and grants nothing outside that one
+workshop, and the app's `isInstructor` gate is about CONTENT (import, solution
+reveal). Neither answers "may this person create a workshop at all?", so in
+practice anyone whose app boot reported `isInstructor || canWrite` saw the
++ New workshop button and Orbital accepted the create with no check whatsoever.
+
+This module is that missing list, and it is deliberately narrow:
+
+  * being in the registry lets you CREATE/schedule workshops, and flip the
+    tenant-wide solutions toggle;
+  * it does NOT make you an admin, and being an admin does not put you here
+    (the two rights are split on purpose — an admin may see admin surfaces
+    without being someone who delivers training);
+  * it does NOT grant anything inside a workshop. Authority there is still
+    workshop membership: see live_sessions.is_trainer / is_owner.
+
+Redis layout (Orbital Redis, same instance as jobs):
+  trainer:registry:index        set of normalized emails — the HOT path. Every
+                                workshop-list call answers "is the caller a
+                                trainer?" with one SISMEMBER, so that question
+                                must never require reading a hash.
+  trainer:registry:{email}      hash — email, name, addedBy, addedAt, note.
+                                Attribution for the Trainers table only.
+
+Two structures for one concept, for the same reason tenant_registry.py has
+INDEX_KEY plus a per-entity hash.
+
+The shaping logic is pure (no Redis) and unit-tested in
+test_trainer_registry.py; the async helpers below are thin wrappers.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from dashboard.live_sessions import is_valid_email, normalize_email
+
+log = logging.getLogger("ops-dashboard.trainer-registry")
+
+INDEX_KEY = "trainer:registry:index"
+
+
+def registry_key(email: str) -> str:
+    return f"trainer:registry:{normalize_email(email)}"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ── Pure shaping ─────────────────────────────────────────────────────────────
+
+def validate_trainer_email(email) -> str:
+    """Normalized email, or ValueError. Same minimal rule the roster uses —
+    Orbital cannot verify an address, only reject an obvious non-address."""
+    normalized = normalize_email(email)
+    if not is_valid_email(normalized):
+        raise ValueError("a valid email is required")
+    return normalized
+
+
+def shape_entry(email: str, *, name: str = "", added_by: str = "",
+                note: str = "", now: str | None = None) -> dict:
+    """Fields for a new registry entry. Empty values are DROPPED so a later
+    re-add never blanks attribution captured the first time (mirrors
+    tenant_registry.shape_deploy)."""
+    fields = {"email": normalize_email(email), "addedAt": now or _now_iso()}
+    if name:
+        fields["name"] = name.strip()
+    if added_by:
+        fields["addedBy"] = added_by.strip()
+    if note:
+        fields["note"] = note.strip()
+    return fields
+
+
+def seed_emails(raw) -> list[str]:
+    """Parse OPS_TRAINER_SEED — a comma-separated list. Invalid entries are
+    dropped rather than raising: a typo in an env var must not stop boot."""
+    out, seen = [], set()
+    for chunk in (raw or "").split(","):
+        normalized = normalize_email(chunk)
+        if is_valid_email(normalized) and normalized not in seen:
+            seen.add(normalized)
+            out.append(normalized)
+    return out
+
+
+# ── Async Redis helpers ──────────────────────────────────────────────────────
+
+async def is_trainer(pool, email) -> bool:
+    """The hot path. One SISMEMBER; never raises — an unreachable registry
+    means "not a trainer", which hides a button rather than breaking a page."""
+    normalized = normalize_email(email)
+    if not normalized:
+        return False
+    try:
+        return bool(await pool.sismember(INDEX_KEY, normalized))
+    except Exception as exc:
+        log.warning("trainer-registry lookup failed for %s: %s", normalized, exc)
+        return False
+
+
+async def list_entries(pool) -> list[dict]:
+    """All trainers, sorted by email. Writer-gated by the caller — values are
+    returned unmasked. An index member with no hash still appears (email only),
+    so a half-written entry is visible and removable rather than invisible."""
+    emails = sorted(await pool.smembers(INDEX_KEY) or [])
+    out: list[dict] = []
+    for email in emails:
+        entry = await pool.hgetall(registry_key(email)) or {}
+        out.append({"email": email, **entry})
+    return out
+
+
+async def add_entry(pool, email, *, name: str = "", added_by: str = "",
+                    note: str = "") -> dict:
+    """Add or update a trainer. Raises ValueError on a bad address."""
+    normalized = validate_trainer_email(email)
+    key = registry_key(normalized)
+    existing = await pool.hgetall(key) or {}
+    fields = shape_entry(normalized, name=name, added_by=added_by, note=note)
+    if existing.get("addedAt"):
+        # Keep the original attribution; a re-add is not a new grant.
+        fields["addedAt"] = existing["addedAt"]
+        fields.pop("addedBy", None)
+    await pool.hset(key, mapping=fields)
+    await pool.sadd(INDEX_KEY, normalized)
+    return {**existing, **fields}
+
+
+async def remove_entry(pool, email) -> bool:
+    """Remove a trainer. True when they were actually in the registry.
+
+    Removes from the index FIRST: if the delete then fails, the worst outcome
+    is an orphan hash, not someone who still passes the gate.
+    """
+    normalized = normalize_email(email)
+    if not normalized:
+        return False
+    removed = bool(await pool.srem(INDEX_KEY, normalized))
+    await pool.delete(registry_key(normalized))
+    return removed
+
+
+async def seed(pool, emails) -> int:
+    """Idempotent boot seed. Only ever ADDS — an operator who removed someone
+    through the UI must not have them reappear on the next restart... except
+    for a genuinely empty registry, which is the case this exists for (fresh
+    install, or a Redis wipe). Returns the number of entries created."""
+    wanted = [e for e in (emails or []) if is_valid_email(e)]
+    if not wanted:
+        return 0
+    if await pool.scard(INDEX_KEY):
+        return 0
+    created = 0
+    for email in wanted:
+        await pool.hset(registry_key(email), mapping=shape_entry(
+            email, added_by="seed", note="seeded at startup"))
+        await pool.sadd(INDEX_KEY, email)
+        created += 1
+    log.info("trainer registry seeded with %d entries", created)
+    return created

--- a/ops-server/nginx/ops-server.conf
+++ b/ops-server/nginx/ops-server.conf
@@ -128,6 +128,26 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Workshops & Delivery admin (dashboard tab) — org members only, HARD gate.
+    # Distinct from /api/live/, which is opportunistic because the enablement
+    # app calls it with a service bearer and no X-Auth-User. These routes read
+    # EVERY tenant's workshops and rosters, so the service bearer must not be
+    # enough: only a signed-in org member gets here, and FastAPI re-checks with
+    # _require_writer. Never add http2 to this server (WebSocket/RFC 8441).
+    location ~ ^/api/workshops/admin/ {
+        auth_request /oauth2/auth;
+        error_page 401 = @json_unauthorized;
+        auth_request_set $user  $upstream_http_x_auth_request_user;
+        auth_request_set $email $upstream_http_x_auth_request_email;
+        proxy_set_header X-Auth-User  $user;
+        proxy_set_header X-Auth-Email $email;
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Token-based deploy/undeploy — NOT org-member-gated: the platform token in the
     # body carries the target tenant's own authority, so a signed-out user with a valid
     # token may deploy/register. Opportunistic auth (mirrors /api/auth/role): forward


### PR DESCRIPTION
Orbital half of the Workshops & Delivery epic. Orbital was already the system of record for workshops (`live:session:*` in Redis, ~35 `/api/live/*` routes); what it lacked was any cross-tenant view of them, any notion of who may schedule one, and any way to fix a single learner without nuking the cohort.

## What lands

**Trainer registry (new).** `trainer:registry:index` SET + per-email HASH, so "is this person a trainer?" is one `SISMEMBER` on the workshop-list path. `GET /api/live/sessions` returns `callerIsTrainer`, riding the call the app's boot aggregate already makes — no new round-trip. Trainers are added through the new tab; there is no seed file and no env var.

**Workshops & Delivery dashboard tab**, sibling of Content Service: a month calendar plus a table of every tenant's workshops (owner, co-trainers, schedule, state, tenant, seats taken/open, registrants), row-click editor reusing the existing PATCH/cancel/delete/start/end routes, and a Trainers sub-tab.

**Owner vs co-trainer.** `is_owner()` = `trainers[0]`. Exactly one gate changes — DELETE. Co-trainers keep every other authority deliberately: one who cannot act is not a co-trainer. No migration; `validate_trainers` has always forced `trainers[0]` to the creator.

**Automatic tenant binding**, replacing "Provision here" — a button whose label promised an action it never performed. New `live:session:{id}:boundat`, one `_bind_tenant()` funnel, FIRST-WRITE-WINS so walking into a second tenant never silently moves a learner. `provision-ack` is the single caller allowed to override, because it reports where an environment actually landed. Binding is **not** attendance: it works with the room closed, days early, and never writes `:joined`.

**Per-learner terminate / reprovision.** Scoped by `workshop_id`, so a learner's environment from a different workshop of the *same training* is never touched — the cohort-wide route matches `(arena_user, training_id)` and would hit it. Gated on `is_trainer`, since a co-trainer troubleshooting a stuck learner is the case these exist for.

## Security note

`/api/workshops/admin/*` is `_require_writer`, **not** `_require_service_or_writer`: every app install ships the same baked bearer, so accepting it would let any tenant's app read every other tenant's rosters. nginx gets a matching hard-gated location, placed before `~ ^/api/live/`.

## Incidental fixes

- `live:sessions:index` was `ZREM`'d on hard delete but not on TTL expiry, so members accumulated. `_walk_workshop_index()` now self-heals it.
- `test_delete_only_before_started` asserted delete raises from ended/cancelled, but the route was deliberately widened to allow cleaning up finished workshops. Renamed and corrected.

## Tests

700 pass (baseline was 647 with 1 pre-existing failure, now fixed). Scheduler 17/17. L1 workshop API harness 32/37 — **all 5 failures reproduce unchanged on `origin/main`** (a stale 7-day-TTL expectation, and 4 chat checks blocked on room-open).

## Deploy note

Purely additive, so an app on the current version keeps working against it — but `/join` stops re-binding the moment this lands, which makes the old app's "Provision here instead" button inert. Ship the app half back to back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)