### PR TITLE
fix(nginx): let the dashboard frame wildcard-subdomain apps

### DIFF
--- a/ops-server/docs/known-issues/astroshop-proxy.md
+++ b/ops-server/docs/known-issues/astroshop-proxy.md
@@ -1,8 +1,42 @@
 # Known Issue: Astroshop In-Dashboard Proxy — Incomplete Navigation
 
-**Status:** Open  
+**Status:** Open for the `/apps/…` rewriting proxy — but no longer on the path the UI uses.  
 **Component:** `ops-server/dashboard/app.py` — `proxy_job_app` / `_rewrite_proxy_body`  
 **Symptom:** Astroshop loads partially but product images may not render and page may appear blank on initial load in some browsers/cache states.
+
+---
+
+## Superseded in practice: use the wildcard subdomain
+
+The app tab in the dashboard (`dashboard/static/app.js`, `_loadShellAppTabs` /
+`_loadLivelogAppTabs`) sets `frame.src = app.subdomain_url || app.proxy_url`, so a job whose
+apps have an `orbital_subdomain` never reaches the rewriting proxy below. The subdomain
+serves the app at `/` with **no rewriting at all**, so none of the URL classes in the table
+below can break — every `/_next/*`, `/images/*` and `/api/*` request resolves natively.
+
+That path was itself unusable until 2026-08-13, for an unrelated reason: the wildcard
+`server` block in `nginx/ops-server.conf` sent
+
+```nginx
+add_header X-Frame-Options "SAMEORIGIN" always;   # ← the bug
+```
+
+`{app}--{job_id}.autonomous-enablements…` and the dashboard's apex host are **different
+origins**, so `SAMEORIGIN` blocked the embed the block existed to serve:
+
+```
+Refused to display 'https://astroshop--<job_id>.autonomous-enablements.whydevslovedynatrace.com/'
+in a frame because it set 'X-Frame-Options' to 'sameorigin'.
+```
+
+It affected every wildcard-served app (todoapp failed identically), not just astroshop.
+`X-Frame-Options` has no cross-origin allowlist form — `ALLOW-FROM` is unsupported in every
+modern browser — so the header was replaced with a CSP `frame-ancestors` allowlist naming
+the apex host and the wildcard. Upstream astroshop sends no framing header of its own, so
+that nginx block is the only thing deciding who may frame it.
+
+Everything below still describes the `/apps/{job_id}/{app_name}/` rewriting proxy, which
+remains the fallback for jobs with no `orbital_subdomain`.
 
 ---
 

--- a/ops-server/nginx/ops-server.conf
+++ b/ops-server/nginx/ops-server.conf
@@ -651,8 +651,20 @@ server {
     ssl_certificate     /etc/letsencrypt/live/autonomous-enablements.whydevslovedynatrace.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/autonomous-enablements.whydevslovedynatrace.com/privkey.pem;
 
-    # Allow embedding in the dashboard iframe
-    add_header X-Frame-Options "SAMEORIGIN" always;
+    # Allow embedding in the dashboard iframe.
+    #
+    # X-Frame-Options MUST NOT be set here. Each app is served from its own
+    # subdomain ({app}--{job_id}.autonomous-enablements...), while the dashboard
+    # that frames it runs on the apex host. Those are DIFFERENT origins, so
+    # "SAMEORIGIN" blocks the very embed this block exists to serve:
+    #   Refused to display '...' in a frame because it set 'X-Frame-Options'
+    #   to 'sameorigin'.
+    # X-Frame-Options has no cross-origin allowlist form (ALLOW-FROM is dead in
+    # every modern browser), so the allowlist is expressed with CSP
+    # frame-ancestors instead — which browsers honour over XFO when both exist.
+    # Upstream apps (astroshop/todoapp) send no framing header of their own, so
+    # this block is the only place that decides who may frame them.
+    add_header Content-Security-Policy "frame-ancestors 'self' https://autonomous-enablements.whydevslovedynatrace.com https://*.autonomous-enablements.whydevslovedynatrace.com" always;
     add_header X-Content-Type-Options nosniff always;
 
     location / {


### PR DESCRIPTION
## Problem

Clicking the **Astro shop** app tab in the Orbital dashboard showed a browser error instead of the app:

```
Refused to display 'https://astroshop--<job_id>.autonomous-enablements.whydevslovedynatrace.com/'
in a frame because it set 'X-Frame-Options' to 'sameorigin'.
```

The wildcard server block in `ops-server/nginx/ops-server.conf` carried a header whose comment stated the opposite of its effect:

```nginx
# Allow embedding in the dashboard iframe
add_header X-Frame-Options "SAMEORIGIN" always;
```

Apps are served at `{app}--{job_id}.autonomous-enablements.whydevslovedynatrace.com`; the dashboard that frames them runs on the **apex** host. A subdomain is not same-origin, so `SAMEORIGIN` blocked the exact embed the block exists to serve.

This is **not astroshop-specific** — todoapp fails identically. It affects every wildcard-served app in every repo that exposes one under Orbital. Astroshop was where it surfaced because `dashboard/static/app.js` (`_loadShellAppTabs` / `_loadLivelogAppTabs`) sets `frame.src = app.subdomain_url || app.proxy_url`, so any app with an `orbital_subdomain` only ever reaches the broken surface.

The two serving surfaces have opposite defects, which is why this looked like the older astroshop image bug:

| Surface | Assets | Framable |
|---|---|---|
| subdomain (no rewriting) | all 200 — `/_next/*`, `/images/products/*`, `/api/*` | **blocked** |
| `/apps/{job}/{app}/` (rewriting proxy) | 404 storm — see `docs/known-issues/astroshop-proxy.md` | ok (same origin) |

The k8s ingress and the FastAPI proxy were both healthy throughout; upstream returned 200 on `:32008`. nginx was the only broken layer.

## Fix

`X-Frame-Options` cannot express a cross-origin allowlist — `ALLOW-FROM` is unimplemented in every modern browser. The allowlist is stated as CSP `frame-ancestors` instead, which browsers honour over XFO when both are present:

```nginx
add_header Content-Security-Policy "frame-ancestors 'self' https://autonomous-enablements.whydevslovedynatrace.com https://*.autonomous-enablements.whydevslovedynatrace.com" always;
```

Scope is deliberately one block. The apex server block keeps `X-Frame-Options DENY`; the same-origin `/apps/` location keeps `SAMEORIGIN`. Astroshop and todoapp send no framing header of their own, so this block is the only thing deciding who may frame them.

Because the subdomain path does no URL rewriting, making it reachable also resolves the astroshop image problem in the dashboard tab. `docs/known-issues/astroshop-proxy.md` is updated to record that the UI no longer reaches the rewriting proxy, and that the 404s there remain open for jobs with no `orbital_subdomain`.

## Verification

- Header confirmed replaced on a live astroshop job; iframe from the dashboard origin loads with **no console refusal and no 404s**, page renders including product images.
- todoapp subdomain reproduced the identical refusal before the change, confirming the scope is all wildcard apps.
- Ingress sub-paths healthy on the subdomain: `/images/products/LensCleaningKit.jpg` 200, `/api/products` 200, `/_next/*` 200. (`/images/Hero.jpg` 404s on a healthy astroshop — wrong filename, not a routing gap.)
- `k3d-apps` framework suite queued on this branch (astroshop deploy + ingress reachability under Sysbox/k3d), plus a `log-ingest-101` daemon pinned to this branch for the full learner path.

**Codespaces is unaffected by construction.** `getAppURL` (`functions.sh:2267-2277`) only returns the Orbital subdomain when `detectRunEnvironment == orbital`; Codespaces gets `${CODESPACE_NAME}-80.app.github.dev` and never touches this nginx. `registerAstroshopIngress` writes `orbital_subdomain` under the same guard.

## Deploy

Master only — no Python changed, so no worker pull/restart:

```bash
sudo cp ops-server/nginx/ops-server.conf /etc/nginx/sites-available/ops-server
sudo nginx -t && sudo systemctl reload nginx
```

Already applied and reloaded on the master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)